### PR TITLE
Casts MAX_ENTITIES to int and removes import

### DIFF
--- a/dags/srs_ingestion.py
+++ b/dags/srs_ingestion.py
@@ -1,4 +1,3 @@
-import filesplit
 import os
 import logging
 

--- a/dags/srs_ingestion.py
+++ b/dags/srs_ingestion.py
@@ -54,11 +54,11 @@ def add_marc_to_srs():
         split = Split(srs_filename, srs_dir)
         """
         Splits files are generated in this fashion:
-            [original_filename]_1.ext, [original_filename]_2.ext, .., [original_filename]_n.ext
+            [original_filename]_1.json, [original_filename]_2.json, .., [original_filename]_n.json
         """
         split.bylinecount(Variable.get("NUMBER_OF_SRS_FILES", 10000))
 
-        for srs_file in Path(srs_dir).glob("*.ext"):
+        for srs_file in Path(srs_dir).glob("*_[0-9].json"):
             logger.info(f"Starting ingestion of {srs_file}")
             post_marc_to_srs(
                 dag_run=context.get("dag_run"),

--- a/plugins/folio/helpers.py
+++ b/plugins/folio/helpers.py
@@ -27,6 +27,9 @@ def archive_artifacts(*args, **kwargs):
     airflow_results = airflow_path / "migration/results"
     archive_directory = airflow_path / "migration/archive"
 
+    if not archive_directory.exists():
+        archive_directory.mkdir()
+
     for tmp_file in tmp_path.glob("*.json"):
         try:
             tmp_file.unlink()

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -46,7 +46,7 @@ def post_folio_holding_records(**kwargs):
 
     tmp_location = kwargs.get("tmp_dir", "/tmp")
 
-    batch_size = kwargs.get("MAX_ENTITIES", 1000)
+    batch_size = int(kwargs.get("MAX_ENTITIES", 1000))
     job_number = kwargs.get("job")
 
     with open(f"{tmp_location}/holdings-{dag.run_id}-{job_number}.json") as fo:

--- a/plugins/folio/instances.py
+++ b/plugins/folio/instances.py
@@ -12,7 +12,7 @@ def post_folio_instance_records(**kwargs):
     """Creates new records in FOLIO"""
     dag = kwargs["dag_run"]
 
-    batch_size = kwargs.get("MAX_ENTITIES", 1000)
+    batch_size = int(kwargs.get("MAX_ENTITIES", 1000))
     job_number = kwargs.get("job")
 
     with open(f"/tmp/instances-{dag.run_id}-{job_number}.json") as fo:

--- a/plugins/folio/items.py
+++ b/plugins/folio/items.py
@@ -54,7 +54,7 @@ def post_folio_items_records(**kwargs):
     """Creates/overlays Items records in FOLIO"""
     dag = kwargs["dag_run"]
 
-    batch_size = kwargs.get("MAX_ENTITIES", 1000)
+    batch_size = int(kwargs.get("MAX_ENTITIES", 1000))
     job_number = kwargs.get("job")
 
     with open(f"/tmp/items-{dag.run_id}-{job_number}.json") as fo:

--- a/plugins/tests/mocks.py
+++ b/plugins/tests/mocks.py
@@ -80,7 +80,6 @@ def mock_file_system(tmp_path):
     (airflow_path / "migration/reports").mkdir(parents=True)
     (airflow_path / "migration/mapping_files").mkdir(parents=True)
     archive_dir = airflow_path / "migration/archive"
-    archive_dir.mkdir(parents=True)
 
     # Mock .gitignore
     gitignore = airflow_path / "migration/.gitignore"

--- a/plugins/tests/test_helpers.py
+++ b/plugins/tests/test_helpers.py
@@ -89,6 +89,8 @@ def test_archive_artifacts(mock_dag_run, mock_file_system):  # noqa
 
     target_file = archive_dir / instance_filename
 
+    assert not archive_dir.exists()
+
     archive_artifacts(dag_run=dag, airflow=airflow_path, tmp_dir=tmp_dir)
 
     assert not instance_file.exists()
@@ -213,7 +215,7 @@ def test_move_001_to_035(mock_marc_record):
 
 def test_missing_001_to_034(mock_marc_record):
     record = mock_marc_record
-    record.remove_fields('001')
+    record.remove_fields("001")
     _move_001_to_035(record)
     assert record.get_fields("035") == []
 
@@ -225,7 +227,8 @@ def test_transform_move_tsvs(mock_file_system):  # noqa
     # mock sample tsv
     symphony_tsv = source_dir / "sample.tsv"
     symphony_tsv.write_text(
-        "CATKEY\tCALL_NUMBER_TYPE\tBARCODE\n123456\tLC 12345\t45677  ")
+        "CATKEY\tCALL_NUMBER_TYPE\tBARCODE\n123456\tLC 12345\t45677  "
+    )
     tsv_directory = airflow_path / "migration/data/items"
     sample_tsv = tsv_directory / "sample.tsv"
     sample_notes_tsv = tsv_directory / "sample.notes.tsv"
