### PR TITLE
Supports dropping and restoring mod_inventory indices for SRS ingestion

### DIFF
--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -320,7 +320,7 @@ with DAG(
         task_id="ingest-srs-records",
         trigger_dag_id="add_marc_to_srs",
         conf={
-            "srs_filename": "folio_srs_instances_{{ dag_run.run_id }}_bibs-transformer.json"
+            "srs_filename": "/opt/airflow/migration/archive/folio_srs_instances_{{ dag_run.run_id }}_bibs-transformer.json",
         },
     )
 

--- a/dags/remediate_records.py
+++ b/dags/remediate_records.py
@@ -44,7 +44,7 @@ with DAG(
             "base": "instance-storage",
             "endpoint": "/inventory/instances",
             "folio_client": folio_client,
-        }
+        },
     )
 
     holdings_errors = PythonOperator(

--- a/dags/srs_ingestion.py
+++ b/dags/srs_ingestion.py
@@ -36,6 +36,7 @@ sul_config = LibraryConfiguration(
     start_date=datetime(2022, 6, 23),
     catchup=False,
     tags=["folio", "bib_import"],
+    max_active_runs=1,
 )
 def add_marc_to_srs():
     """
@@ -65,7 +66,7 @@ def add_marc_to_srs():
             name = row[0]
             if name.endswith("pkey"):
                 continue
-            sql = f"{sql}DROP INDEX sul_mod_inventory_storage.{name}"
+            sql = f"{sql}DROP INDEX sul_mod_inventory_storage.{name};"
         return PostgresOperator(
             task_id="remove-srs-indices",
             sql=sql,

--- a/plugins/folio/db.py
+++ b/plugins/folio/db.py
@@ -1,0 +1,41 @@
+import logging
+
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+
+logger = logging.getLogger(__name__)
+
+def drop_inventory_indices(**kwargs):
+    postgres_connect = kwargs.get("connection", "postgres_folio")
+    database = kwargs.get("database", "okapi")
+    index_result = kwargs["index_result"]
+    pg_hook = PostgresHook(postgres_conn_id=postgres_connect, database=database)
+    sql = ""
+    for row in index_result:
+        name = row[0]
+        if name.endswith("pkey"):
+            continue
+        sql = f"{sql}DROP INDEX sul_mod_inventory_storage.{name};"
+    logger.info("Dropping all mod_inventory_storage indices")
+    connection = pg_hook.get_conn()
+    cursor = connection.cursor()
+    cursor.execute(sql)
+    connection.commit()
+    logger.info("Finished dropping mod_inventory_storage indices")
+
+    
+def query_inventory_indices(**kwargs):
+    postgres_connect = kwargs.get("connection", "postgres_folio")
+    database = kwargs.get("database", "okapi")
+    pg_hook = PostgresHook(postgres_conn_id=postgres_connect, database=database)
+    sql="""
+        SELECT indexname, indexdef FROM pg_indexes
+        WHERE schemaname = 'sul_mod_inventory_storage' AND
+        (tablename = 'instance' OR tablename = 'holdings_records'
+        OR tablename = 'item');
+        """
+    connection = pg_hook.get_conn()
+    cursor = connection.cursor()
+    cursor.execute(sql)
+    indices_info = cursor.fetchall()
+    return indices_info
+

--- a/plugins/folio/helpers.py
+++ b/plugins/folio/helpers.py
@@ -41,7 +41,7 @@ def archive_artifacts(*args, **kwargs):
         target = archive_directory / artifact.name
 
         shutil.move(artifact, target)
-        logger.info("Moved {artifact} to {target}")
+        logger.info(f"Moved {artifact} to {target}")
 
 
 def move_marc_files_check_tsv(*args, **kwargs) -> str:


### PR DESCRIPTION
Fixes #110 

Using the `PostgresOperator`, adds tasks to the `add_marc_to_srs` DAG:
![Screen Shot 2022-07-06 at 4 07 49 PM](https://user-images.githubusercontent.com/71847/177651935-398c1c5f-d825-40f5-964e-f3d40f24dd84.png)

The `PostgresOperator` operators require a new  Postgres Connection with an id of `postgres_folio` that specifies the Postgres `host`, `username`, and `password`.

TODO:
- [ ] Finish testing from server (not locally because Postgres VM is only accessible from the Airflow server)
- [ ] Add tests (either by refactoring or by testing `add_marc_to_srs` DAG directly)