### PR TITLE
FOLIO Reports now use Iterations Directory for Reports and Downloads

### DIFF
--- a/plugins/folio/main.py
+++ b/plugins/folio/main.py
@@ -19,22 +19,78 @@ bp = Blueprint(
 )
 
 
-def _extract_dag_run_id(file_path: pathlib.Path) -> str:
-    """Extracts DAG ID run from file name, varies depending on file type"""
-    dag_run_id = None
-    path_parts = file_path.name.split("_")
-    if path_parts[0].startswith("transformation"):
-        dag_run_id = "_".join(path_parts[3:6])
-    if path_parts[0:2] == ["data", "issues"]:
-        dag_run_id = "_".join(path_parts[4:7])
-    if (
-        path_parts[0:3] == ["failed", "bib", "records"]
-        and file_path.suffix == ".mrc"  # noqa
-    ):  # noqa
-        dag_run_id = "_".join(path_parts[3:6])
-        # remove file extension
-        dag_run_id = dag_run_id.replace(".mrc", "")
-    return dag_run_id
+def _get_catkey_range(path):
+    start, end = None, None
+
+    try:
+        marc_path = next((path / "source_data/instances").glob("*.mrc"))
+    except StopIteration:
+        # File doesn't exist
+        return start, end
+
+    name_parts = marc_path.name.split("_")
+    if len(name_parts) < 3:  # Non-standard name
+        return start, end
+
+    start_part, end_part = name_parts[1], name_parts[2].split(".")[0]
+    try:
+        start = f"{int(start_part):,}"
+    except ValueError:
+        pass
+    try:
+        end = f"{int(end_part):,}"
+    except ValueError:
+        pass
+    return start, end
+
+
+def _get_folio_records(path):
+    records = {
+        "instances": [],
+        "holdings": [],
+        "items": [],
+        "srs": []
+    }
+    for result_path in (path / "results").glob("folio_*"):
+        result_name = result_path.name
+        match result_name:
+            case result_name if result_name.startswith("folio_instances"):
+                records["instances"].append(result_name)
+
+            case result_name if result_name.startswith("folio_holdings"):
+                records["holdings"].append(result_name)
+
+            case result_name if result_name.startswith("folio_items"):
+                records["items"].append(result_name)
+
+            case result_name if result_name.startswith("folio_srs"):
+                records["srs"].append(result_name)
+
+    return records
+
+
+def _get_reports_data_issues(path):
+    reports, data_issues = [], []
+    for report_path in (path / "reports").iterdir():
+        report_name = report_path.name
+        if report_name.startswith("data_issues"):
+            data_issues.append(report_name)
+        if report_name.startswith("report"):
+            reports.append(report_name)
+    return reports, data_issues
+
+
+def _get_source_data(path):
+    sources = {"instances": [], "holdings": [], "items": []}
+    for instance_mrc in (path / "source_data/instances").glob("*.mrc"):
+        sources["instances"].append(instance_mrc.name)
+    for mhlds_mrc in (path / "source_data/holdings").glob("*.mrc"):
+        sources["holdings"].append(mhlds_mrc.name)
+    for file_path in (path / "source_data/items").glob("*.tsv"):
+        file_name = file_path.name
+        sources["holdings"].append(file_name)
+        sources["items"].append(file_name)
+    return sources
 
 
 class FOLIO(AppBuilderBaseView):
@@ -43,57 +99,57 @@ class FOLIO(AppBuilderBaseView):
     @expose("/")
     def folio_view(self):
         content = {}
-        for path in pathlib.Path(f"{MIGRATION_HOME}/reports").iterdir():
-            dag_run_id = _extract_dag_run_id(path)
+        for path in pathlib.Path(f"{MIGRATION_HOME}/iterations").glob("manual__*"):
+            dag_run_id = path.name
             if dag_run_id not in content:
-                content[dag_run_id] = {
-                    "reports": [],
-                    "data_issues": [],
-                    "marc_errors": [],
-                }
-            if path.name.startswith("transformation"):
-                content[dag_run_id]["reports"].append(path.name)
-            if path.name.startswith("data_issues"):
-                content[dag_run_id]["data_issues"].append(path.name)
+                content[dag_run_id] = {}
+            reports, data_issues = _get_reports_data_issues(path)
+            content[dag_run_id]["reports"] = reports
+            content[dag_run_id]["data_issues"] = data_issues
+            content[dag_run_id]["records"] = _get_folio_records(path)
+            content[dag_run_id]["sources"] = _get_source_data(path)
+            (
+                content[dag_run_id]["ckey_start"],
+                content[dag_run_id]["ckey_end"],
+            ) = _get_catkey_range(path)
 
