### PR TITLE
Return empty dict for 201 Response 

### DIFF
--- a/plugins/folio/helpers.py
+++ b/plugins/folio/helpers.py
@@ -319,6 +319,8 @@ def post_to_okapi(**kwargs) -> bool:
         logger.error(new_record_result.text)
         _save_error_record_ids(error_code=new_record_result.status_code, **kwargs)
 
+    if len(new_record_result.text) < 1:
+        return {}
     return new_record_result.json()
 
 

--- a/plugins/tests/mocks.py
+++ b/plugins/tests/mocks.py
@@ -27,7 +27,7 @@ def mock_okapi_success(monkeypatch, mocker: MockerFixture):
         post_response_elapsed = mocker.stub(name="post_elapsed")
         post_response_elapsed.total_seconds = lambda: 30
         post_response.elapsed = post_response_elapsed
-        post_response.json = lambda: {}
+        post_response.text = ""
         return post_response
 
     def mock_put(*args, **kwargs):

--- a/plugins/tests/test_aeon_to_lobby.py
+++ b/plugins/tests/test_aeon_to_lobby.py
@@ -82,7 +82,7 @@ def test_user_data(mock_queue_requests, mock_aeon_variable):
 
 
 def test_aeon_request_params(caplog):
-    from plugins.aeon_to_lobby.aeon import aeon_user
+    from plugins.aeon_to_lobby.aeon import aeon_user  # noqa
 
     assert "aeon rsponded with" not in caplog.text
 

--- a/plugins/tests/test_helpers.py
+++ b/plugins/tests/test_helpers.py
@@ -133,7 +133,7 @@ def mock_okapi_success(monkeypatch, mocker: MockerFixture):
     def mock_post(*args, **kwargs):
         post_response = mocker.stub(name="post_result")
         post_response.status_code = 201
-        post_response.json = lambda: {}
+        post_response.text = ""
 
         return post_response
 


### PR DESCRIPTION
When a successful POST to okapi, okapi's response body is an empty string which raises the following exception trying to decode as JSON

```python
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/operators/python.py", line 171, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/operators/python.py", line 189, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/opt/airflow/plugins/folio/instances.py", line 39, in post_folio_instance_records
    post_to_okapi(
  File "/opt/airflow/plugins/folio/helpers.py", line 322, in post_to_okapi
    return new_record_result.json()
  File "/home/airflow/.local/lib/python3.10/site-packages/requests/models.py", line 917, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: [Errno Expecting value] : 0
```

Now if the body is an empty string, we just return an empty dict.