### PR TITLE
Simplify HRID and UUID generation for Holdings and Items

### DIFF
--- a/plugins/folio/helpers/folio_ids.py
+++ b/plugins/folio/helpers/folio_ids.py
@@ -1,48 +1,142 @@
+import json
+import logging
+import pathlib
+
 from airflow.models import Variable
 from folio_uuid.folio_uuid import FOLIONamespaces, FolioUUID
 
-def generate_holdings_identifiers(
-    holdings: list,
+logger = logging.getLogger(__name__)
+
+
+def _generate_instance_map(instance_path: pathlib.Path) -> dict:
+    """
+    Takes FOLIO instance files and returns a dictionary by
+    uuid keys with hrid and holdings list values
+    """
+    instance_map = {}
+    with instance_path.open() as fo:
+        for line in fo.readlines():
+            instance = json.loads(line)
+            instance_map[instance["id"]] = {"hrid": instance["hrid"], "holdings": []}
+
+    return instance_map
+
+
+def _update_holding_ids(
+    holdings_path: pathlib.Path,
     instance_map: dict,
-    holdings_map: dict=None,
+    okapi_url: str,
+    holdings_map: dict = {},
 ) -> None:
-    for holding in holdings:
-        instance_id = holding["instanceId"]
-        instance_hrid = instance_map[instance_id]["hrid"]
-        current_count = len(instance_map[instance_id]["holdings"])
-        holdings_hrid = f"{instance_hrid[:1]}h{instance_hrid[1:]}_{current_count + 1}"
-        holding["hrid"] = holdings_hrid
-        new_holdings_id = str(FolioUUID(
-            Variable.get("OKAPI_URI"),
-            FOLIONamespaces.holdings,
-            holdings_hrid
-        ))
-        if holdings_map:
-            holdings_map[holding["id"]] = { 
-                "new": new_holdings_id,
-                "hrid": holdings_hrid,
-                "items": []
-            }
-        holding["id"] = new_holdings_id
-        instance_map[instance_id]["holdings"].append(new_holdings_id)
+    """
+    Iterates through a list of holdings, generates uuid and hrids based
+    on the instance map, and optionally populates a holdings map for
+    later item identifier generation
+    """
+    with holdings_path.open() as fo:
+        holdings = [json.loads(line) for line in fo.readlines()]
 
-
-def generate_item_identifiers(
-    items: list,
-    holdings_map: dict
-    ) -> None:
-    for item in items:
-        holding_id = item['holdingsRecordId']
-        holdings_hrid = holdings_map[holding_id]["hrid"]
-        current_count = len(holdings_map[holding_id]["items"])
-        item_hrid = f"{holdings_hrid[:1]}i{holdings_hrid[2:]}_{current_count + 1}"
-        item["hrid"] = item_hrid
-        item_uuid = str(
-            FolioUUID(
-                "https://okapiurl.edu",
-                FOLIONamespaces.items,
-                item_hrid
+    with holdings_path.open("w+") as fo:
+        for i, holding in enumerate(holdings):
+            instance_id = holding["instanceId"]
+            instance_hrid = instance_map[instance_id]["hrid"]
+            current_count = len(instance_map[instance_id]["holdings"])
+            holdings_hrid = (
+                f"{instance_hrid[:1]}h{instance_hrid[1:]}_{current_count + 1}"
             )
-        )
-        item["id"] = item_uuid
-        holdings_map[holding_id]["items"].append(item_uuid)
+            holding["hrid"] = holdings_hrid
+            new_holdings_id = str(
+                FolioUUID(okapi_url, FOLIONamespaces.holdings, holdings_hrid)
+            )
+            if len(holdings_map) > 0:
+                holdings_map[holding["id"]] = {
+                    "new": new_holdings_id,
+                    "hrid": holdings_hrid,
+                    "items": [],
+                }
+            holding["id"] = new_holdings_id
+            # For optimistic locking handling
+            holding["_version"] = 1
+            instance_map[instance_id]["holdings"].append(new_holdings_id)
+            fo.write(f"{json.dumps(holding)}\n")
+            if not i % 1_000 and i > 0:
+                logger.info(f"Generated uuids and hrids for {i:,} holdings")
+
+    # Persists holdings_map if populated
+    if len(holdings_map) > 0:
+        holdings_map_path = holdings_path.parent / "holdings-items-map.json"
+        with holdings_map_path.open("w+") as fo:
+            json.dump(holdings_map, fo)
+
+    logger.info(f"Finished updating {i:,} for {holdings_path} ")
+
+
+def generate_holdings_identifiers(**kwargs) -> None:
+    """
+    Loads FOLIO instances and holdings, generates and saves
+    uuids and hrids for holdings
+    """
+    airflow = kwargs.get("airflow", "/opt/airflow")
+    dag = kwargs["dag_run"]
+    results_dir = pathlib.Path(airflow) / f"migration/iterations/{dag.run_id}/results/"
+    okapi_url = Variable.get("OKAPI_URL")
+
+    instance_path = results_dir / "folio_instances_bibs-transformer.json"
+
+    instance_map = _generate_instance_map(instance_path)
+    tsv_holdings_path = results_dir / "folio_holdings_tsv-transformer.json"
+
+    # Adds a stub key-value holdings map to populate from base tsv file
+    _update_holding_ids(
+        tsv_holdings_path, instance_map, okapi_url, {"type": "base tsv"}
+    )
+    logger.info(f"Finished updating tsv holdings {tsv_holdings_path}")
+
+    # Updates MHLD holdings
+    mhld_holdings_path = results_dir / "folio_holdings_mhld-transformer.json"
+    _update_holding_ids(mhld_holdings_path, instance_map, okapi_url)
+    logger.info(f"Finished updating mhls holdings {mhld_holdings_path}")
+
+    # Updates Electronic holdings
+    electronic_holdings_path = (
+        results_dir / "folio_holdings_electronic-transformer.json"
+    )
+    _update_holding_ids(electronic_holdings_path, instance_map, okapi_url)
+    logger.info(f"Finished updating electronic holdings {electronic_holdings_path}")
+
+
+def generate_item_identifiers(**kwargs) -> None:
+    """
+    Loads FOLIO holdings map and items, generates and saves
+    uuids and hrids for
+    """
+    airflow = kwargs.get("airflow", "/opt/airflow")
+    dag = kwargs["dag_run"]
+    results_dir = pathlib.Path(airflow) / f"migration/iterations/{dag.run_id}/results/"
+    okapi_url = Variable.get("OKAPI_URL")
+
+    items_path = results_dir / "folio_items_transformer.json"
+
+    with items_path.open() as fo:
+        items = [json.loads(line) for line in fo.readlines()]
+
+    with (results_dir / "holdings-items-map.json").open() as fo:
+        holdings_map = json.load(fo)
+
+    with items_path.open("w+") as fo:
+        for i, item in enumerate(items):
+            holding_id = item["holdingsRecordId"]
+            current_holding = holdings_map[holding_id]
+            holdings_hrid = current_holding["hrid"]
+            current_count = len(current_holding["items"])
+            item_hrid = f"{holdings_hrid[:1]}i{holdings_hrid[2:]}_{current_count + 1}"
+            item["hrid"] = item_hrid
+            item["holdingsRecordId"] = current_holding["new"]
+            item_uuid = str(FolioUUID(okapi_url, FOLIONamespaces.items, item_hrid))
+            item["id"] = item_uuid
+            current_holding["items"].append(item_uuid)
+            if not i % 1_000 and i > 0:
+                logger.info(f"Generated uuids and hrids for {i:,} items")
+            fo.write(f"{json.dumps(item)}\n")
+
+    logger.info(f"Finished updating identifiers for {len(items):,} items")

--- a/plugins/folio/helpers/folio_ids.py
+++ b/plugins/folio/helpers/folio_ids.py
@@ -1,0 +1,48 @@
+from airflow.models import Variable
+from folio_uuid.folio_uuid import FOLIONamespaces, FolioUUID
+
+def generate_holdings_identifiers(
+    holdings: list,
+    instance_map: dict,
+    holdings_map: dict=None,
+) -> None:
+    for holding in holdings:
+        instance_id = holding["instanceId"]
+        instance_hrid = instance_map[instance_id]["hrid"]
+        current_count = len(instance_map[instance_id]["holdings"])
+        holdings_hrid = f"{instance_hrid[:1]}h{instance_hrid[1:]}_{current_count + 1}"
+        holding["hrid"] = holdings_hrid
+        new_holdings_id = str(FolioUUID(
+            Variable.get("OKAPI_URI"),
+            FOLIONamespaces.holdings,
+            holdings_hrid
+        ))
+        if holdings_map:
+            holdings_map[holding["id"]] = { 
+                "new": new_holdings_id,
+                "hrid": holdings_hrid,
+                "items": []
+            }
+        holding["id"] = new_holdings_id
+        instance_map[instance_id]["holdings"].append(new_holdings_id)
+
+
+def generate_item_identifiers(
+    items: list,
+    holdings_map: dict
+    ) -> None:
+    for item in items:
+        holding_id = item['holdingsRecordId']
+        holdings_hrid = holdings_map[holding_id]["hrid"]
+        current_count = len(holdings_map[holding_id]["items"])
+        item_hrid = f"{holdings_hrid[:1]}i{holdings_hrid[2:]}_{current_count + 1}"
+        item["hrid"] = item_hrid
+        item_uuid = str(
+            FolioUUID(
+                "https://okapiurl.edu",
+                FOLIONamespaces.items,
+                item_hrid
+            )
+        )
+        item["id"] = item_uuid
+        holdings_map[holding_id]["items"].append(item_uuid)

--- a/plugins/folio/helpers/tsv.py
+++ b/plugins/folio/helpers/tsv.py
@@ -138,29 +138,3 @@ def transform_move_tsvs(*args, **kwargs):
         task_instance.xcom_push(key="tsv-notes", value=str(notes_path))
 
     return tsv_base.name
-
-
-def update_items(full_path: pathlib.Path, holdings: list, mapping: list):
-    id_location_library = {}
-    for row in mapping:
-        info = {"HOMELOCATION": row["HOMELOCATION"], "LIBRARY": row["LIBRARY"]}
-        if row["folio_id"] in id_location_library:
-            id_location_library[row["folio_id"]].append(info)
-        else:
-            id_location_library[row["folio_id"]] = [
-                info,
-            ]
-    items_df = pd.read_csv(full_path, sep="\t")
-    new_items_df = pd.DataFrame()
-    for holding in holdings:
-        location_info = id_location_library[holding["permanentLocationId"]]
-        for info in location_info:
-            matched_items = items_df.loc[
-                (items_df["CATKEY"] == holding["formerIds"][0])
-                & (items_df["HOMELOCATION"] == info["HOMELOCATION"])
-                & (items_df["LIBRARY"] == info["LIBRARY"])
-            ].copy()
-            if len(matched_items) > 0:
-                matched_items["CATKEY"] = holding["hrid"]
-                new_items_df = pd.concat([new_items_df, matched_items])
-    new_items_df.to_csv(full_path, sep="\t", index=False)

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -14,7 +14,6 @@ from folio_migration_tools.migration_tasks.holdings_marc_transformer import (
 )
 
 from plugins.folio.helpers import post_to_okapi, setup_data_logging
-from plugins.folio.helpers.tsv import update_items
 
 logger = logging.getLogger(__name__)
 
@@ -27,83 +26,6 @@ def _run_transformer(transformer, airflow, dag_run_id, item_path):
     transformer.do_work()
 
     transformer.wrap_up()
-
-    #_add_identifiers(airflow, dag_run_id, transformer, item_path)
-
-
-def _add_identifiers(
-    airflow: str,
-    dag_run_id: str,
-    holdings_transformer: HoldingsCsvTransformer,
-    item_path: pathlib.Path
-):
-    # Creates/opens file with Instance IDs
-    instance_holdings_path = pathlib.Path(
-        f"{airflow}/migration/iterations/{dag_run_id}/results/holdings-hrids.json"
-    )
-
-    if instance_holdings_path.exists():
-        with instance_holdings_path.open() as fo:
-            instance_keys = json.load(fo)
-    else:
-        instance_keys = {}
-
-    holdings_path = pathlib.Path(
-        f"{airflow}/migration/iterations/{dag_run_id}/results/folio_holdings_{holdings_transformer.task_configuration.name}.json"
-    )
-
-    with holdings_path.open() as fo:
-        holdings_records = [json.loads(row) for row in fo.readlines()]
-
-    logger.info("Adding HRIDs and re-generated UUIDs for holdings")
-
-    for record in holdings_records:
-        instance_uuid = record["instanceId"]
-        former_id = record["formerIds"][0]
-        # Adds an "h" for holdings prefix
-        if former_id.startswith("a"):
-            former_id = former_id[:1] + "h" + former_id[1:]
-        if instance_uuid in instance_keys:
-            new_count = instance_keys[instance_uuid] + 1
-        else:
-            new_count = 1
-        instance_keys[instance_uuid] = new_count
-        record["hrid"] = f"{former_id}_{new_count}"
-
-        # Adds Determinstic UUID based on CATKEY and HRID
-        record["id"] = str(
-            FolioUUID(
-                holdings_transformer.folio_client.okapi_url,
-                FOLIONamespaces.holdings,
-                f"{record['formerIds'][0]}{record['hrid']}",
-            )
-        )
-
-        # To handle optimistic locking
-        record["_version"] = 1
-
-    with instance_holdings_path.open("w+") as fo:
-        json.dump(instance_keys, fo)
-
-    with holdings_path.open("w+") as fo:
-        for holding in holdings_records:
-            fo.write(f"{json.dumps(holding)}\n")
-
-    # Saves holdings id maps to backup
-    with open(
-        f"{airflow}/migration/iterations/{dag_run_id}/results/holdings_id_map_all.json",
-        "a+",
-    ) as all_id_map:
-        for holding in holdings_records:
-            lookup = {"legacy_id": holding["hrid"], "folio_id": holding["id"]}
-            all_id_map.write(f"{json.dumps(lookup)}\n")
-
-    # Updates items tsv replacing CATKEY values with new holdings HRIDs
-    if item_path:
-        update_items(
-            item_path,
-            holdings_records,
-            holdings_transformer.mapper.location_mapping.regular_mappings)
 
 
 def _extract_catkey(mhld_record: list) -> str:

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -13,8 +13,6 @@ from folio_migration_tools.migration_tasks.holdings_marc_transformer import (
     HoldingsMarcTransformer,
 )
 
-from folio_uuid.folio_uuid import FOLIONamespaces, FolioUUID
-
 from plugins.folio.helpers import post_to_okapi, setup_data_logging
 from plugins.folio.helpers.tsv import update_items
 
@@ -30,7 +28,7 @@ def _run_transformer(transformer, airflow, dag_run_id, item_path):
 
     transformer.wrap_up()
 
-    _add_identifiers(airflow, dag_run_id, transformer, item_path)
+    #_add_identifiers(airflow, dag_run_id, transformer, item_path)
 
 
 def _add_identifiers(
@@ -186,7 +184,7 @@ def run_holdings_tranformer(*args, **kwargs):
     holdings_configuration = HoldingsCsvTransformer.TaskConfiguration(
         name="csv-transformer",
         migration_task_type="HoldingsCsvTransformer",
-        hrid_handling="preserve001",
+        hrid_handling="default",
         files=[{"file_name": holdings_filepath.name, "suppress": False}],
         create_source_records=False,
         call_number_type_map_file_name="call_number_type_mapping.tsv",
@@ -268,7 +266,7 @@ def electronic_holdings(*args, **kwargs) -> str:
     holdings_configuration = HoldingsCsvTransformer.TaskConfiguration(
         name="electronic-transformer",
         migration_task_type="HoldingsCsvTransformer",
-        hrid_handling="preserve001",
+        hrid_handling="default",
         files=[{"file_name": filename, "suppress": False}],
         create_source_records=False,
         call_number_type_map_file_name="call_number_type_mapping.tsv",

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -3,7 +3,7 @@ import logging
 import pathlib
 import re
 
-
+from folio_uuid.folio_uuid import FOLIONamespaces, FolioUUID
 from airflow.models import Variable
 
 from folio_migration_tools.migration_tasks.holdings_csv_transformer import (
@@ -182,7 +182,7 @@ def run_holdings_tranformer(*args, **kwargs):
     holdings_filepath = library_config.base_folder / f"iterations/{dag.run_id}/source_data/items/{holdings_stem}.tsv"
 
     holdings_configuration = HoldingsCsvTransformer.TaskConfiguration(
-        name="csv-transformer",
+        name="tsv-transformer",
         migration_task_type="HoldingsCsvTransformer",
         hrid_handling="default",
         files=[{"file_name": holdings_filepath.name, "suppress": False}],
@@ -285,19 +285,6 @@ def electronic_holdings(*args, **kwargs) -> str:
     _run_transformer(holdings_transformer, airflow, dag.run_id, full_path)
 
     logger.info(f"Finished transforming electronic {filename} to FOLIO holdings")
-
-
-def consolidate_holdings_map(*args, **kwargs):
-    dag = kwargs["dag_run"]
-    airflow = kwargs.get("airflow", "/opt/airflow")
-    last_id_map = pathlib.Path(
-        f"{airflow}/migration/iterations/{dag.run_id}/results/holdings_id_map.json"
-    )
-    all_id_map = pathlib.Path(
-        f"{airflow}/migration/iterations/{dag.run_id}/results/holdings_id_map_all.json"
-    )
-    all_id_map.rename(last_id_map)
-    logger.info(f"Finished moving {all_id_map} to {last_id_map}")
 
 
 def update_mhlds_uuids(*args, **kwargs):

--- a/plugins/folio/items.py
+++ b/plugins/folio/items.py
@@ -6,12 +6,10 @@ import pandas as pd
 import requests
 
 from folio_migration_tools.migration_tasks.items_transformer import ItemsTransformer
-from folio_uuid.folio_uuid import FOLIONamespaces, FolioUUID
 
 from plugins.folio.helpers import post_to_okapi, setup_data_logging
 
 logger = logging.getLogger(__name__)
-
 
 
 def _generate_item_notes(

--- a/plugins/folio/items.py
+++ b/plugins/folio/items.py
@@ -109,7 +109,7 @@ def _add_additional_info(**kwargs):
 
     results_dir = pathlib.Path(f"{airflow}/migration/iterations/{dag_run_id}/results")
 
-    holdings_keys = _generate_holdings_keys(results_dir, holdings_pattern)
+    # holdings_keys = _generate_holdings_keys(results_dir, holdings_pattern)
 
     if tsv_notes_path is not None:
         tsv_notes_path = pathlib.Path(tsv_notes_path)
@@ -123,22 +123,22 @@ def _add_additional_info(**kwargs):
         with items_file.open() as fo:
             for line in fo.readlines():
                 item = json.loads(line)
-                holding = holdings_keys[item["holdingsRecordId"]]
-                former_id = holding["formerId"]
-                holding["counter"] = holding["counter"] + 1
-                hrid_prefix = former_id[:1] + "i" + former_id[2:]
-                item["hrid"] = f"{hrid_prefix}_{holding['counter']}"
-                if "barcode" in item:
-                    id_seed = item["barcode"]
-                else:
-                    id_seed = item["hrid"]
-                item["id"] = str(
-                    FolioUUID(
-                        folio_client.okapi_url,
-                        FOLIONamespaces.items,
-                        id_seed,
-                    )
-                )
+                # holding = holdings_keys[item["holdingsRecordId"]]
+                # former_id = holding["formerId"]
+                # holding["counter"] = holding["counter"] + 1
+                # hrid_prefix = former_id[:1] + "i" + former_id[2:]
+                # item["hrid"] = f"{hrid_prefix}_{holding['counter']}"
+                # if "barcode" in item:
+                #     id_seed = item["barcode"]
+                # else:
+                #     id_seed = item["hrid"]
+                # item["id"] = str(
+                #     FolioUUID(
+                #         folio_client.okapi_url,
+                #         FOLIONamespaces.items,
+                #         id_seed,
+                #     )
+                # )
                 # To handle optimistic locking
                 item["_version"] = 1
                 if tsv_notes_path is not None:

--- a/plugins/tests/helpers/test_folio_ids.py
+++ b/plugins/tests/helpers/test_folio_ids.py
@@ -1,0 +1,116 @@
+import json
+
+from plugins.folio.helpers.folio_ids import (
+    generate_holdings_identifiers,
+    generate_item_identifiers,
+)
+
+from plugins.tests.test_holdings import holdings as mock_holding_records
+
+from plugins.tests.mocks import mock_dag_run, mock_file_system, mock_okapi_variable  # noqa
+
+
+def test_generate_holdings_identifiers(
+    mock_file_system, mock_dag_run, mock_okapi_variable  # noqa
+):
+    airflow = mock_file_system[0]
+    results_dir = mock_file_system[3]
+
+    instance_filepath = results_dir / "folio_instances_bibs-transformer.json"
+
+    with instance_filepath.open("w+") as fo:
+        for instance in [
+            {"id": "xyzabc-def-ha", "hrid": "a123345"},
+            {"id": "d97eeaae-9087-5b38-a78b-e789d0ab67f0", "hrid": "a700000"},
+        ]:
+            fo.write(f"{json.dumps(instance)}\n")
+
+    holdings_filepath = results_dir / "folio_holdings_tsv-transformer.json"
+    with holdings_filepath.open("w+") as fo:
+        for holding in mock_holding_records:
+            fo.write(f"{json.dumps(holding)}\n")
+
+    mhlds_holdings_filepath = results_dir / "folio_holdings_mhld-transformer.json"
+    with mhlds_holdings_filepath.open("w+") as fo:
+        for holding in [{"instanceId": "d97eeaae-9087-5b38-a78b-e789d0ab67f0"}]:
+            fo.write(f"{json.dumps(holding)}\n")
+
+    electronic_holdings_filepath = (
+        results_dir / "folio_holdings_electronic-transformer.json"
+    )
+    with electronic_holdings_filepath.open("w+") as fo:
+        for holding in [{"instanceId": "xyzabc-def-ha"}]:
+            fo.write(f"{json.dumps(holding)}\n")
+
+    generate_holdings_identifiers(airflow=airflow, dag_run=mock_dag_run)
+
+    with holdings_filepath.open() as fo:
+        modified_holdings = [json.loads(line) for line in fo.readlines()]
+
+    assert modified_holdings[0]["hrid"] == "ah123345_1"
+    assert modified_holdings[0]["id"] == "03e6d8da-9c1e-58d1-8459-4f657200a5df"
+
+    assert modified_holdings[1]["hrid"] == "ah123345_2"
+
+    with mhlds_holdings_filepath.open() as fo:
+        mhlds_modified_holdings = [json.loads(line) for line in fo.readlines()]
+
+    assert mhlds_modified_holdings[0]["hrid"] == "ah700000_1"
+
+    with electronic_holdings_filepath.open() as fo:
+        electronic_modified_holdings = [json.loads(line) for line in fo.readlines()]
+
+    assert electronic_modified_holdings[0]["hrid"] == "ah123345_3"
+
+
+def test_generate_item_identifiers(
+    mock_file_system, mock_dag_run, mock_okapi_variable  # noqa
+):
+
+    airflow = mock_file_system[0]
+    results_dir = mock_file_system[3]
+
+    mock_holdings_items_map = results_dir / "holdings-items-map.json"
+    with mock_holdings_items_map.open("w+") as fo:
+        fo.write(
+            json.dumps(
+                {
+                    "e9ff785b-97e1-5f00-8dd0-4fce8fef1da3": {
+                        "hrid": "ah650005_1",
+                        "items": [],
+                        "new": "1df5a25b-2b80-59a3-824a-1ab8f983cfaf",
+                    }
+                }
+            )
+        )
+
+    mock_items_filepath = results_dir / "folio_items_transformer.json"
+    with mock_items_filepath.open("w+") as fo:
+        for item in [
+            {
+                "holdingsRecordId": "e9ff785b-97e1-5f00-8dd0-4fce8fef1da3",
+                "barcode": "36105226756356",
+            },
+            {
+                "holdingsRecordId": "e9ff785b-97e1-5f00-8dd0-4fce8fef1da3",
+                "barcode": "36105021595322",
+            },
+        ]:
+            fo.write(f"{json.dumps(item)}\n")
+
+    generate_item_identifiers(airflow=airflow, dag_run=mock_dag_run)
+
+    with mock_items_filepath.open() as fo:
+        mock_modified_items = [json.loads(line) for line in fo.readlines()]
+
+    assert (
+        mock_modified_items[0]["holdingsRecordId"]
+        == "1df5a25b-2b80-59a3-824a-1ab8f983cfaf"
+    )
+    assert mock_modified_items[0]["hrid"] == "ai650005_1_1"
+
+    assert (
+        mock_modified_items[1]["holdingsRecordId"]
+        == "1df5a25b-2b80-59a3-824a-1ab8f983cfaf"
+    )
+    assert mock_modified_items[1]["hrid"] == "ai650005_1_2"

--- a/plugins/tests/helpers/test_tsv.py
+++ b/plugins/tests/helpers/test_tsv.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pydantic
 import pytest
 
-from plugins.folio.helpers.tsv import _merge_notes, transform_move_tsvs, update_items
+from plugins.folio.helpers.tsv import _merge_notes, transform_move_tsvs
 
 from plugins.tests.mocks import mock_file_system  # noqa
 from pytest_mock import MockerFixture  # noqa
@@ -206,41 +206,3 @@ def test_transform_move_tsvs_doesnt_exist(mock_file_system, mock_dag_run):  # no
             tsv_stem="sample",
             dag_run=mock_dag_run,
         )
-
-
-def test_update_items(mock_file_system, mock_dag_run):  # noqa
-    location_mapping = [
-        {
-            "HOMELOCATION": "STACKS",
-            "LIBRARY": "GREEN",
-            "folio_id": "e06f5d50-8a7b-4777-9f83-d3675695f568",
-        },
-        {
-            "HOMELOCATION": "DEV-HOLD",
-            "LIBRARY": "GREEN",
-            "folio_id": "e06f5d50-8a7b-4777-9f83-d3675695f568",
-        },
-    ]
-    items_tsv_mock = mock_file_system[2] / "source_data/items/ckeys_0001.tsv"
-
-    items_tsv_df = pd.DataFrame(
-        [{"CATKEY": "a12345", "HOMELOCATION": "STACKS", "LIBRARY": "GREEN"}]
-    )
-
-    items_tsv_df.to_csv(items_tsv_mock, sep="\t", index=False)
-
-    holdings = [
-        {
-            "formerIds": ["a12345"],
-            "permanentLocationId": "e06f5d50-8a7b-4777-9f83-d3675695f568",
-            "hrid": "ah12345_1",
-        }
-    ]
-
-    update_items(items_tsv_mock, holdings, location_mapping)
-
-    new_items_df = pd.read_csv(items_tsv_mock, sep="\t")
-
-    item_row = new_items_df.loc[new_items_df["CATKEY"] == "ah12345_1"]
-
-    assert item_row is not None

--- a/plugins/tests/test_items.py
+++ b/plugins/tests/test_items.py
@@ -120,7 +120,6 @@ def test_add_additional_info(mock_file_system, mock_dag_run, mock_item_note_type
     _add_additional_info(
         airflow=str(airflow_path),
         dag_run_id=mock_dag_run.run_id,
-        holdings_pattern="holdings_transformer-*.json",
         items_pattern="items_transformer-*.json",
         tsv_notes_path=items_notes_path,
         folio_client=folio_client,
@@ -129,8 +128,6 @@ def test_add_additional_info(mock_file_system, mock_dag_run, mock_item_note_type
     with items_path.open() as items_fo:
         new_items_recs = [json.loads(row) for row in items_fo.readlines()]
 
-    assert new_items_recs[0]["hrid"] == "ai23456_1_1"
-    assert new_items_recs[0]["id"] == "f644a96e-8bb0-5d99-897a-6b10589fb4da"
     assert new_items_recs[0]["_version"] == 1
     assert new_items_recs[0]["notes"][0]["staffOnly"] is False
     assert new_items_recs[0]["notes"][0]["note"] == "available for checkout"
@@ -143,7 +140,7 @@ def test_add_additional_info(mock_file_system, mock_dag_run, mock_item_note_type
         new_items_recs[0]["notes"][1]["itemNoteTypeId"]
         == "e9f6de86-e564-4095-a61a-38c9e0e6b2fc"
     )
-    assert new_items_recs[1]["hrid"] == "ai9704208_1_1"
+
     assert new_items_recs[1]["notes"][0]["staffOnly"]
     assert (
         new_items_recs[1]["notes"][0]["itemNoteTypeId"]
@@ -178,8 +175,8 @@ def test_add_additional_info_missing_barcode(
     with items_path.open() as items_fo:
         new_items_recs = [json.loads(row) for row in items_fo.readlines()]
 
-    assert new_items_recs[0]["hrid"] == "ai23456_1_1"
-    assert new_items_recs[0]["id"] == "682512e6-1052-5ef5-ae50-410393f524d8"
+    assert new_items_recs[0]["_version"] == 1
+
     assert "barcode" not in new_items_recs[0]
 
 


### PR DESCRIPTION
This PR uses a different approach from our current code for generating the HRIDs and UUIDs from the original Symphony catkey. Before we running the different holdings transformers (tsv, mhlds, electronic) while also trying to update the holdings_map with the correct UUID and HRIDs for the downstream item transformer. The `symphony_marc_import` DAG  now has the following new/changed task groups (`marc21-and-tsv-to-folio`, `mhlds-electronic-holdings`, and `update-hrids-identifiers`): 

![Screen Shot 2022-10-17 at 1 16 22 PM](https://user-images.githubusercontent.com/71847/196274701-28acf5cd-6b89-4511-99ac-c30fa1c2e1f1.png)

- **marc21-and-tsv-to-folio** this task group runs the [folio_migration_tools](https://github.com/sul-dlss/folio_migration_tools) workflow with the MARC21 file and standard tsv file with supporting notes. The output from these tasks are the slightly modified JSON records in the `folio_instances_bibs-transformer.json`, `folio_holdings_tsv-transformer.json`, and `folio_items_transformer.json` files. 
- **mhlds-electronic-holdings** task group runs the MHLDs MARC21 transformer and the tsv file generated from the MARC 856 fields and saves the resulting FOLIO holdings in the `folio_holdings_mhld-transformer.json` and `folio_holdings_electronic-transformer.json` files.
- **update-hrids-identifiers** task group takes the original `folio_instances_bibs-transformer.json` and  FOLIO holding files and based on the Instance HRID, updates the holdings records with the new HRID and UUID. Next, the items HRIDs and UUIDs are added/updated, and the SRS MHLDs records are updated based on the new holding's UUIDs and HRIDs