### PR TITLE
Handling Optimistic locking 

### DIFF
--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -17,12 +17,15 @@ from airflow.models import Variable
 
 from folio_migration_tools.library_configuration import LibraryConfiguration
 
+from plugins.folio.db import add_inventory_triggers, drop_inventory_triggers
+
 from plugins.folio.helpers import (
     move_marc_files_check_tsv,
     process_marc,
     process_records,
     transform_move_tsvs,
 )
+
 from plugins.folio.holdings import run_holdings_tranformer, post_folio_holding_records
 
 from plugins.folio.login import folio_login
@@ -102,6 +105,11 @@ with DAG(
         """\
         ####  Monitor File Mount
         Monitor's `/s/SUL/Dataload/Folio` for new MARC21 export files"""
+    )
+
+    drop_triggers = PythonOperator(
+        task_id="drop-inventory-triggers",
+        python_callable=drop_inventory_triggers
     )
 
     with TaskGroup(group_id="move-transform") as move_transform_process:
@@ -329,6 +337,11 @@ with DAG(
         task_id="finish_loading",
     )
 
-    monitor_file_mount >> move_transform_process >> marc_to_folio
+    create_triggers = PythonOperator(
+        task_id='create-inventory-triggers',
+        python_callable=add_inventory_triggers
+    )
+
+    monitor_file_mount >> [move_transform_process, drop_triggers] >> marc_to_folio
     marc_to_folio >> post_to_folio >> finish_loading
-    finish_loading >> [ingest_srs_records, remediate_errors]
+    finish_loading >> [ingest_srs_records, remediate_errors, create_triggers]

--- a/dags/ol_manage.py
+++ b/dags/ol_manage.py
@@ -1,0 +1,69 @@
+import logging
+import time
+
+from datetime import datetime
+
+from airflow.decorators import dag, task
+from airflow.models.dagrun import DagRun
+
+from plugins.folio.db import add_inventory_triggers, drop_inventory_triggers
+
+logger = logging.getLogger(__name__)
+
+
+@dag(
+    schedule_interval=None,
+    start_date=datetime(2022, 7, 19),
+    catchup=False,
+    max_active_runs=1,
+    tags=["folio", "bib_import"],
+)
+def optimistic_locking_management():
+    """
+    ## Manages FOLIO's Optimistic Locking
+    DAG should be triggered before any symphony_marc_import DAG runs. Drops
+    OL triggers on mod_inventory_storage and then monitors for current
+    symphony_marc_import. If there are not any active symphony_marc_import DAG
+    runs, waits 15 minutes before creating OL triggers.
+    """
+
+    @task
+    def drop_ol_triggers():
+        logger.info("Dropping FOLIO's optimistic locking for inventory")
+        drop_inventory_triggers()
+        logger.info("Finished dropping inventory triggers")
+
+    @task
+    def monitor_dag_runs():
+        logger.info("Monitoring symphony_marc_import active dag runs")
+        not_finished = True
+        while 1:
+            time.sleep(30)
+            dag_runs = DagRun.active_runs_of_dags(dag_ids=["symphony_marc_import"])
+            logger.info(
+                f"Total number of symphony_marc_import dag runs {len(dag_runs)}"
+            )
+            if len(dag_runs) < 1 and not_finished is True:
+                logger.info("Sleeping for 5 minutes")
+                time.sleep(300)
+                logger.info("Finished sleeping")
+                not_finished = False
+                continue
+            if len(dag_runs) < 1:
+                logger.info("Finished, no active symphony_marc_import dag runs")
+                return
+            else:
+                not_finished = True
+
+    @task
+    def create_ol_triggers():
+        logger.info("Creating triggers for FOLIO's inventory optimistic locking")
+        add_inventory_triggers()
+        logger.info(
+            "Finished creating triggers for FOLIO's inventory optimistic locking"
+        )
+
+    drop_ol_triggers() >> monitor_dag_runs() >> create_ol_triggers()
+
+
+inventory_ol_manage = optimistic_locking_management()

--- a/plugins/folio/db.py
+++ b/plugins/folio/db.py
@@ -26,7 +26,7 @@ def add_inventory_triggers(**kwargs):
           FOR EACH ROW EXECUTE FUNCTION sul_mod_inventory_storage.holdings_record_set_ol_version();
           CREATE TRIGGER set_item_ol_version_trigger
           AFTER INSERT OR UPDATE ON sul_mod_inventory_storage.item