-        for path in pathlib.Path(f"{MIGRATION_HOME}/results").glob(
-            "failed_*.mrc"
-        ):  # noqa
-            dag_run_id = _extract_dag_run_id(path)
-            if dag_run_id is None or dag_run_id not in content:
-                continue
-            content[dag_run_id]["marc_errors"].append(
-                {"file": path.name, "size": path.stat().st_size}
-            )
         return self.render_template("folio/index.html", content=content)
 
-    @expose("/reports/<report_name>")
-    def folio_report(self, report_name):
-        markdown_path = pathlib.Path(f"{MIGRATION_HOME}/reports/{report_name}")
+    @expose("/reports/<iteration_id>/<report_name>")
+    def folio_report(self, iteration_id, report_name):
+        markdown_path = pathlib.Path(
+            f"{MIGRATION_HOME}/iterations/{iteration_id}/reports/{report_name}"
+        )
         raw_text = markdown_path.read_text()
         # Sets attribute to convert markdown in embedded HTML tags
         final_mrkdown = raw_text.replace("<details>", """<details markdown="block">""")
         rendered = markdown.markdown(final_mrkdown, extensions=["tables", "md_in_html"])
         return self.render_template("folio/report.html", content=rendered)
 
-    @expose("/data_issues/<log_name>")
-    def folio_data_issues(self, log_name):
-        dag_run_id = _extract_dag_run_id(pathlib.Path(log_name))
+    @expose("/data_issues/<iteration_id>/<log_name>")
+    def folio_data_issues(self, iteration_id, log_name):
         data_issues_df = pd.read_csv(
-            f"{MIGRATION_HOME}/reports/{log_name}",
+            f"{MIGRATION_HOME}/iterations/{iteration_id}/reports/{log_name}",
             sep="\t",
             names=["Type", "Catkey", "Error", "Value"],
         )
 
         return self.render_template(
             "folio/data-issues.html",
-            content={"df": data_issues_df, "dag_run_id": dag_run_id},
+            content={"df": data_issues_df, "dag_run_id": iteration_id},
         )
 
-    @expose("/marc/<filename>")
-    def folio_marc_error(self, filename):
+    @expose("/records/<iteration_id>/<filename>")
+    def folio_json_records(self, iteration_id, filename):
         file_bytes = pathlib.Path(
-            f"{MIGRATION_HOME}/results/{filename}"
+            f"{MIGRATION_HOME}/iterations/{iteration_id}/results/{filename}"
+        ).read_bytes()  # noqa
+        return file_bytes
+
+    @expose("/sources/<iteration_id>/<folio_type>/<filename>")
+    def source_record(self, iteration_id, folio_type, filename):
+        file_bytes = pathlib.Path(
+            f"{MIGRATION_HOME}/iterations/{iteration_id}/source_data/{folio_type}/{filename}"
         ).read_bytes()  # noqa
         return file_bytes
 

--- a/plugins/folio/templates/folio/index.html
+++ b/plugins/folio/templates/folio/index.html
@@ -6,34 +6,88 @@
     <table class="table table-striped">
         <tr>
             <th>DAG Run ID</th>
+            <th>Sources</th>
             <th>Transformation Reports</th>
             <th>Data Issues</th>
-            <th>Error MARC21 file</th>
+            <th>FOLIO Records</th>
         </tr>
     {% for dag_run_id, info in content.items() %}
     <tr>
