### PR TITLE
Corrects generation of UUIDs and HRID for Items

### DIFF
--- a/dags/srs_ingestion.py
+++ b/dags/srs_ingestion.py
@@ -80,20 +80,12 @@ def add_marc_to_srs():
 
         return posted_srs_files
 
-    @task
-    def cleanup(srs_filenames):
-        context = get_current_context()
-        params = context.get("params")
-        iteration_id = params.get("iteration_id")
-        logger.info(f"Removing SRS JSON {srs_filenames}")
-        remove_srs_json(srs_filenames=srs_filenames, iteration_id=iteration_id)
 
     @task
     def finish():
         logger.info("Finished migration")
 
-    srs_files = ingestion_marc()
-    cleanup(srs_files) >> finish()
+    ingestion_marc() >> finish()
 
 
 ingest_marc_to_srs = add_marc_to_srs()

--- a/dags/srs_ingestion.py
+++ b/dags/srs_ingestion.py
@@ -8,7 +8,7 @@ from airflow.models import Variable, DagRun
 
 from folio_migration_tools.library_configuration import LibraryConfiguration
 
-from plugins.folio.helpers.marc import post_marc_to_srs, remove_srs_json
+from plugins.folio.helpers.marc import post_marc_to_srs
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,6 @@ def add_marc_to_srs():
             posted_srs_files.append(srs_file)
 
         return posted_srs_files
-
 
     @task
     def finish():

--- a/plugins/folio/helpers/folio_ids.py
+++ b/plugins/folio/helpers/folio_ids.py
@@ -26,36 +26,51 @@ def _generate_instance_map(instance_path: pathlib.Path) -> dict:
 
 def _generate_barcode_call_number_map(tsv_path: pathlib.Path) -> dict:
     """
-    Generates a dict of item barcodes to holdings call numbers
+    Generates a dict of item barcodes to holdings perm
     """
     barcode_call_number_map = {}
     with tsv_path.open() as fo:
         dict_reader = DictReader(fo, delimiter="\t")
         for row in dict_reader:
-            barcode_call_number_map[row["BARCODE"]] = row["BASE_CALL_NUMBER"]
+            barcode_call_number_map[row["BARCODE"]] = row["BASE_CALL_NUMBER"].strip()
 
     return barcode_call_number_map
 
 
 def _lookup_holdings_uuid(
-    barcode_call_number_map: dict, holdings_map: dict, barcode: str
+    item_permanent_location_id: str, item_call_number: str, holdings_map: dict
 ) -> str:
     """
-    Does a lookup to retrieve the call numbers for an item's barcode
-    in order to extract the correct holdings uuid
+    Does a lookup to retrieve the permanentLocationId and associated call number
+    for an item's uuid in order to extract the correct holdings uuid. Uses call
+    number to distinguish between holdings that have the same
+    permanentLocationId
     """
-    # Creates a dict of call numbers to holdings uuid
-    call_number_holdings = {}
+    new_holdings_uuid = None
     for uuid, info in holdings_map.items():
-        call_number_holdings[info["call_number"]] = uuid
-    item_call_number = barcode_call_number_map[barcode]
-    return call_number_holdings[item_call_number]
+        if info["permanentLocationId"] == item_permanent_location_id:
+            if info["callNumber"] == item_call_number or info["callNumber"] is None:
+                new_holdings_uuid = uuid
+                break
+    if new_holdings_uuid is None:
+        logger.warn(
+            f"New holdings UUID not found for item with permanentLocationId of {item_permanent_location_id} and call number {item_call_number}"
+        )
+    return new_holdings_uuid
 
 
 def _update_holdings_map(mapping, hrid, uuid, holding) -> None:
     if len(mapping) < 1:
         return
-    info = {"hrid": hrid, "call_number": holding["callNumber"], "items": []}
+    call_number = holding.get("callNumber")
+    if isinstance(call_number, str):
+        call_number = call_number.strip()
+    info = {
+        "hrid": hrid,
+        "permanentLocationId": holding["permanentLocationId"],
+        "callNumber": call_number,
+        "items": [],
+    }
     if holding["id"] in mapping:
         mapping[holding["id"]][uuid] = info
     else:
@@ -156,12 +171,13 @@ def generate_item_identifiers(**kwargs) -> None:
         task_ids="bib-files-group", key="tsv-base"
     ).split("/")[-1]
 