-          FOR EACH ROW sul_mod_inventory_storage.item_set_ol_version();
+          FOR EACH ROW EXECUTE FUNCTION sul_mod_inventory_storage.item_set_ol_version();
     """
     logger.info("Creating mod_inventory_storage triggers")
     connection = pg_hook.get_conn()
@@ -38,7 +38,7 @@ def add_inventory_triggers(**kwargs):
 
 def drop_inventory_triggers(**kwargs):
     """
-    Drops Inventory triggers used for optimistic Locking
+    Drops Inventory triggers used for optimistic locking
     """
     pg_hook = _db_connection(**kwargs)
     sql = """

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -39,6 +39,9 @@ def _add_identifiers(holdings_transformer: HoldingsCsvTransformer):
             )
         )
 
+        # To handle optimistic locking
+        record["_version"] = 1
+
 
 def post_folio_holding_records(**kwargs):
     """Creates/overlays Holdings records in FOLIO"""
@@ -53,7 +56,7 @@ def post_folio_holding_records(**kwargs):
         holding_records = json.load(fo)
 
     for i in range(0, len(holding_records), batch_size):
-        holdings_batch = holding_records[i:i + batch_size]
+        holdings_batch = holding_records[i: i + batch_size]
         logger.info(f"Posting {i} to {i+batch_size} holding records")
         post_to_okapi(
             token=kwargs["task_instance"].xcom_pull(

--- a/plugins/folio/items.py
+++ b/plugins/folio/items.py
@@ -43,6 +43,8 @@ def _add_hrid(okapi_url: str, holdings_path: str, items_path: str):
                     id_seed,
                 )
             )
+            # To handle optimistic locking
+            item["_version"] = 1
             items.append(item)
 
     with open(items_path, "w+") as write_output:
@@ -61,7 +63,7 @@ def post_folio_items_records(**kwargs):
         items_records = json.load(fo)
 
     for i in range(0, len(items_records), batch_size):
-        items_batch = items_records[i:i + batch_size]
+        items_batch = items_records[i: i + batch_size]
         logger.info(f"Posting {len(items_batch)} in batch {i/batch_size}")
         post_to_okapi(
             token=kwargs["task_instance"].xcom_pull(

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -83,3 +83,6 @@ def test_add_identifiers():
     # Test HRIDs
     assert transformer.holdings.values()[0]["hrid"] == "ah123345_1"
     assert transformer.holdings.values()[1]["hrid"] == "ah123345_2"
+
+    # Test _version
+    assert transformer.holdings.values()[0]["_version"] == 1

--- a/plugins/tests/test_instances.py
+++ b/plugins/tests/test_instances.py
@@ -1,7 +1,26 @@
+import pydantic
+
 from plugins.folio.instances import (
+    _add_version,
     post_folio_instance_records,
     run_bibs_transformer
 )
+
+instances = [{}, {}]
+
+
+class MockInstances(pydantic.BaseModel):
+    values = lambda x: instances  # noqa
+
+
+class MockBibsTransformer(pydantic.BaseModel):
+    instances = MockInstances()
+
+
+def test_add_version():
+    bib_transformer = MockBibsTransformer()
+    _add_version(bib_transformer)
+    assert bib_transformer.instances.values()[0]["_version"] == 1
 
 
 def test_post_folio_instance_records():

--- a/plugins/tests/test_items.py
+++ b/plugins/tests/test_items.py
@@ -44,3 +44,4 @@ def test_add_hrid(tmp_path):  # noqa
 
     assert(new_items_rec['hrid']) == "ai23456_1"
     assert(new_items_rec['id']) == "f40ad979-32e8-5f54-bb3d-698c0f611a54"
+    assert(new_items_rec['_version']) == 1


### PR DESCRIPTION
FIXES #101 

Creates a new DAG `optimistic_locking_management` that is meant to be run before and during multiple `symphony_marc_import` DAG runs. 

![Screen Shot 2022-07-20 at 12 55 38 PM](https://user-images.githubusercontent.com/71847/180061672-4b50e9e0-14ab-4388-a624-8ddb531ca54e.png)

1.  When started, the DAG drops the OL triggers for the inventory databases and monitors active `symphony_marc_import` DAG runs. 
2. When five minutes have elapsed after there are no longer any active `symphony_marc_import` runs, the OL triggers are created for the inventory tables.

Also adds a `_version` property to the Instances, Holdings, and Items JSON records. 