### PR TITLE
Clone migration repo during deploy and fix release folder permissions

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,6 +4,7 @@ set :application, 'libsys-airflow'
 set :repo_url, 'https://github.com/sul-dlss/libsys-airflow.git'
 set :user, 'libsys'
 set :venv, '/home/libsys/virtual-env/bin/activate'
+set :migration, 'https://github.com/sul-dlss/folio_migration.git'
 
 # Default branch is :master
 ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
@@ -21,10 +22,26 @@ set :linked_dirs, %w[config]
 # Default value for keep_releases is 5
 set :keep_releases, 3
 
+before 'deploy:cleanup', 'fix_permissions'
+
+desc 'Change release directories ownership'
+task :fix_permissions do
+  on roles(:app) do
+    within release_path do
+      execute :sudo, :chown, '-R', "#{fetch(:user)}:#{fetch(:user)}", '*'
+    end
+  end
+end
+
 task :deploy do
   on roles(:app) do
+    invoke 'airflow:stop'
     execute "cd #{release_path} && source #{fetch(:venv)} && pip3 install -r requirements.txt"
     execute "cp #{release_path}/config/.env #{release_path}/."
+    execute "cd #{release_path} && git clone #{fetch(:migration)} migration"
+    execute "chmod +x #{release_path}/migration/create_folder_structure.sh"
+    execute "cd #{release_path}/migration && ./create_folder_structure.sh"
+    invoke 'airflow:start'
   end
 end
 


### PR DESCRIPTION
Still not sure why the release directories are being created, but I added a before hook to change the directory owner so that capistrano can do its normal thing.