-    items_lookup = _generate_barcode_call_number_map(
+    barcode_call_numbers = _generate_barcode_call_number_map(
         iteration_dir / f"source_data/items/{tsv_filename}"
     )
 
     items_path = results_dir / "folio_items_transformer.json"
 
+    items = []
     with items_path.open() as fo:
         items = [json.loads(line) for line in fo.readlines()]
 
@@ -172,14 +188,15 @@ def generate_item_identifiers(**kwargs) -> None:
     with items_path.open("w+") as fo:
         for i, item in enumerate(items):
             original_holding_id = item["holdingsRecordId"]
-            if len(holdings_map[original_holding_id]) == 1:
-                # Only one holding exists so use
-                holding_uuid = list(holdings_map[original_holding_id].keys())[0]
-            else:
-                # Retrieves the new Holding's UUID based on call number
-                holding_uuid = _lookup_holdings_uuid(
-                    items_lookup, holdings_map[original_holding_id], item["barcode"]
-                )
+            call_number_from_holdings = barcode_call_numbers.get(item.get("barcode"))
+            holding_uuid = _lookup_holdings_uuid(
+                item["permanentLocationId"],
+                call_number_from_holdings,
+                holdings_map[original_holding_id],
+            )
+            if holding_uuid is None:
+                logger.error(f"Unable to retrieve generated holdings UUID for {item['id']}")
+                continue
             current_holding = holdings_map[original_holding_id][holding_uuid]
             holdings_hrid = current_holding["hrid"]
             current_count = len(current_holding["items"])
@@ -192,5 +209,8 @@ def generate_item_identifiers(**kwargs) -> None:
             if not i % 1_000 and i > 0:
                 logger.info(f"Generated uuids and hrids for {i:,} items")
             fo.write(f"{json.dumps(item)}\n")
+
+    with (results_dir / "holdings-items-map.json").open("w+") as fo:
+        json.dump(holdings_map, fo)
 
     logger.info(f"Finished updating identifiers for {len(items):,} items")

--- a/plugins/folio/helpers/marc.py
+++ b/plugins/folio/helpers/marc.py
@@ -6,8 +6,6 @@ import shutil
 import pandas as pd
 import pymarc
 
-from pathlib import Path
-
 from folio_migration_tools.migration_tasks.batch_poster import BatchPoster
 
 
@@ -208,16 +206,3 @@ def process(*args, **kwargs):
             marc_writer.write(record)
             if not i % 10_000 and i > 0:
                 logger.info(f"Writing record {i}")
-
-
-def remove_srs_json(*args, **kwargs):
-    airflow = kwargs.get("airflow", "/opt/airflow")
-    srs_filenames = kwargs["srs_filenames"]
-    iteration_id = kwargs["iteration_id"]
-
-    srs_filedir = Path(airflow) / f"migration/iterations/{iteration_id}/results/"
-
-    for srs_file in srs_filenames:
-        srs_filepath = srs_filedir / srs_file
-        srs_filepath.unlink()
-        logger.info(f"Removed {srs_filepath}")

--- a/plugins/folio/helpers/tsv.py
+++ b/plugins/folio/helpers/tsv.py
@@ -99,7 +99,7 @@ def _processes_tsv(**kwargs):
         tsv_notes_name = ".".join(tsv_notes_name_parts)
 
         new_tsv_notes_path = pathlib.Path(
-            f"{airflow}/migration/data_preparation/{tsv_notes_name}"
+            f"{airflow}/migration/iterations/{dag_run_id}/source_data/items/{tsv_notes_name}"
         )
 
         tsv_notes_df.to_csv(new_tsv_notes_path, sep="\t", index=False)

--- a/plugins/folio/items.py
+++ b/plugins/folio/items.py
@@ -79,8 +79,7 @@ def _retrieve_item_notes_ids(folio_client) -> dict:
 
 
 def _add_additional_info(**kwargs):
-    """Adds an HRID based on Holdings formerIds and generates notes from
-    tsv files"""
+    """Generates notes from tsv files"""
     airflow: str = kwargs["airflow"]
     items_pattern: str = kwargs["items_pattern"]
     tsv_notes_path = kwargs["tsv_notes_path"]
@@ -112,9 +111,6 @@ def _add_additional_info(**kwargs):
         with open(items_file, "w+") as write_output:
             for item in items:
                 write_output.write(f"{json.dumps(item)}\n")
-
-    if tsv_notes_path is not None:
-        tsv_notes_path.unlink()
 
 
 def post_folio_items_records(**kwargs):

--- a/plugins/tests/helpers/test_folio_ids.py
+++ b/plugins/tests/helpers/test_folio_ids.py
@@ -86,7 +86,7 @@ def test_generate_item_identifiers(
                         "1df5a25b-2b80-59a3-824a-1ab8f983cfaf": {
                             "hrid": "ah650005_1",
                             "items": [],
-                            "call_number": "B3212 .Z7 A12",
+                            "permanentLocationId": "b26d05ad-80a3-460d-8b49-00ddb72593bc",
                         },
                     }
                 }
