### PR TITLE
Use pip for installing folio_migration_tools

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,9 +10,7 @@ on:
     branches: [ main ]
 
 env:
-  PYTHONPATH: /Users/Shared/folio_migration_tools
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   build:
     runs-on: macos-11
@@ -24,14 +22,13 @@ jobs:
         python-version: "3.9"
     - name: Install airflow dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Install FOLIO-FSE tools
+      run: |
+        pip install folioclient folio-migration-tools folio-uuid
     - name: Lint with flake8
       run: |
         flake8 --ignore=E501,W503
-    - name: Install support repos
-      run: |
-        git clone https://github.com/FOLIO-FSE/folio_migration_tools.git /Users/Shared/folio_migration_tools --depth=2
     - name: Test with pytest
       run: |
         coverage run -m pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,10 @@ FROM apache/airflow:2.2.4-python3.9
 USER root
 RUN usermod -u 214 airflow
 
-
-RUN apt-get -y update && apt-get -y install git
-
-ENV PYTHONPATH "${PYTHONPATH}:/opt/airflow/folio_migration_tools"
+ENV PYTHONPATH "${PYTHONPATH}:/opt/airflow/"
 
 USER airflow
 
-RUN git clone https://github.com/FOLIO-FSE/folio_migration_tools.git --depth=2
-
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt
+RUN pip install --no-deps -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,14 @@ USER root
 RUN usermod -u 214 airflow
 
 ENV PYTHONPATH "${PYTHONPATH}:/opt/airflow/"
+ENV SLUGIFY_USES_TEXT_UNIDECODE "yes"
 
 USER airflow
 
 COPY requirements.txt .
 
-RUN pip install --no-deps -r requirements.txt
+RUN pip install -r requirements.txt
+# Needed to fix an import error see https://stackoverflow.com/questions/47884709/python-importerror-no-module-named-pluggy
+RUN pip install -U pytest-metadata
+# Install FOLIO-FSE tools
+RUN pip install folioclient folio-migration-tools folio-uuid

--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -14,7 +14,7 @@ from airflow.sensors.filesystem import FileSensor
 from airflow.utils.task_group import TaskGroup
 from airflow.models import Variable
 
-from migration_tools.library_configuration import LibraryConfiguration
+from folio_migration_tools.library_configuration import LibraryConfiguration
 
 from plugins.folio.helpers import (
     archive_artifacts,

--- a/plugins/folio/helpers.py
+++ b/plugins/folio/helpers.py
@@ -8,7 +8,7 @@ import pymarc
 import requests
 
 from airflow.models import Variable
-from migration_tools.migration_tasks.migration_task_base import LevelFilter
+from folio_migration_tools.migration_tasks.migration_task_base import LevelFilter
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from migration_tools.migration_tasks.holdings_csv_transformer import (
+from folio_migration_tools.migration_tasks.holdings_csv_transformer import (
     HoldingsCsvTransformer,
 )
 
@@ -62,6 +62,7 @@ def run_holdings_tranformer(*args, **kwargs):
         location_map_file_name="locations.tsv",
         default_call_number_type_name="Library of Congress classification",
         fallback_holdings_type_id="03c9c400-b9e3-4a07-ac0e-05ab470233ed",
+        holdings_type_uuid_for_boundwiths="",
     )
 
     holdings_transformer = HoldingsCsvTransformer(

--- a/plugins/folio/instances.py
+++ b/plugins/folio/instances.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from migration_tools.migration_tasks.bibs_transformer import BibsTransformer
+from folio_migration_tools.migration_tasks.bibs_transformer import BibsTransformer
 
 from plugins.folio.helpers import post_to_okapi, setup_data_logging
 

--- a/plugins/folio/items.py
+++ b/plugins/folio/items.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from migration_tools.migration_tasks.items_transformer import ItemsTransformer
+from folio_migration_tools.migration_tasks.items_transformer import ItemsTransformer
 
 from plugins.folio.helpers import post_to_okapi, setup_data_logging
 

--- a/plugins/folio/marc.py
+++ b/plugins/folio/marc.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pathlib
 
-from migration_tools.migration_tasks.batch_poster import BatchPoster
+from folio_migration_tools.migration_tasks.batch_poster import BatchPoster
 
 
 def post_marc_to_srs(*args, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ coverage
 coveralls
 flake8
 folioclient
+folio-migration-tools
 folio-uuid
 numpy
 objectpath

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,7 @@
-apache-airflow
 argparse_prompt
 coverage
 coveralls
 flake8
-folioclient
-folio-migration-tools
-folio-uuid
 numpy
 objectpath
 pandas
@@ -13,3 +9,4 @@ pydantic
 pymarc
 pytest
 pytest_mock
+apache-airflow >= 2.2.4


### PR DESCRIPTION
The FOLIO-FSE team just published the [folio_migration_tools](https://pypi.org/project/folio-migration-tools/) to pypi; this PR updates the Dockerfile and requirements.txt to install this package instead of cloning the repository. Part of the changes in the code files is to use the new `folio_migration_tools` namespace instead of `migration_tools`.