### PR TITLE
Require TSV to Holdings Task to depend on MARC to Instance Task completion 

### DIFF
--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -228,8 +228,7 @@ with DAG(
             >> convert_instances_valid_json
             >> finish_conversion
         )
-        (convert_marc_to_folio_instances >> finish_conversion)  # noqa
-        marc_only_convert_check >> [
+        convert_marc_to_folio_instances >> marc_only_convert_check >> [
             convert_tsv_to_folio_holdings,
             finish_conversion,
         ]  # noqa


### PR DESCRIPTION
Fixes an issue with some HRIDs not being found in the `instance_id_map` because the `convert_tsv_to_folio_holdings` tasks was running in parallel with the `convert_marc_to_folio_instances`. The `convert_marc_to_folio_instances` needs to complete first before any further downstream tasks are run.