-        <td><a href="/graph?dag_id=symphony_marc_import&run_id={{ dag_run_id }}">{{ dag_run_id }}</a></td>
+        <td>
+            <p>
+                <a href="/graph?dag_id=symphony_marc_import&run_id={{ dag_run_id }}">{{ dag_run_id }}</a>
+            </p>
+            <p>
+                <strong>CKEY Range</strong>: {{ info.get("ckey_start", "None") }} to 
+                {{ info.get("ckey_end", "None") }}
+            </p>
+        </td>
+        <td>
+            <ul>
+                <li>
+                    <strong>Instances</strong>
+                    {% for row in info["sources"]["instances"] %}
+                    <a href="{{ url_for('FOLIO.source_record', iteration_id=dag_run_id, folio_type='instances', filename=row) }}" download>{{ row }}</a>
+                    {% endfor %}
+                </li>
+                <li>
+                    <strong>Holdings</strong>
+                    {% for row in info["sources"]["holdings"] %}
+                    {% if "mhlds" in row %}
+                    <a href="{{ url_for('FOLIO.source_record', iteration_id=dag_run_id, folio_type='holdings', filename=row) }}" download>{{ row }}</a>
+                    {% else %}
+                    <a href="{{ url_for('FOLIO.source_record', iteration_id=dag_run_id, folio_type='items', filename=row) }}" download>{{ row }}</a>
+                    {% endif %}
+                    {% endfor %}    
+                </li>
+                <li>
+                    <strong>Items</strong>
+                    {% for row in info["sources"]["items"] %}
+                    <a href="{{ url_for('FOLIO.source_record', iteration_id=dag_run_id, folio_type='items', filename=row) }}" download>{{ row }}</a>
+                    {% endfor %} 
+                </li>
+            </ul>
+        </td>
         <td>
             <ul>
             {% for report in info.get('reports') %}
-            <li><a href="{{ url_for('FOLIO.folio_report', report_name=report) }}">{{ report }}</a></li>
+            <li><a href="{{ url_for('FOLIO.folio_report', iteration_id=dag_run_id, report_name=report) }}">{{ report }}</a></li>
             {% endfor %}
             </ul>
         </td>
         <td>
             <ul>
             {% for issues_log in info.get('data_issues') %}
-            <li><a href="{{ url_for('FOLIO.folio_data_issues', log_name=issues_log) }}">{{ issues_log }}</a></li>
+            <li><a href="{{ url_for('FOLIO.folio_data_issues', iteration_id=dag_run_id, log_name=issues_log) }}">{{ issues_log }}</a></li>
             {% endfor %}
             </ul>
         </td>
         <td>
             <ul>
-            {% for row in info.get('marc_errors') %}
-            <li><a href="{{ url_for('FOLIO.folio_marc_error', filename=row.file) }}">{{ row.file }}</a>
-             Size: {{ row.size }} kb
-            </li>
-            {% endfor %}
+                <li>
+                    <strong>Instances</strong>
+                    {% for row in info["records"]["instances"] %}
+                        <a href="{{ url_for('FOLIO.folio_json_records', iteration_id=dag_run_id, filename=row) }}" download>{{ row }}</a>
+                    {% endfor %}
+                </li>
+                <li>
+                    <strong>Holdings</strong>
+                    {% for row in info["records"]["holdings"] %}
+                    <a href="{{ url_for('FOLIO.folio_json_records', iteration_id=dag_run_id, filename=row) }}" download>{{ row }}</a>
+                    {% endfor %}    
+                </li>
+                <li>
+                    <strong>Items</strong>
+                    {% for row in info["records"]["items"] %}
+                    <a href="{{ url_for('FOLIO.folio_json_records', iteration_id=dag_run_id, filename=row) }}" download>{{ row }}</a>
+                    {% endfor %} 
+                </li>
+                <li>
+                    <strong>Source Record Storage</strong>
+                    {% for row in info["records"]["srs"] %}
+                    <a href="{{ url_for('FOLIO.folio_json_records', iteration_id=dag_run_id, filename=row) }}" download>{{ row }}</a>
+                    {% endfor %}
+                </li>
             </ul>
         </td>
     </tr>

--- a/plugins/tests/test_main.py
+++ b/plugins/tests/test_main.py
@@ -1,36 +1,112 @@
 import pytest  # noqa
 
