### PR TITLE
HRIDs based on CATKEYs

### DIFF
--- a/plugins/folio/helpers.py
+++ b/plugins/folio/helpers.py
@@ -220,7 +220,7 @@ def setup_data_logging(transformer):
 
 
 def _apply_processing_tsv(tsv_path, airflow, column_transforms):
-    df = pd.read_csv(tsv_path, sep="\t")
+    df = pd.read_csv(tsv_path, sep="\t", dtype=object)
     # Performs any transformations to values
     for transform in column_transforms:
         column = transform[0]

--- a/plugins/folio/instances.py
+++ b/plugins/folio/instances.py
@@ -45,9 +45,9 @@ def run_bibs_transformer(*args, **kwargs):
         name="bibs-transformer",
         migration_task_type="BibsTransformer",
         library_config=library_config,
-        hrid_handling="default",
+        hrid_handling="preserve001",
         files=[{"file_name": f"{marc_stem}.mrc", "suppress": False}],
-        ils_flavour="voyager",  # Voyager uses 001 field, using tag001 works
+        ils_flavour="tag001",
     )
 
     bibs_transformer = BibsTransformer(

--- a/plugins/tests/test_helpers.py
+++ b/plugins/tests/test_helpers.py
@@ -253,7 +253,8 @@ def test_transform_move_tsvs(mock_file_system):
     tsv_directory.mkdir(parents=True)
     sample_tsv = tsv_directory / "sample.tsv"
 
-    column_transforms = [("CATKEY", lambda x: f"a{x}")]
+    column_transforms = [("CATKEY", lambda x: f"a{x}"),
+                         ("BARCODE", lambda x: x.strip())]
 
     transform_move_tsvs(
         airflow=airflow_path,

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -68,7 +68,8 @@ def test_run_holdings_tranformer():
 
 
 holdings = [
-    {"id": "abcdedf123345", "instanceId": "xyzabc-def-ha", "formerIds": ["a123345"]}
+    {"id": "abcdedf123345", "instanceId": "xyzabc-def-ha", "formerIds": ["a123345"]},
+    {"id": "exyqdf123345", "instanceId": "xyzabc-def-ha", "formerIds": ["a123345"]}
 ]
 
 
@@ -91,3 +92,4 @@ def test_add_hrid():
     _add_hrid(transformer)
 
     assert transformer.holdings.values()[0]["hrid"] == "ah123345_1"
+    assert transformer.holdings.values()[1]["hrid"] == "ah123345_2"

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -67,7 +67,9 @@ def test_run_holdings_tranformer():
     assert run_holdings_tranformer
 
 
-holdings = [{"id": "abcdedf123345"}]
+holdings = [{"id": "abcdedf123345", 
+             "instanceId": "xyzabc-def-ha", 
+             "formerIds": ["a123345"]}]
 
 
 class MockHoldings(pydantic.BaseModel):
@@ -88,4 +90,4 @@ def test_add_hrid():
     transformer = MockHoldingsTransformer()
     _add_hrid(transformer)
 
-    assert transformer.holdings.values()[0]["hrid"] == "hold00000000001"
+    assert transformer.holdings.values()[0]["hrid"] == "ah123345_1"

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -67,9 +67,9 @@ def test_run_holdings_tranformer():
     assert run_holdings_tranformer
 
 
-holdings = [{"id": "abcdedf123345", 
-             "instanceId": "xyzabc-def-ha", 
-             "formerIds": ["a123345"]}]
+holdings = [
+    {"id": "abcdedf123345", "instanceId": "xyzabc-def-ha", "formerIds": ["a123345"]}
+]
 
 
 class MockHoldings(pydantic.BaseModel):

--- a/plugins/tests/test_items.py
+++ b/plugins/tests/test_items.py
@@ -1,4 +1,12 @@
-from plugins.folio.items import post_folio_items_records, run_items_transformer
+import json
+
+import pytest  # noqa
+
+from plugins.folio.items import (
+    post_folio_items_records,
+    run_items_transformer,
+    _add_hrid
+)
 
 
 def test_post_folio_items_records():
@@ -7,3 +15,29 @@ def test_post_folio_items_records():
 
 def test_items_transformers():
     assert run_items_transformer
+
+
+def test_add_hrid(tmp_path):  # noqa
+    holdings_path = tmp_path / "holdings_transformer-test_dag.json"
+
+    holdings_rec = {
+        "id": "8e6e9fb5-f914-4d38-87d2-ccb52f9a44a4",
+        "formerIds": ["a23456"]
+    }
+
+    holdings_path.write_text(f"{json.dumps(holdings_rec)}\n")
+
+    items_path = tmp_path / "items_transformer-test_dag.json"
+
+    items_rec = {
+        "holdingsRecordId": "8e6e9fb5-f914-4d38-87d2-ccb52f9a44a4"
+    }
+
+    items_path.write_text(f"{json.dumps(items_rec)}\n")
+
+    _add_hrid(str(holdings_path), str(items_path))
+
+    with items_path.open() as items_fo:
+        new_items_rec = json.loads(items_fo.readline())
+
+    assert(new_items_rec['hrid']) == "ai23456_1"


### PR DESCRIPTION
Generates HRID for instances, holdings, and items based on the bib record's CATKEY using the following strategy:

- Instance HRID uses the CATKEY with an `a` prefix
- Holding HRID uses the CATKEY with an `ah` prefix, the catkey, and then an underscore with a counter, i.e. `ah34578_1`, with counter being incremented for each holding record associated with the Instance.
- Item HRID uses the CATKEY with an `ai` prefix, the catkey, and then an underscore with a counter, i.e. `ai34578_1` with the counter being incremented for each item record associated with the Holding record.

~~NOTE: This PR has been rebased on the `t82-refactor-for-tsv` branch from PR #82~~

TODO:
- [x] Increase test coverage, especially the holding's and item's `_add_hrid` functions that are specific to Stanford.