@@ -236,14 +239,16 @@ def test_transform_move_tsvs(mock_file_system):  # noqa
         "BARCODE\tCIRCNOTE\n45677 \tpencil marks 7/28/18cc"
     )
 
-    column_transforms = [("CATKEY", lambda x: f"a{x}"),
-                         ("BARCODE", lambda x: x.strip())]
+    column_transforms = [
+        ("CATKEY", lambda x: f"a{x}"),
+        ("BARCODE", lambda x: x.strip()),
+    ]
 
     transform_move_tsvs(
         airflow=airflow_path,
         column_transforms=column_transforms,
         source="symphony",
-        tsv_stem="sample"
+        tsv_stem="sample",
     )
 
     f = open(sample_tsv, "r")
@@ -251,7 +256,9 @@ def test_transform_move_tsvs(mock_file_system):  # noqa
     f.close()
 
     f_notes = open(sample_notes_tsv, "r")
-    assert f_notes.readlines()[1] == "a123456\tLC 12345\t45677\tpencil marks 7/28/18cc\n"
+    assert (
+        f_notes.readlines()[1] == "a123456\tLC 12345\t45677\tpencil marks 7/28/18cc\n"
+    )
     f_notes.close()
 
 
@@ -259,22 +266,27 @@ def test_transform_move_tsvs_doesnt_exit(mock_file_system):  # noqa
     airflow_path = mock_file_system[0]
 
     with pytest.raises(ValueError, match="sample.tsv does not exist for workflow"):
-        transform_move_tsvs(
-            airflow=airflow_path,
-            source="symphony",
-            tsv_stem="sample"
-        )
+        transform_move_tsvs(airflow=airflow_path, source="symphony", tsv_stem="sample")
 
 
 def test_merge_notes_into_base():
-    base_df = pd.DataFrame([{"CATKEY": "a1442278",
-                             "BARCODE": "36105033974929",
-                             "BASE_CALL_NUMBER": "PQ6407 .A1 1980B"},
-                            {"CATKEY": "a13776856",
-                             "BARCODE": "36105231406765",
-                             "BASE_CALL_NUMBER": "KGF3055 .M67 2019"}])
-    notes_df = pd.DataFrame([{"BARCODE": "36105033974929",
-                              "CIRCNOTE": "pen marks 6/5/19cc"}])
+    base_df = pd.DataFrame(
+        [
+            {
+                "CATKEY": "a1442278",
+                "BARCODE": "36105033974929",
+                "BASE_CALL_NUMBER": "PQ6407 .A1 1980B",
+            },
+            {
+                "CATKEY": "a13776856",
+                "BARCODE": "36105231406765",
+                "BASE_CALL_NUMBER": "KGF3055 .M67 2019",
+            },
+        ]
+    )
+    notes_df = pd.DataFrame(
+        [{"BARCODE": "36105033974929", "CIRCNOTE": "pen marks 6/5/19cc"}]
+    )
     base_df = _merge_notes_into_base(base_df, notes_df)
     assert "CIRCNOTE" in base_df.columns
 


### PR DESCRIPTION
Changes to improve or fix functionality:
- Make sure MAX_ENTITIES is an int for record load batches
- Removes unused import
- Checks if archive directory exists and creates if it doesn't
- Fixes glob pattern to match JSON SRS split files