-from plugins.folio.main import _extract_dag_run_id
+from plugins.tests.mocks import mock_file_system, mock_dag_run  # noqa
+
+from plugins.folio.main import (
+    _get_catkey_range,
+    _get_folio_records,
+    _get_reports_data_issues,
+    _get_source_data,
+)
 
 
-def test_extract_dag_run_id_reports(tmp_path):
-    report = (
-        tmp_path
-        / "transformation_report_instances_manual__2022-02-14T23:27:04.675755+00:00_bibs.md"  # noqa
+def test_get_catkey_range_existing_mrc(mock_file_system):  # noqa
+
+    iteration_dir = mock_file_system[2]
+
+    marc_file = iteration_dir / "source_data/instances/ckeys_00350000_00399999.mrc"
+    marc_file.write_text("marc string")
+
+    start, end = _get_catkey_range(iteration_dir)
+
+    assert start == "350,000"
+    assert end == "399,999"
+
+
+def test_get_catkey_range_nonexistant_mrc(mock_file_system):  # noqa
+
+    iteration_dir = mock_file_system[2]
+
+    start, end = _get_catkey_range(iteration_dir)
+
+    assert start is None
+    assert end is None
+
+
+def test_get_catkey_range_nonstandard_name(mock_file_system):  # noqa
+
+    iteration_dir = mock_file_system[2]
+
+    marc_file = iteration_dir / "source_data/instances/ON-ORDER.law.01.mrc"
+    marc_file.write_text("marc_string")
+
+    start, end = _get_catkey_range(iteration_dir)
+
+    assert start is None
+    assert end is None
+
+
+def test_get_folio_records(mock_file_system):  # noqa
+
+    iteration_dir = mock_file_system[2]
+
+    (iteration_dir / "results/folio_instances_bibs-transformer.json").write_text(
+        """{ id="1234" }"""
     )
-    dag_id = _extract_dag_run_id(report)
-    assert dag_id == "manual__2022-02-14T23:27:04.675755+00:00"
 
-
-def test_extract_dag_run_id_mrc(tmp_path):
-    error_marc = (
-        tmp_path
-        / "failed_bib_records_manual__2022-02-14T23:36:51.056707+00:00.mrc"  # noqa
+    (iteration_dir / "results/folio_holdings_tsv-transformer.json").write_text(
+        """{ id="45567" }"""
     )
-    dag_id = _extract_dag_run_id(error_marc)
-    assert dag_id == "manual__2022-02-14T23:36:51.056707+00:00"
 
-
-def test_extract_run_id_data_issues(tmp_path):
-    data_issues = (
-        tmp_path
-        / "data_issues_log_instances_scheduled__2022-03-09T22:30:49.801082+00:00_bibs-transformer.tsv"  # noqa
+    (iteration_dir / "results/folio_holdings_electronic-transformer.json").write_text(
+        """{ id="49900" }"""
     )
-    dag_id = _extract_dag_run_id(data_issues)
-    assert dag_id == "scheduled__2022-03-09T22:30:49.801082+00:00"
+
+    (iteration_dir / "results/folio_items_transformer.json").write_text(
+        """{ id="49900" }"""
+    )
+
+    records = _get_folio_records(iteration_dir)
+
+    assert len(records["instances"]) == 1
+    assert len(records["holdings"]) == 2
+    assert records["items"][0].startswith("folio_items_transformer.json")
 
 
-def test_extract_dag_run_id_unknown(tmp_path):
-    unknown_file = tmp_path / "sample.txt"
-    dag_id = _extract_dag_run_id(unknown_file)
-    assert dag_id is None
+def test_get_reports_data_issues(mock_file_system):  # noqa
+
+    iteration_dir = mock_file_system[2]
+
+    (iteration_dir / "reports/report_bibs-transformer.md").write_text("# A Report")
+
+    (iteration_dir / "reports/data_issues_log_tsv-transformer.tsv").write_text(
+        """Type\tCatkey\tError\tValue\nRECORD FAILED\ta350008\tCould not map\tSAL3 Stacks missing"""
+    )
+
+    reports, data_issues = _get_reports_data_issues(iteration_dir)
+
+    assert reports[0].startswith("report_bibs-transformer.md")
+    assert data_issues[0].startswith("data_issues_log_tsv-transformer.tsv")
+
+
+def test_get_source_data(mock_file_system):  # noqa
+
+    iteration_dir = mock_file_system[2]
+
+    (iteration_dir / "source_data/instances/ckey_003000_005000.mrc").write_text(
+        "marc record"
+    )
+
+    (iteration_dir / "source_data/holdings/ckey_003000_005000.mhlds.mrc").write_text(
+        "mhlds record"
+    )
+
+    (iteration_dir / "source_data/items/ckey_003_005.tsv").write_text(
+        """CATKEY\tTEMPORARY_LOCATION\tLIBRARY\tBARCODE\na3456\tSTACKS\tGREEN\t3456789"""
+    )
+
+    sources = _get_source_data(iteration_dir)
+
+    assert sources["instances"] == ["ckey_003000_005000.mrc"]
+    assert len(sources["holdings"]) == 2
+    assert len(sources["items"]) == 1


### PR DESCRIPTION
Fixes #174 

This PR also allows user to download the original source MARC record and TSVs used to generate the FOLIO records. Also provides downloads for the new FOLIO Inventory and SRS records.  
![Screen Shot 2022-11-11 at 2 48 43 PM](https://user-images.githubusercontent.com/71847/201441223-6f66d644-0fba-4a65-8058-f16b0ab573e8.png)