@@ -97,20 +97,17 @@ def test_generate_item_identifiers(
     with mock_items_filepath.open("w+") as fo:
         for item in [
             {
+                "id": "f9262e00-1501-5f6e-a9ee-cc14a8f641ec",
                 "holdingsRecordId": "e9ff785b-97e1-5f00-8dd0-4fce8fef1da3",
-                "barcode": "36105226756356",
+                "permanentLocationId": "b26d05ad-80a3-460d-8b49-00ddb72593bc",
             },
             {
+                "id": "1cde0ebe-2cdd-5c9c-90f3-d4ce0dc63587",
                 "holdingsRecordId": "e9ff785b-97e1-5f00-8dd0-4fce8fef1da3",
-                "barcode": "36105021595322",
+                "permanentLocationId": "b26d05ad-80a3-460d-8b49-00ddb72593bc",
             },
         ]:
             fo.write(f"{json.dumps(item)}\n")
-
-    mock_items_tsv_filepath = results_dir.parent / "source_data/items/ckey_0001.tsv"
-
-    with mock_items_tsv_filepath.open("w+") as fo:
-        fo.write("BARCODE\tBASE_CALL_NUMBER\n36105226756356\tB3212 .Z7 A12")
 
     generate_item_identifiers(
         airflow=airflow, dag_run=mock_dag_run, task_instance=MockTaskInstance()
@@ -133,21 +130,21 @@ def test_generate_item_identifiers(
 
 
 def test_lookup_holdings_uuid():
-    barcode_callnumber_map = {
-        "36105080793552": "DA958.O3 A3",
-        "36105080793560": "DA965 .C6 O18",
-        "36105070345157": "DA958.O5 A3",
+    item_uuid_location_map = {
+        "ad9fce9d-e538-5916-ba74-4bfbce9af81a": "0edeef57-074a-4f07-aee2-9f09d55e65c3",
+        "994c8f9a-d622-566e-9a03-42703b6083d5": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "36778651d-c393-5718-943e-dea3ebd73706": "2b94c631-fca9-4892-a730-03ee529ffe27",
     }
 
     holdings_map = {
-        "c4287ea6-324d-5de6-973c-50d8a773429d": {
+        "527b783d-6624-56fe-be28-895f2c69cf1f": {
             "hrid": "ah660592_1",
-            "call_number": "DA965 .C6 O18",
+            "permanentLocationId": "0edeef57-074a-4f07-aee2-9f09d55e65c3",
             "items": [],
         }
     }
 
     holdings_uuid = _lookup_holdings_uuid(
-        barcode_callnumber_map, holdings_map, "36105080793560"
+        item_uuid_location_map, holdings_map, "ad9fce9d-e538-5916-ba74-4bfbce9af81a"
     )
-    assert holdings_uuid == "c4287ea6-324d-5de6-973c-50d8a773429d"
+    assert holdings_uuid == "527b783d-6624-56fe-be28-895f2c69cf1f"

--- a/plugins/tests/helpers/test_marc.py
+++ b/plugins/tests/helpers/test_marc.py
@@ -13,7 +13,6 @@ from plugins.folio.helpers.marc import (
     move_marc_files,
     _move_001_to_035,
     post_marc_to_srs,
-    remove_srs_json,
 )
 
 from plugins.folio.helpers.marc import process as process_marc
@@ -345,16 +344,3 @@ def test_post_marc_to_srs(
 
 def test_process_marc():
     assert process_marc
-
-
-def test_remove_srs_json(srs_file, mock_file_system, mock_dag_run):  # noqa
-    assert srs_file.exists() is True
-
-    remove_srs_json(
-        airflow=mock_file_system[0],
-        dag_run=mock_dag_run,
-        srs_filenames=["test-srs.json"],
-        iteration_id=mock_dag_run.run_id,
-    )
-
-    assert srs_file.exists() is False

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -90,13 +90,13 @@ holdings = [
         "id": "abcdedf123345",
         "instanceId": "xyzabc-def-ha",
         "formerIds": ["a123345"],
-        "callNumber": "A1234",
+        "permanentLocationId": "0edeef57-074a-4f07-aee2-9f09d55e65c3"
     },
     {
         "id": "exyqdf123345",
         "instanceId": "xyzabc-def-ha",
         "formerIds": ["a123345"],
-        "callNumber": "B1234",
+        "permanentLocationId": "04c54d2f-0e14-42ab-97a6-27fc7f4d061"
     },
 ]
 


### PR DESCRIPTION
Now uses the combination of Item's `permanentLocationId` and call number from the tsv to retrieve the correct Holdings UUID.

To help troubleshoot individual DAG runs, removed deletion of srs files in the `add_marc_to_srs` DAG and moves the tsv notes to the results directory.