### PR TITLE
Use item uuid generated from folio_migration_tools and migration mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ The `optimistic_locking_management` DAG requires a Postgres Airflow
 database being used by Okapi.
 
 ## Testing
-- Activate python virtual environment: `source /venv/bin/activate`
+- Activate python virtual environment: `source virtual-env/bin/activate`
 - Install the FOLIO-FSE tools: `pip install folioclient folio-uuid`
-- Install sul-dlss fork of folio_migration_tools: `pip install ${local_directory}/folio_migration_tools`
+- Install sul-dlss fork of folio_migration_tools: `pip install ${local_directory}/folio_migration_tools` (e.g. `pip install ../folio_migration_tools/`)
 - Install Airflow: `pip install apache-airflow apache-airflow-providers-postgres`
 
 Run the flake8 linter:

--- a/plugins/folio/helpers/folio_ids.py
+++ b/plugins/folio/helpers/folio_ids.py
@@ -179,7 +179,6 @@ def generate_item_identifiers(**kwargs) -> None:
     task_instance = kwargs["task_instance"]
     iteration_dir = pathlib.Path(airflow) / f"migration/iterations/{dag.run_id}/"
     results_dir = iteration_dir / "results"
-    okapi_url = Variable.get("OKAPI_URL")
 
     tsv_filename = task_instance.xcom_pull(
         task_ids="bib-files-group", key="tsv-base"
@@ -219,9 +218,7 @@ def generate_item_identifiers(**kwargs) -> None:
             item_hrid = f"{holdings_hrid[:1]}i{holdings_hrid[2:]}_{current_count + 1}"
             item["hrid"] = item_hrid
             item["holdingsRecordId"] = holding_uuid
-            item_uuid = str(FolioUUID(okapi_url, FOLIONamespaces.items, item_hrid))
-            item["id"] = item_uuid
-            current_holding["items"].append(item_uuid)
+            current_holding["items"].append(item["id"])
             if not i % 1_000 and i > 0:
                 logger.info(f"Generated uuids and hrids for {i:,} items")
             fo.write(f"{json.dumps(item)}\n")


### PR DESCRIPTION
Uses https://github.com/sul-dlss/folio_migration/pull/44 to allow the migration tools to create the unique item UUID by using a concatenation of the ckey+barcode. In the case of items with barcodes the combination will be unique. IN the case of on-order items without barcodess the ckey alone will always be unique because there are no duplicate ckeys in the generating tsv files.