### PR TITLE
Streamline srs ingestion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,16 @@ FROM apache/airflow:2.3.3-python3.10
 USER root
 RUN usermod -u 214 airflow
 RUN apt-get update && apt-get install -y gcc
+RUN apt-get -y update && apt-get -y install git
 
 ENV PYTHONPATH "${PYTHONPATH}:/opt/airflow/"
 ENV SLUGIFY_USES_TEXT_UNIDECODE "yes"
 
 USER airflow
+
+# Use folio_migration_tools branch tthat skips over batch posting retries until another solution can be found
+#  to address the SQL Unique constraint violation errors
+RUN git clone -b streamline-batch-reposting-tries https://github.com/jermnelson/folio_migration_tools.git --depth=2
 
 COPY requirements.txt .
 
@@ -15,4 +20,5 @@ RUN pip install -r requirements.txt
 # Needed to fix an import error see https://stackoverflow.com/questions/47884709/python-importerror-no-module-named-pluggy
 RUN pip install -U pytest-metadata
 # Install FOLIO-FSE tools
-RUN pip install folioclient folio-migration-tools folio-uuid
+RUN pip install folioclient folio-uuid
+RUN pip install /opt/airflow/folio_migration_tools

--- a/dags/srs_ingestion.py
+++ b/dags/srs_ingestion.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
     start_date=datetime(2022, 6, 23),
     catchup=False,
     tags=["folio", "bib_import"],
+    max_active_runs=1,
 )
 def add_marc_to_srs():
     """
@@ -70,7 +71,7 @@ def add_marc_to_srs():
             dag_run=context.get("dag_run"),
             library_config=sul_config,
             srs_file=srs_filename,
-            MAX_ENTITIES=Variable.get("MAX_SRS_ENTITIES", 500),
+            MAX_ENTITIES=Variable.get("MAX_SRS_ENTITIES", 250),
         )
 
     @task


### PR DESCRIPTION
- use forked folio_migration_tools that skips the multiple retries whenever HTTP 500 happens (in our case because of SQL Unique constraint violation) 
- decrease default batch size to 250
- throttle srs ingestion dag so only one can run at any given time.