### PR TITLE
Adds ON-ORDER Bibs support in DAG and FOLIO plugin 

### DIFF
--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -116,7 +116,7 @@ with DAG(
                     # Adds a prefix to match bib 001
                     ("CATKEY", lambda x: x if x.startswith("a") else f"a{x}"),
                     # Strips out spaces from barcode
-                    ("BARCODE", lambda x: x.strip()),
+                    ("BARCODE", lambda x: x.strip() if isinstance(x, str) else x),
                 ],
                 "tsv_files": "{{ ti.xcom_pull('bib-file-groups', key='tsv-files') }}",  # noqa
             },

--- a/plugins/folio/helpers.py
+++ b/plugins/folio/helpers.py
@@ -383,6 +383,11 @@ def _processes_tsv(tsv_base: str, tsv_notes: list, airflow, column_transforms):
         logging.info(f"Merged {len(note_df)} notes into items tsv")
         tsv_notes_path.unlink()
 
+    # Add note columns to tsv_base_df if notes do not exist
+    if len(tsv_notes) < 1:
+        for note in ['CIRCNOTE', 'CIRCNOTE', 'TECHSTAFF', 'PUBLIC']:
+            tsv_base_df[note] = np.NaN
+
     tsv_notes_name_parts = tsv_base.name.split(".")
     tsv_notes_name_parts.insert(-1, "notes")
 

--- a/plugins/tests/test_items.py
+++ b/plugins/tests/test_items.py
@@ -1,6 +1,8 @@
 import json
 
 import pytest  # noqa
+from plugins.tests.mocks import mock_file_system  # noqa
+
 
 from plugins.folio.items import (
     post_folio_items_records,
@@ -17,17 +19,19 @@ def test_items_transformers():
     assert run_items_transformer
 
 
-def test_add_hrid(tmp_path):  # noqa
-    holdings_path = tmp_path / "holdings_transformer-test_dag.json"
+def test_add_hrid(mock_file_system):  # noqa
+    results_dir = mock_file_system[3]
+    holdings_path = results_dir / "holdings_transformer-test_dag.json"
 
     holdings_rec = {
         "id": "8e6e9fb5-f914-4d38-87d2-ccb52f9a44a4",
-        "formerIds": ["a23456"]
+        "formerIds": ["a23456"],
+        "hrid": "ah23456_1"
     }
 
     holdings_path.write_text(f"{json.dumps(holdings_rec)}\n")
 
-    items_path = tmp_path / "items_transformer-test_dag.json"
+    items_path = results_dir / "items_transformer-test_dag.json"
 
     items_rec = {
         "holdingsRecordId": "8e6e9fb5-f914-4d38-87d2-ccb52f9a44a4"
@@ -36,8 +40,9 @@ def test_add_hrid(tmp_path):  # noqa
     items_path.write_text(f"{json.dumps(items_rec)}\n")
 
     _add_hrid("https://okapi-endpoint.edu",
-              str(holdings_path),
-              str(items_path))
+              str(mock_file_system[0]),
+              "holdings_transformer-*.json",
+              "items_transformer-*.json")
 
     with items_path.open() as items_fo:
         new_items_rec = json.loads(items_fo.readline())


### PR DESCRIPTION
Fixes #112 

Accompanying PR [17](https://github.com/sul-dlss/folio_migration/pull/17) in folio_migration needs to be merged for this PR to map the on-order status.

TODO:
- ~~Increase test coverage~~ coverage remains the same
- [x] Troubleshoot error with holdings task failing first run but succeeding the second time
- [x] Ensure that item status is `On order` is set correctly for these records