### PR TITLE
Adds missing folio_client to Task in DAG

### DIFF
--- a/dags/audit_remediate.py
+++ b/dags/audit_remediate.py
@@ -64,6 +64,7 @@ with DAG(
         python_callable=add_missing_records,
         op_kwargs={
             "iteration_id": "{{ ti.xcom_pull(task_ids='start-check-add') }}",
+            "folio_client": folio_client
         }
     )
 


### PR DESCRIPTION
Another small fix to get `audit_fix_record_loads` DAG working.