### PR TITLE
Fixes errors due to processing and removes forked dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,5 @@ COPY requirements.txt .
 
 RUN pip install -r requirements.txt
 
-RUN git clone https://github.com/sul-dlss/folio_migration_tools.git --depth=2
-RUN pip install /opt/airflow/folio_migration_tools
-RUN pip install -r /opt/airflow/folio_migration_tools/requirements.txt
 RUN pip install apache-airflow
 RUN pip install apache-airflow-providers-postgres

--- a/dags/preceding_succeding_titles.py
+++ b/dags/preceding_succeding_titles.py
@@ -47,6 +47,7 @@ def post_to_folio(*args, **kwargs):
                 records=obj,
                 endpoint="/preceding-succeeding-titles",
                 payload_key=None,
+                iteration_id=iteration_id,
                 **kwargs,
             )
 

--- a/plugins/folio/audit.py
+++ b/plugins/folio/audit.py
@@ -75,6 +75,8 @@ def _audit_holdings_records(
         (results_path / "folio_holdings_mhld-transformer.json"),
     ]
     for holdings_file in holdings_files:
+        if not holdings_file.exists():
+            continue
         logger.info(f"Starting auditing of {holdings_file.name}")
         with holdings_file.open() as fo:
             for line in fo.readlines():

--- a/plugins/tests/test_preceding_succeeding_titles.py
+++ b/plugins/tests/test_preceding_succeeding_titles.py
@@ -1,11 +1,9 @@
-from unittest.mock import MagicMock
 import requests
 import pytest
 
-
 from pytest_mock import MockerFixture
 from dags.preceding_succeding_titles import post_to_folio
-from plugins.folio import helpers
+
 from plugins.tests.mocks import (  # noqa
     MockTaskInstance,
     mock_file_system,
@@ -57,8 +55,6 @@ def test_preceding_succeeding_titles(
     airflow = mock_file_system[0]
     results_dir = mock_file_system[3]
 
-    helpers._save_error_record_ids = MagicMock(airflow=results_dir)
-
     # Create mock JSON file
     titles_filename = "preceding_succeeding_titles.json"
     titles_file = results_dir / titles_filename
@@ -68,7 +64,7 @@ def test_preceding_succeeding_titles(
 
     mock_task_instance = MockTaskInstance
     post_to_folio(
-        airflow=str(airflow),
+        airflow=airflow,
         dag_run=mock_dag_run,
         task_instance=mock_task_instance,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pydantic
 pymarc
 pytest
 pytest_mock
+folio_migration_tools


### PR DESCRIPTION
Fixes some slight errors that surfaced during the latest complete migration run. If missing `preceding_succeeding_titles.json`  file for DAG run and adds iteration_id for capturing error file.  PR also restores upstream `folio_migration_tools` with the recent [release](https://github.com/FOLIO-FSE/folio_migration_tools/releases/tag/1_6_3) that now generates files like `preceding_succeeding_titles.json` so as not to depend on logging.