### PR TITLE
Simplify HRID generation for Holdings and Items

### DIFF
--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 import logging
 
+
 from textwrap import dedent
 from typing_extensions import TypeAlias  # noqa
 
@@ -24,7 +25,7 @@ from plugins.folio.helpers.marc import (
     move_marc_files,
 )
 
-from plugins.folio.helpers.tsv import transform_move_tsvs
+from plugins.folio.helpers.tsv import transform_move_tsvs, unwanted_item_cat1
 
 from plugins.folio.helpers.folio_ids import (
     generate_holdings_identifiers,
@@ -118,6 +119,8 @@ with DAG(
                 "column_transforms": [
                     # Adds a prefix to match bib 001
                     ("CATKEY", lambda x: x if x.startswith("a") else f"a{x}"),
+                    # Filters out unwanted values we don't want mapped to statcodes
+                    ("ITEM_CAT1", lambda x: None if x in unwanted_item_cat1 else x),
                     # Strips out spaces from barcode
                     ("BARCODE", lambda x: x.strip() if isinstance(x, str) else x),
                 ],

--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -215,9 +215,10 @@ with DAG(
         finish_additional_holdings = DummyOperator(task_id="finish-additional-holdings")
 
         (
-            start_additional_holdings
-            >> [convert_mhld_to_folio_holdings, generate_electronic_holdings, generate_boundwith_holdings]
-            >> finish_additional_holdings
+            start_additional_holdings >> 
+            generate_electronic_holdings >> 
+            [ convert_mhld_to_folio_holdings, generate_boundwith_holdings] >>
+            finish_additional_holdings
         )
 
     with TaskGroup(group_id="update-hrids-identifiers") as update_hrids:

--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -215,10 +215,10 @@ with DAG(
         finish_additional_holdings = DummyOperator(task_id="finish-additional-holdings")
 
         (
-            start_additional_holdings >> 
-            generate_electronic_holdings >> 
-            [ convert_mhld_to_folio_holdings, generate_boundwith_holdings] >>
-            finish_additional_holdings
+            start_additional_holdings
+            >> generate_electronic_holdings
+            >> [convert_mhld_to_folio_holdings, generate_boundwith_holdings]
+            >> finish_additional_holdings
         )
 
     with TaskGroup(group_id="update-hrids-identifiers") as update_hrids:
@@ -231,7 +231,6 @@ with DAG(
         merge_all_holdings = PythonOperator(
             task_id="merge-all-holdings",
             python_callable=merge_update_holdings,
-
         )
 
         update_items = PythonOperator(
@@ -372,9 +371,7 @@ with DAG(
     remediate_errors = TriggerDagRunOperator(
         task_id="audit_fix_record_loads",
         trigger_dag_id="audit_fix_record_loads",
-        conf={
-            "iteration_id": "{{ dag_run.run_id }}"
-        }
+        conf={"iteration_id": "{{ dag_run.run_id }}"},
     )
 
     finish_loading = DummyOperator(

--- a/dags/srs_ingestion.py
+++ b/dags/srs_ingestion.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from airflow.decorators import dag, task
 from airflow.operators.python import get_current_context
-from airflow.models import Variable, DagRun
+from airflow.models import Variable
 
 from folio_migration_tools.library_configuration import LibraryConfiguration
 
@@ -38,18 +38,7 @@ def add_marc_to_srs():
         srs_filenames = params.get("srs_filenames")
         iteration_id = params.get("iteration_id")
 
-        """
-        FOLIO needs to have a number of sul_admin_{N} superusers equal or greater than
-        the maximum number of possible 'add_marc_to_srs' dags that can run.
-        """
-        running_dags = DagRun.active_runs_of_dags(only_running=True).get(
-            "add_marc_to_srs"
-        )
-        okapi_admin = 0 if running_dags is None else f"sul_admin_{running_dags}"
-
-        okapi_username = okapi_admin or params.get(
-            "okapi_username", Variable.get("FOLIO_USER")
-        )
+        okapi_username = Variable.get("FOLIO_USER")
 
         okapi_password = context.get("okapi_password", Variable.get("FOLIO_PASSWORD"))
         logger.info(f"Okapi username: {okapi_username}")

--- a/plugins/folio/helpers/folio_ids.py
+++ b/plugins/folio/helpers/folio_ids.py
@@ -77,6 +77,8 @@ def generate_holdings_identifiers(**kwargs) -> None:
                         logger.info(
                             f"Generated holdings hrids for {i:,} in {holdings_name} "
                         )
+            holdings_path.unlink()
+
     with (results_dir / "instance-holdings-items.json").open("w+") as fo:
         json.dump(instance_map, fo, indent=2)
 

--- a/plugins/folio/helpers/folio_ids.py
+++ b/plugins/folio/helpers/folio_ids.py
@@ -39,6 +39,8 @@ def _update_holding(**kwargs) -> None:
 
     instance_map[instance_id]["holdings"][holding["id"]] = {
         "hrid": holding_hrid,
+        "permanentLocationId": holding["permanentLocationId"],
+        "merged": False,
         "items": [],
     }
 
@@ -64,6 +66,8 @@ def generate_holdings_identifiers(**kwargs) -> None:
         ]:
             logger.info(f"Starting holdings update for {holdings_name}")
             holdings_path = results_dir / holdings_name
+            if not holdings_path.exists():
+                continue
             with holdings_path.open() as fo:
                 for i, row in enumerate(fo.readlines()):
                     holding = json.loads(row)
@@ -124,6 +128,11 @@ def generate_item_identifiers(**kwargs) -> None:
             if not i % 1_000 and i > 0:
                 logger.info(f"Generated uuids and hrids for {i:,} items")
             fo.write(f"{json.dumps(item)}\n")
+
+    # Remove instance uuid from holdings in map
+    for instance in instances_map.values():
+        for holding in instance['holdings'].values():
+            holding.pop('instance')
 
     with (results_dir / "instance-holdings-items.json").open("w+") as fo:
         json.dump(instances_map, fo)

--- a/plugins/folio/helpers/folio_ids.py
+++ b/plugins/folio/helpers/folio_ids.py
@@ -24,108 +24,28 @@ def _generate_instance_map(instance_path: pathlib.Path) -> dict:
     return instance_map
 
 
-def _generate_barcode_call_number_map(tsv_path: pathlib.Path) -> dict:
-    """
-    Generates a dict of item barcodes to holdings perm
-    """
-    barcode_call_number_map = {}
-    with tsv_path.open() as fo:
-        dict_reader = DictReader(fo, delimiter="\t")
-        for row in dict_reader:
-            barcode_call_number_map[row["BARCODE"]] = row["BASE_CALL_NUMBER"].strip()
-
-    return barcode_call_number_map
-
-
-def _lookup_holdings_uuid(
-    item_permanent_location_id: str, item_call_number: str, holdings_map: dict
-) -> str:
-    """
-    Does a lookup to retrieve the permanentLocationId and associated call number
-    for an item's uuid in order to extract the correct holdings uuid. Uses call
-    number to distinguish between holdings that have the same
-    permanentLocationId
-    """
-    new_holdings_uuid = None
-    for uuid, info in holdings_map.items():
-        if info["permanentLocationId"] == item_permanent_location_id:
-            if info["callNumber"] == item_call_number or info["callNumber"] is None:
-                new_holdings_uuid = uuid
-                break
-    if new_holdings_uuid is None:
-        logger.warning(
-            f"New holdings UUID not found for item with permanentLocationId of {item_permanent_location_id} and call number {item_call_number}"
-        )
-    return new_holdings_uuid
-
-
-def _update_holdings_map(mapping, hrid, uuid, holding) -> None:
-    if len(mapping) < 1:
-        return
-    call_number = holding.get("callNumber")
-    if isinstance(call_number, str):
-        call_number = call_number.strip()
-    info = {
-        "hrid": hrid,
-        "permanentLocationId": holding["permanentLocationId"],
-        "callNumber": call_number,
-        "items": [],
-    }
-    if holding["id"] in mapping:
-        mapping[holding["id"]][uuid] = info
-    else:
-        mapping[holding["id"]] = {uuid: info}
-
-
-def _update_holding_ids(**kwargs) -> None:
+def _update_holding(**kwargs) -> None:
     """
     Iterates through a list of holdings, generates uuid and hrids based
     on the instance map, and optionally populates a holdings map for
     later item identifier generation
     """
-    holdings_path: pathlib.Path = kwargs["holdings_path"]
     instance_map: dict = kwargs["instance_map"]
-    okapi_url: str = kwargs["okapi_url"]
-    holdings_map: dict = kwargs.get("holdings_map", {})
-    merged: bool = kwargs.get("merged", False)
-    if not holdings_path.exists():
-        logger.info(f"{holdings_path.name} does not exist, returning")
-        return
-    with holdings_path.open() as fo:
-        holdings = [json.loads(line) for line in fo.readlines()]
+    holding: dict = kwargs["holding"]
 
-    i = 0
-    with holdings_path.open("w+") as fo:
-        for i, holding in enumerate(holdings):
-            instance_id = holding["instanceId"]
-            instance_hrid = instance_map[instance_id]["hrid"]
-            current_count = len(instance_map[instance_id]["holdings"])
-            holdings_hrid = (
-                f"{instance_hrid[:1]}h{instance_hrid[1:]}_{current_count + 1}"
-            )
-            holding["hrid"] = holdings_hrid
-            new_holdings_id = str(
-                FolioUUID(okapi_url, FOLIONamespaces.holdings, holdings_hrid)
-            )
-            _update_holdings_map(holdings_map, holdings_hrid, new_holdings_id, holding)
-            holding["id"] = new_holdings_id
-            # For optimistic locking handling
-            holding["_version"] = 1
-            instance_map[instance_id]["holdings"][new_holdings_id] = {
-                "location_id": holding["permanentLocationId"],
-                "merged": merged,
-            }
-            fo.write(f"{json.dumps(holding)}\n")
-            if not i % 1_000 and i > 0:
-                logger.info(f"Generated uuids and hrids for {i:,} holdings")
+    instance_id = holding['instanceId']
+    instance_hrid = instance_map[instance_id]["hrid"]
+    current_count = len(instance_map[instance_id]["holdings"])
+    holding_hrid = f"{instance_hrid[:1]}h{instance_hrid[1:]}_{current_count + 1}"
 
-    # Persists holdings_map if populated
-    if len(holdings_map) > 0:
-        holdings_map_path = holdings_path.parent / "holdings-items-map.json"
-        with holdings_map_path.open("w+") as fo:
-            json.dump(holdings_map, fo)
+    holding["hrid"] = holding_hrid
+    # For optimistic locking handling
+    holding["_version"] = 1
 
-    logger.info(f"Finished updating {i:,} for {holdings_path} ")
+    instance_map[instance_id]["holdings"][holding["id"]] = {
+        "hrid": holding_hrid,
+        "items": []
+    }
 
 
 def generate_holdings_identifiers(**kwargs) -> None:
@@ -136,37 +56,31 @@ def generate_holdings_identifiers(**kwargs) -> None:
     airflow = kwargs.get("airflow", "/opt/airflow")
     dag = kwargs["dag_run"]
     results_dir = pathlib.Path(airflow) / f"migration/iterations/{dag.run_id}/results/"
-    okapi_url = Variable.get("OKAPI_URL")
 
     instance_path = results_dir / "folio_instances_bibs-transformer.json"
 
     instance_map = _generate_instance_map(instance_path)
-    tsv_holdings_path = results_dir / "folio_holdings_tsv-transformer.json"
 
-    # Adds a stub key-value holdings map to populate from base tsv file
-    _update_holding_ids(
-        holdings_path=tsv_holdings_path,
-        instance_map=instance_map,
-        okapi_url=okapi_url,
-        holdings_map={"type": "base tsv"},
-    )
-    logger.info(f"Finished updating tsv holdings {tsv_holdings_path}")
-
-    # Updates Electronic holdings
-    electronic_holdings_path = (
-        results_dir / "folio_holdings_electronic-transformer.json"
-    )
-    _update_holding_ids(
-        holdings_path=electronic_holdings_path,
-        instance_map=instance_map,
-        okapi_url=okapi_url,
-        merged=True,
-    )
-
-    with (results_dir / "instance_holdings_map.json").open("w+") as fo:
+    with (results_dir / "folio_holdings.json").open("w+") as holdings_fo:
+        for holdings_name in [
+            "folio_holdings_tsv-transformer.json",
+            "folio_holdings_electronic-transformer.json",
+            "folio_holdings_boundwith.json" ]:
+            logger.info(f"Starting holdings update for {holdings_name}")
+            holdings_path = results_dir / holdings_name
+            with holdings_path.open() as fo:
+                for i, row in enumerate(fo.readlines()):
+                    holding = json.loads(row)
+                    _update_holding(
+                        holding=holding,
+                        instance_map=instance_map
+                    )
+                    holdings_fo.write(f"{json.dumps(holding)}\n")
+                    if not i%1_000 and i > 0:
+                        logger.info(f"Generated holdings hrids for {i:,} in {holdings_name} ")
+    with (results_dir / "instance-holdings-items.json").open("w+") as fo:
         json.dump(instance_map, fo, indent=2)
-
-    logger.info(f"Finished updating electronic holdings {electronic_holdings_path}")
+    logger.info(f"Finished updating Holdings")
 
 
 def generate_item_identifiers(**kwargs) -> None:
@@ -176,17 +90,9 @@ def generate_item_identifiers(**kwargs) -> None:
     """
     airflow = kwargs.get("airflow", "/opt/airflow")
     dag = kwargs["dag_run"]
-    task_instance = kwargs["task_instance"]
+
     iteration_dir = pathlib.Path(airflow) / f"migration/iterations/{dag.run_id}/"
     results_dir = iteration_dir / "results"
-
-    tsv_filename = task_instance.xcom_pull(
-        task_ids="bib-files-group", key="tsv-base"
-    ).split("/")[-1]
-
-    barcode_call_numbers = _generate_barcode_call_number_map(
-        iteration_dir / f"source_data/items/{tsv_filename}"
-    )
 
     items_path = results_dir / "folio_items_transformer.json"
 
@@ -194,36 +100,34 @@ def generate_item_identifiers(**kwargs) -> None:
     with items_path.open() as fo:
         items = [json.loads(line) for line in fo.readlines()]
 
-    with (results_dir / "holdings-items-map.json").open() as fo:
-        holdings_map = json.load(fo)
+    with (results_dir / "instance-holdings-items.json").open() as fo:
+        instances_map = json.load(fo)
+
+    holdings_map = {}
+    for instance_id, instance in instances_map.items():
+        for uuid, holding in instance["holdings"].items():
+            holding["instance"] = instance_id
+            holdings_map[uuid] = holding
 
     logger.info(f"Start updating identifiers for {len(items):,} items")
     with items_path.open("w+") as fo:
         for i, item in enumerate(items):
-            original_holding_id = item["holdingsRecordId"]
-            call_number_from_holdings = barcode_call_numbers.get(item.get("barcode"))
-            holding_uuid = _lookup_holdings_uuid(
-                item["permanentLocationId"],
-                call_number_from_holdings,
-                holdings_map[original_holding_id],
-            )
-            if holding_uuid is None:
-                logger.error(
-                    f"Unable to retrieve generated holdings UUID for {item['id']}"
-                )
+            holding_id = item["holdingsRecordId"]
+            if not holding_id in holdings_map:
+                logger.error(f"{holding_id} not in found in Holdings")
                 continue
-            current_holding = holdings_map[original_holding_id][holding_uuid]
+            current_holding = holdings_map[holding_id]
             holdings_hrid = current_holding["hrid"]
             current_count = len(current_holding["items"])
             item_hrid = f"{holdings_hrid[:1]}i{holdings_hrid[2:]}_{current_count + 1}"
             item["hrid"] = item_hrid
-            item["holdingsRecordId"] = holding_uuid
             current_holding["items"].append(item["id"])
+            instances_map[current_holding["instance"]]["holdings"][holding_id]["items"].append(item["id"])
             if not i % 1_000 and i > 0:
                 logger.info(f"Generated uuids and hrids for {i:,} items")
             fo.write(f"{json.dumps(item)}\n")
 
-    with (results_dir / "holdings-items-map.json").open("w+") as fo:
-        json.dump(holdings_map, fo)
+    with (results_dir / "instance-holdings-items.json").open("w+") as fo:
+        json.dump(instances_map, fo)
 
     logger.info(f"Finished updating identifiers for {len(items):,} items")

--- a/plugins/folio/helpers/tsv.py
+++ b/plugins/folio/helpers/tsv.py
@@ -124,6 +124,29 @@ def _processes_tsv(**kwargs):
         return new_tsv_notes_path
 
 
+unwanted_item_cat1 = [
+    "BUSCORPRPT",
+    "BW-CHILD",
+    "BW-PARENT",
+    "CATEVAL",
+    "EEM",
+    "M-MARCADIA",
+    "PC-FALLSEM",
+    "PC-FQTR",
+    "PC-F-SPSEM",
+    "PC-FWSQTRS"
+    "PC-PERM",
+    "PC-SPQTR",
+    "PC-SPSEM",
+    "PC-SUQTR",
+    "PC-WQTR",
+    "RECYCLE",
+    "SALPROB1",
+    "SALPROB2",
+    "TEAMS"
+]
+
+
 def transform_move_tsvs(*args, **kwargs):
     airflow = kwargs.get("airflow", "/opt/airflow")
     dag = kwargs["dag_run"]

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -435,7 +435,7 @@ def boundwith_holdings(*args, **kwargs):
                     FolioUUID(
                         okapi_url,
                         FOLIONamespaces.holdings,
-                        f"{row['CATKEY']}{row['CALL_SEQ']}",
+                        f"{row['CATKEY']}{row['CALL_SEQ']}{row['COPY']}",
                     )
                 )
                 loc_code = f"{constants.see_other_lib_locs[row['LIBRARY']]}"

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -57,12 +57,12 @@ def _alt_get_legacy_ids(*args):
     that duplicate CATKEYs in the 004 will generate separate records
     """
     marc_record = args[2]
-    catkey = marc_record["004"].value()
+    field_001 = marc_record["001"].value()
     library, location = "", ""
     if "852" in marc_record:
         library = marc_record["852"]["b"]
         location = marc_record["852"]["c"]
-    return [f"{catkey} {library} {location}"]
+    return [f"{field_001} {library} {location}"]
 
 
 def _mhld_into_holding(mhld_record: dict, holding_record: dict) -> dict:

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -137,9 +137,11 @@ def _process_mhld(**kwargs) -> dict:
 def _update_srs_ids(
     mhld_record: dict, srs_record: dict, locations_lookup: dict
 ) -> dict:
+    existing_holdings_uuid = mhld_record["id"]
     existing_hrid = mhld_record["hrid"]
     location_id = mhld_record["permanentLocationId"]
     srs_record["externalIdsHolder"]["holdingsHrid"] = existing_hrid
+    srs_record["externalIdsHolder"]["holdingsId"] = existing_holdings_uuid
     for field in srs_record["parsedRecord"]["content"]["fields"]:
         tag = list(field.keys())[0]
         match tag:

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -117,6 +117,7 @@ def _process_mhld(**kwargs) -> dict:
     if merged_holding is None:
         current_count = len(instance["holdings"])
         instance_hrid = instance["hrid"]
+        holding_id = mhld_record["id"]
         holdings_hrid = f"{instance_hrid[:1]}h{instance_hrid[1:]}_{current_count + 1}"
         mhld_record["hrid"] = holdings_hrid
         all_holdings[holding_id] = mhld_record
@@ -432,7 +433,7 @@ def boundwith_holdings(*args, **kwargs):
                     FolioUUID(
                         okapi_url,
                         FOLIONamespaces.holdings,
-                        f"{row['CAT_KEY']}{row['CALL_SEQ']}",
+                        f"{row['CATKEY']}{row['CALL_SEQ']}",
                     )
                 )
                 loc_code = f"{constants.see_other_lib_locs[row['LIBRARY']]}"
@@ -442,7 +443,7 @@ def boundwith_holdings(*args, **kwargs):
                     "id": holdings_id,
                     "instanceId": str(
                         FolioUUID(
-                            okapi_url, FOLIONamespaces.instances, f"a{row['CAT_KEY']}"
+                            okapi_url, FOLIONamespaces.instances, f"a{row['CATKEY']}"
                         )
                     ),
                     "callNumber": row["BASE_CALL_NUMBER"],
@@ -460,7 +461,7 @@ def boundwith_holdings(*args, **kwargs):
                     FolioUUID(
                         okapi_url,
                         FOLIONamespaces.other,
-                        row["CAT_KEY"] + row["BARCODE"],
+                        row["CATKEY"] + row["BARCODE"],
                     )
                 )
 

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -58,8 +58,10 @@ def _alt_get_legacy_ids(*args):
     """
     marc_record = args[2]
     catkey = marc_record["004"].value()
-    library = marc_record["852"]["b"]
-    location = marc_record["852"]["c"]
+    library, location = "", ""
+    if "852" in marc_record:
+        library = marc_record["852"]["b"]
+        location = marc_record["852"]["c"]
     return [f"{catkey} {library} {location}"]
 
 

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -18,7 +18,9 @@ from folio_migration_tools.migration_tasks.holdings_marc_transformer import (
     HoldingsMarcTransformer,
 )
 
-from folio_migration_tools.marc_rules_transformation.rules_mapper_holdings import RulesMapperHoldings
+from folio_migration_tools.marc_rules_transformation.rules_mapper_holdings import (
+    RulesMapperHoldings,
+)
 
 from plugins.folio.helpers import post_to_okapi, setup_data_logging, constants
 
@@ -48,15 +50,16 @@ def _generate_lookups(holdings_tsv_path: pathlib.Path) -> tuple:
             all_holdings[holding_id] = holding
     return all_holdings
 
+
 def _alt_get_legacy_ids(*args):
     """
     This function overrides RulesMapperHolding method for MHLDs so
     that duplicate CATKEYs in the 004 will generate separate records
     """
     marc_record = args[2]
-    catkey = marc_record['004'].value()
-    library = marc_record['852']['b']
-    location = marc_record['852']['c']
+    catkey = marc_record["004"].value()
+    library = marc_record["852"]["b"]
+    location = marc_record["852"]["c"]
     return [f"{catkey} {library} {location}"]
 
 
@@ -73,7 +76,7 @@ def _mhld_into_holding(mhld_record: dict, holding_record: dict) -> dict:
             else:
                 holding_record[name] = mhld_record[name]
     # Change Source to MARC to display MHLD MARC record in FOLIO
-    holding_record['sourceId'] = mhld_record['sourceId']
+    holding_record["sourceId"] = mhld_record["sourceId"]
     return holding_record
 
 
@@ -83,14 +86,11 @@ def _process_mhld(**kwargs) -> dict:
     merge into existing holdings record, and then updates and returns
     the updated SRS record
     """
-
     mhld_record: dict = kwargs["mhld_record"]
     srs_record: dict = kwargs["srs_record"]
     all_holdings: dict = kwargs["all_holdings"]
     instance_map: dict = kwargs["instance_map"]
-    okapi_url: str = kwargs["okapi_url"]
     iteration_dir: pathlib.Path = kwargs["iteration_dir"]
-    locations_lookup: dict = kwargs["locations_lookup"]
 
     instance_id = mhld_record["instanceId"]
     instance = instance_map[instance_id]
@@ -118,8 +118,6 @@ def _process_mhld(**kwargs) -> dict:
         instance_hrid = instance["hrid"]
         holdings_hrid = f"{instance_hrid[:1]}h{instance_hrid[1:]}_{current_count + 1}"
         mhld_record["hrid"] = holdings_hrid
-        holding_id = str(FolioUUID(okapi_url, FOLIONamespaces.holdings, holdings_hrid))
-        mhld_record["id"] = holding_id
         all_holdings[holding_id] = mhld_record
         mhld_record["_version"] = 1
         instance["holdings"][holding_id] = {
@@ -130,27 +128,16 @@ def _process_mhld(**kwargs) -> dict:
             f"No match found in existing Holdings record {holding_id} for instance HRID {instance_hrid}\n\n"
         )
     mhld_report.close()
-    srs_record = _update_srs_ids(all_holdings[holding_id], srs_record, okapi_url, locations_lookup)
+    srs_record = _update_srs_ids(all_holdings[holding_id], srs_record)
     return srs_record
 
 
-def _update_srs_ids(mhld_record: dict, srs_record: dict, okapi_url: str, locations_lookup: dict) -> dict:
-
+def _update_srs_ids(
+    mhld_record: dict, srs_record: dict, okapi_url: str, locations_lookup: dict
+) -> dict:
     existing_hrid = mhld_record["hrid"]
-    existing_holdings_uuid = mhld_record["id"]
     location_id = mhld_record["permanentLocationId"]
-    new_srs_record_id = str(
-        FolioUUID(
-            okapi_url,
-            FOLIONamespaces.srs_records_holdingsrecord,
-            existing_hrid,
-        )
-    )
-    srs_record["id"] = new_srs_record_id
-    srs_record["matchedId"] = new_srs_record_id
-    srs_record["externalIdsHolder"]["holdingsId"] = existing_holdings_uuid
     srs_record["externalIdsHolder"]["holdingsHrid"] = existing_hrid
-    srs_record["parsedRecord"]["id"] = new_srs_record_id
     for field in srs_record["parsedRecord"]["content"]["fields"]:
         tag = list(field.keys())[0]
         match tag:
@@ -172,12 +159,12 @@ def _update_srs_ids(mhld_record: dict, srs_record: dict, okapi_url: str, locatio
                     subfield = list(row)[0]
                     match subfield:
                         case "i":
-                            row[subfield] = existing_holdings_uuid
+                            row[subfield] = mhld_record["id"]
 
                         case "s":
-                            row["s"] = new_srs_record_id
+                            row["s"] = srs_record["id"]
 
-    srs_record["rawRecord"]["id"] = new_srs_record_id
+    srs_record["rawRecord"]["id"] = srs_record["id"]
     srs_record["rawRecord"]["content"] = json.dumps(
         srs_record["parsedRecord"]["content"]
     )
@@ -185,22 +172,21 @@ def _update_srs_ids(mhld_record: dict, srs_record: dict, okapi_url: str, locatio
 
 
 def merge_update_holdings(**kwargs):
-    okapi_url = Variable.get("OKAPI_URL")
 
     folio_client = kwargs.get("folio_client")
 
     if folio_client is None:
         folio_client = FolioClient(
-            okapi_url,
+            Variable.get("OKAPI_URL"),
             "sul",
             Variable.get("FOLIO_USER"),
-            Variable.get("FOLIO_PASSWORD")
+            Variable.get("FOLIO_PASSWORD"),
         )
 
     airflow = kwargs.get("airflow", "/opt/airflow")
     dag = kwargs["dag_run"]
     iteration_dir = pathlib.Path(f"{airflow}/migration/iterations/{dag.run_id}")
-    holdings_tsv_path = iteration_dir / "results/folio_holdings_tsv-transformer.json"
+    holdings_path = iteration_dir / "results/folio_holdings.json"
     mhld_holdings_path = iteration_dir / "results/folio_holdings_mhld-transformer.json"
 
     if not mhld_holdings_path.exists():
@@ -218,14 +204,14 @@ def merge_update_holdings(**kwargs):
     with srs_path.open() as fo:
         srs_records = [json.loads(line) for line in fo.readlines()]
 
-    with (iteration_dir / "results/instance_holdings_map.json").open() as fo:
+    with (iteration_dir / "results/instance-holdings-items.json").open() as fo:
         instance_map = json.load(fo)
 
     locations_lookup = {}
     for location in folio_client.locations:
-        locations_lookup[location['id']] = location['code']
+        locations_lookup[location["id"]] = location["code"]
 
-    all_holdings= _generate_lookups(holdings_tsv_path)
+    all_holdings = _generate_lookups(holdings_path)
 
     updated_srs_records = []
     count = 0
@@ -235,9 +221,8 @@ def merge_update_holdings(**kwargs):
             srs_record=srs,
             all_holdings=all_holdings,
             instance_map=instance_map,
-            okapi_url=okapi_url,
             iteration_dir=iteration_dir,
-            locations_lookup=locations_lookup
+            locations_lookup=locations_lookup,
         )
         updated_srs_records.append(updated_srs)
         if not count % 1_000:
@@ -251,10 +236,6 @@ def merge_update_holdings(**kwargs):
     with (iteration_dir / "results/folio_holdings.json").open("w+") as fo:
         for holdings_record in all_holdings.values():
             fo.write(f"{json.dumps(holdings_record)}\n")
-
-    # Remove existing holdings JSON files
-    # mhld_holdings_path.unlink()
-    # holdings_tsv_path.unlink()
 
     logger.info("Finished merging MHLDS holdings records and updating SRS records")
 
@@ -352,7 +333,9 @@ def run_mhld_holdings_transformer(*args, **kwargs):
         never_update_hrid_settings=True,
     )
 
-    RulesMapperHoldings.get_legacy_ids = partialmethod(_alt_get_legacy_ids, RulesMapperHoldings)
+    RulesMapperHoldings.get_legacy_ids = partialmethod(
+        _alt_get_legacy_ids, RulesMapperHoldings
+    )
 
     holdings_transformer = HoldingsMarcTransformer(
         mhld_holdings_config, library_config, use_logging=False
@@ -415,41 +398,54 @@ def boundwith_holdings(*args, **kwargs):
     airflow = kwargs.get("airflow", "/opt/airflow")
 
     iteration_dir = pathlib.Path(f"{airflow}/migration/iterations/{dag.run_id}")
-    bw_tsv_path = pathlib.Path(task_instance.xcom_pull(task_ids="bib-files-group", key="bwchild-file"))
+    bw_tsv_path = pathlib.Path(
+        task_instance.xcom_pull(task_ids="bib-files-group", key="bwchild-file")
+    )
     bw_holdings_json_path = iteration_dir / "results/folio_holdings_boundwith.json"
     bw_parts_json_path = iteration_dir / "results/boundwith_parts.json"
 
     if folio_client is None:
         folio_client = FolioClient(
-            okapi_url,
-            "sul",
-            Variable.get("FOLIO_USER"),
-            Variable.get("FOLIO_PASSWORD")
+            okapi_url, "sul", Variable.get("FOLIO_USER"), Variable.get("FOLIO_PASSWORD")
         )
 
     locations_lookup = {}
     for location in folio_client.locations:
         if "SEE-OTHER" in location["code"]:
-            locations_lookup[location['code']] = location['id']
+            locations_lookup[location["code"]] = location["id"]
 
     with bw_tsv_path.open(encoding="utf-8-sig") as tsv:
         logger.info("Processing boundwiths")
         bw_reader = csv.DictReader(tsv, delimiter="\t")
 
-        with bw_holdings_json_path.open("w+") as bwh, bw_parts_json_path.open("w+") as bwp:
+        with bw_holdings_json_path.open("w+") as bwh, bw_parts_json_path.open(
+            "w+"
+        ) as bwp:
             for row in bw_reader:
                 """
-                    includes default holdings-type id for 'Bound-with'
+                includes default holdings-type id for 'Bound-with'
                 """
-                holdings_id = str(FolioUUID(okapi_url, FOLIONamespaces.holdings, f"{row['CAT_KEY']}{row['CALL_SEQ']}"))
+                holdings_id = str(
+                    FolioUUID(
+                        okapi_url,
+                        FOLIONamespaces.holdings,
+                        f"{row['CAT_KEY']}{row['CALL_SEQ']}",
+                    )
+                )
                 loc_code = f"{constants.see_other_lib_locs[row['LIBRARY']]}"
                 perm_loc_id = locations_lookup[loc_code]
 
                 holdings = {
                     "id": holdings_id,
-                    "instanceId": str(FolioUUID(okapi_url, FOLIONamespaces.instances, f"a{row['CAT_KEY']}")),
-                    "callNumber": row['BASE_CALL_NUMBER'],
-                    "callNumberTypeId": constants.call_number_codes[row['CALL_NUMBER_TYPE']],
+                    "instanceId": str(
+                        FolioUUID(
+                            okapi_url, FOLIONamespaces.instances, f"a{row['CAT_KEY']}"
+                        )
+                    ),
+                    "callNumber": row["BASE_CALL_NUMBER"],
+                    "callNumberTypeId": constants.call_number_codes[
+                        row["CALL_NUMBER_TYPE"]
+                    ],
                     "permanentLocationId": perm_loc_id,
                     "holdingsTypeId": "5b08b35d-aaa3-4806-998c-9cd85e5bc406",
                 }
@@ -457,12 +453,20 @@ def boundwith_holdings(*args, **kwargs):
                 logger.info(f"Writing holdings id {holdings_id} to file")
                 bwh.write(f"{json.dumps(holdings)}\n")
 
-                bw_id = str(FolioUUID(okapi_url, FOLIONamespaces.other, row['CAT_KEY'] + row['BARCODE']))
+                bw_id = str(
+                    FolioUUID(
+                        okapi_url,
+                        FOLIONamespaces.other,
+                        row["CAT_KEY"] + row["BARCODE"],
+                    )
+                )
 
                 bw_parts = {
                     "id": bw_id,
                     "holdingsRecordId": holdings_id,
-                    "itemId": str(FolioUUID(okapi_url, FOLIONamespaces.items, row['BARCODE'])),
+                    "itemId": str(
+                        FolioUUID(okapi_url, FOLIONamespaces.items, row["BARCODE"])
+                    ),
                 }
 
                 logger.info(f"Writing bound-with part id {bw_id} to file")

--- a/plugins/tests/helpers/test_folio_ids.py
+++ b/plugins/tests/helpers/test_folio_ids.py
@@ -8,6 +8,7 @@ from plugins.folio.helpers.folio_ids import (
 )
 
 from plugins.tests.test_holdings import holdings as mock_holding_records
+from plugins.tests.test_holdings import instances_holdings_items_map
 
 from plugins.tests.mocks import mock_dag_run, mock_file_system, mock_okapi_variable  # noqa
 
@@ -39,6 +40,7 @@ def test_generate_holdings_identifiers(
         for holding in [
             {
                 "instanceId": "xyzabc-def-ha",
+                "id": "5d2bbdcd-0fe9-4725-8eaa-f0ba3b3b8b55",
                 "permanentLocationId": "048eda24-a3af-4d2f-94f5-efe039d50c79",
             }
         ]:
@@ -46,18 +48,16 @@ def test_generate_holdings_identifiers(
 
     generate_holdings_identifiers(airflow=airflow, dag_run=mock_dag_run)
 
-    with holdings_filepath.open() as fo:
+    with (results_dir / "folio_holdings.json").open() as fo:
         modified_holdings = [json.loads(line) for line in fo.readlines()]
 
     assert modified_holdings[0]["hrid"] == "ah123345_1"
-    assert modified_holdings[0]["id"] == "03e6d8da-9c1e-58d1-8459-4f657200a5df"
+    assert modified_holdings[0]["id"] == "abcdedf123345"
 
     assert modified_holdings[1]["hrid"] == "ah123345_2"
 
-    with electronic_holdings_filepath.open() as fo:
-        electronic_modified_holdings = [json.loads(line) for line in fo.readlines()]
-
-    assert electronic_modified_holdings[0]["hrid"] == "ah123345_3"
+    assert modified_holdings[2]["id"] == "5d2bbdcd-0fe9-4725-8eaa-f0ba3b3b8b55"
+    assert modified_holdings[2]["hrid"] == "ah123345_3"
 
 
 class MockTaskInstance(pydantic.BaseModel):
@@ -82,35 +82,22 @@ def test_generate_item_identifiers(
         ]:
             fo.write(f"{row}\n")
 
-    mock_holdings_items_map = results_dir / "holdings-items-map.json"
-    with mock_holdings_items_map.open("w+") as fo:
-        fo.write(
-            json.dumps(
-                {
-                    "e9ff785b-97e1-5f00-8dd0-4fce8fef1da3": {
-                        "1df5a25b-2b80-59a3-824a-1ab8f983cfaf": {
-                            "hrid": "ah650005_1",
-                            "callNumber": "CSA 1.10:W 99/",
-                            "items": [],
-                            "permanentLocationId": "b26d05ad-80a3-460d-8b49-00ddb72593bc",
-                        },
-                    }
-                }
-            )
-        )
+    mock_instances_holdings_items_path = results_dir / "instance-holdings-items.json"
+    with mock_instances_holdings_items_path.open("w+") as fo:
+        json.dump(instances_holdings_items_map, fo)
 
     mock_items_filepath = results_dir / "folio_items_transformer.json"
     with mock_items_filepath.open("w+") as fo:
         for item in [
             {
                 "id": "f9262e00-1501-5f6e-a9ee-cc14a8f641ec",
-                "holdingsRecordId": "e9ff785b-97e1-5f00-8dd0-4fce8fef1da3",
+                "holdingsRecordId": "abcdedf123345",
                 "permanentLocationId": "b26d05ad-80a3-460d-8b49-00ddb72593bc",
                 "barcode": "36105080396299",
             },
             {
                 "id": "1cde0ebe-2cdd-5c9c-90f3-d4ce0dc63587",
-                "holdingsRecordId": "e9ff785b-97e1-5f00-8dd0-4fce8fef1da3",
+                "holdingsRecordId": "65ae60f2-2340-4126-a690-242d19b598f7",
                 "permanentLocationId": "b26d05ad-80a3-460d-8b49-00ddb72593bc",
             },
         ]:
@@ -123,13 +110,22 @@ def test_generate_item_identifiers(
     with mock_items_filepath.open() as fo:
         mock_modified_items = [json.loads(line) for line in fo.readlines()]
 
-    assert (
-        mock_modified_items[0]["holdingsRecordId"]
-        == "1df5a25b-2b80-59a3-824a-1ab8f983cfaf"
-    )
-    assert mock_modified_items[0]["hrid"] == "ai650005_1_1"
+    assert mock_modified_items[0]["holdingsRecordId"] == "abcdedf123345"
+    assert mock_modified_items[0]["hrid"] == "ai123345_1_1"
 
     assert (
-        "New holdings UUID not found for item with permanentLocationId" in caplog.text
+        "65ae60f2-2340-4126-a690-242d19b598f7 not in found in Holdings" in caplog.text
     )
-    assert "Unable to retrieve generated holdings UUID" in caplog.text
+
+    with mock_instances_holdings_items_path.open() as fo:
+        modified_instances_holdings_items_map = json.load(fo)
+
+    assert modified_instances_holdings_items_map != instances_holdings_items_map
+    assert (
+        len(
+            modified_instances_holdings_items_map["xyzabc-def-ha"]["holdings"][
+                "abcdedf123345"
+            ]["items"]
+        )
+        == 2
+    )

--- a/plugins/tests/helpers/test_folio_ids.py
+++ b/plugins/tests/helpers/test_folio_ids.py
@@ -48,6 +48,8 @@ def test_generate_holdings_identifiers(
 
     generate_holdings_identifiers(airflow=airflow, dag_run=mock_dag_run)
 
+    assert not holdings_filepath.exists()
+
     with (results_dir / "folio_holdings.json").open() as fo:
         modified_holdings = [json.loads(line) for line in fo.readlines()]
 

--- a/plugins/tests/helpers/test_folio_ids.py
+++ b/plugins/tests/helpers/test_folio_ids.py
@@ -5,8 +5,6 @@ import pydantic
 from plugins.folio.helpers.folio_ids import (
     generate_holdings_identifiers,
     generate_item_identifiers,
-    _lookup_holdings_uuid,
-    _update_holding_ids,
 )
 
 from plugins.tests.test_holdings import holdings as mock_holding_records
@@ -135,39 +133,3 @@ def test_generate_item_identifiers(
         "New holdings UUID not found for item with permanentLocationId" in caplog.text
     )
     assert "Unable to retrieve generated holdings UUID" in caplog.text
-
-
-def test_lookup_holdings_uuid():
-
-    holdings_map = {
-        "527b783d-6624-56fe-be28-895f2c69cf1f": {
-            "hrid": "ah660592_1",
-            "permanentLocationId": "0edeef57-074a-4f07-aee2-9f09d55e65c3",
-            "items": [],
-            "callNumber": "MORE 1.345",
-        }
-    }
-
-    holdings_uuid = _lookup_holdings_uuid(
-        "0edeef57-074a-4f07-aee2-9f09d55e65c3", "MORE 1.345", holdings_map
-    )
-    assert holdings_uuid == "527b783d-6624-56fe-be28-895f2c69cf1f"
-
-
-def test_update_holding_ids_no_file(mock_file_system, caplog):  # noqa
-
-    empty_mhlds_path = (
-        mock_file_system[2] / "results/folio_holdings_mhlds-transformer.json"
-    )
-
-    result = _update_holding_ids(
-        holdings_path=empty_mhlds_path,
-        instance_map={},
-        okapi_url="http://okapi.edu/",
-        holdings_map={},
-    )
-
-    assert result is None
-    assert (
-        "folio_holdings_mhlds-transformer.json does not exist, returning" in caplog.text
-    )

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -274,7 +274,7 @@ def test_merge_update_holdings(
         in mhld_merge_report
     )
     assert (
-        "No match found in existing Holdings record nweoasdf42425 for instance HRID a123345"
+        "No match found in existing Holdings record d1e33e3-3b57-53e4-bba0-b2faed059f40 for instance HRID a123345"
         in mhld_merge_report
     )
 
@@ -313,7 +313,7 @@ def test_boundwith_holdings(mock_dag_run, mock_okapi_variable, mock_file_system)
     mocks.messages["bib-files-group"] = {"bwchild-file": str(bw_tsv)}
 
     bw_tsv_lines=[
-        "CAT_KEY\tCALL_SEQ\tCOPY\tBARCODE\tLIBRARY\tHOMELOCATION\tCURRENTLOCATION\tITEM_TYPE\tITEM_CAT1\tITEM_CAT2\tITEM_SHADOW\tCALL_NUMBER_TYPE\tBASE_CALL_NUMBER\tVOLUME_INFO\tCALL_SHADOW\tFORMAT\tCATALOG_SHADOW",
+        "CATKEY\tCALL_SEQ\tCOPY\tBARCODE\tLIBRARY\tHOMELOCATION\tCURRENTLOCATION\tITEM_TYPE\tITEM_CAT1\tITEM_CAT2\tITEM_SHADOW\tCALL_NUMBER_TYPE\tBASE_CALL_NUMBER\tVOLUME_INFO\tCALL_SHADOW\tFORMAT\tCATALOG_SHADOW",
         "2956972\t2\t1\t36105127895816\tGREEN\tSEE-OTHER\tSEE-OTHER\tGOVSTKS\tBW-CHILD\t\t0\tSUDOC\tI\t29.9/5:148\t\t0\tMARC\t0"
     ]
 

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -343,9 +343,9 @@ def test_boundwith_holdings(mock_dag_run, mock_okapi_variable, mock_file_system)
 
 def test_alt_get_legacy_ids():
     marc_record = pymarc.Record()
-    field_004 = pymarc.Field(tag='004', data='a2798312')
-    marc_record.add_field(field_004)
+    field_001 = pymarc.Field(tag='001', data='1964746')
+    marc_record.add_field(field_001)
     field_852 = pymarc.Field(tag='852', subfields=['b', 'SAL3', 'c', 'PAGE-GR'])
     marc_record.add_field(field_852)
     legacy_id = _alt_get_legacy_ids(None, None, marc_record)
-    assert legacy_id == ["a2798312 SAL3 PAGE-GR"]
+    assert legacy_id == ["1964746 SAL3 PAGE-GR"]

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -2,6 +2,7 @@ import json
 
 import pytest  # noqa
 import pydantic
+import pymarc
 
 from plugins.folio.holdings import (
     electronic_holdings,
@@ -10,6 +11,7 @@ from plugins.folio.holdings import (
     run_holdings_tranformer,
     run_mhld_holdings_transformer,
     boundwith_holdings,
+    _alt_get_legacy_ids
 )
 
 from plugins.tests.mocks import (  # noqa
@@ -168,21 +170,27 @@ srs_mhdls = [
 ]
 
 
-instances_holdings_map = {
+instances_holdings_items_map = {
     "xyzabc-def-ha": {
         "hrid": "a123345",
         "holdings": {
             "abcdedf123345": {
-                "location_id": "0edeef57-074a-4f07-aee2-9f09d55e65c3",
+                "hrid": "ah123345_1",
+                "permanentLocationId": "0edeef57-074a-4f07-aee2-9f09d55e65c3",
                 "merged": False,
+                "items": []
             },
             "exyqdf123345": {
-                "location_id": "04c54d2f-0e14-42ab-97a6-27fc7f4d061",
+                "hrid": "ah123345_2",
+                "permanentLocationId": "21b7083b-1013-440e-8e62-64169824dcb8",
                 "merged": False,
+                "items": []
             },
             "nweoasdf42425": {  # Stand-in for Electronic Holding
-                "location_id": "16211e24-f904-47f8-beaa-f91b4646c434",
-                "merged": True,
+                "hrid": "ah123345_3",
+                "permanentLocationId": "b0a1a8c3-cc9a-487c-a2ed-308fc3a49a91",
+                "merged": False,
+                "items": []
             },
         },
     }
@@ -194,7 +202,7 @@ def test_merge_update_holdings(
 ):
     results_dir = mock_file_system[3]
     reports_dir = mock_file_system[2] / "reports"
-    holdings_tsv = results_dir / "folio_holdings_tsv-transformer.json"
+    holdings_tsv = results_dir / "folio_holdings.json"
     holdings_mhld = results_dir / "folio_holdings_mhld-transformer.json"
 
     with (holdings_tsv).open("w+") as fo:
@@ -205,8 +213,8 @@ def test_merge_update_holdings(
         for row in mhld_holdings:
             fo.write(f"{json.dumps(row)}\n")
 
-    with (results_dir / "instance_holdings_map.json").open("w+") as fo:
-        json.dump(instances_holdings_map, fo)
+    with (results_dir / "instance-holdings-items.json").open("w+") as fo:
+        json.dump(instances_holdings_items_map, fo)
 
     with (results_dir / "folio_srs_holdings_mhld-transformer.json").open("w+") as fo:
         for row in srs_mhdls:
@@ -228,7 +236,6 @@ def test_merge_update_holdings(
     with (results_dir / "folio_holdings.json").open() as fo:
         combined_holdings = [json.loads(line) for line in fo.readlines()]
 
-    assert not holdings_tsv.exists()
     assert not holdings_mhld.exists()
 
     # Tests merged Holdings with MHLD Holdings Record 1
@@ -267,7 +274,7 @@ def test_merge_update_holdings(
         in mhld_merge_report
     )
     assert (
-        "No match found in existing Holdings record 71857ce4-0ea0-5d4a-b7a5-456255515c63 for instance HRID a123345"
+        "No match found in existing Holdings record nweoasdf42425 for instance HRID a123345"
         in mhld_merge_report
     )
 
@@ -306,7 +313,7 @@ def test_boundwith_holdings(mock_dag_run, mock_okapi_variable, mock_file_system)
     mocks.messages["bib-files-group"] = {"bwchild-file": str(bw_tsv)}
 
     bw_tsv_lines=[
-        "CATKEY\tCALL_SEQ\tCOPY\tBARCODE\tLIBRARY\tHOMELOCATION\tCURRENTLOCATION\tITEM_TYPE\tITEM_CAT1\tITEM_CAT2\tITEM_SHADOW\tCALL_NUMBER_TYPE\tBASE_CALL_NUMBER\tVOLUME_INFO\tCALL_SHADOW\tFORMAT\tCATALOG_SHADOW",
+        "CAT_KEY\tCALL_SEQ\tCOPY\tBARCODE\tLIBRARY\tHOMELOCATION\tCURRENTLOCATION\tITEM_TYPE\tITEM_CAT1\tITEM_CAT2\tITEM_SHADOW\tCALL_NUMBER_TYPE\tBASE_CALL_NUMBER\tVOLUME_INFO\tCALL_SHADOW\tFORMAT\tCATALOG_SHADOW",
         "2956972\t2\t1\t36105127895816\tGREEN\tSEE-OTHER\tSEE-OTHER\tGOVSTKS\tBW-CHILD\t\t0\tSUDOC\tI\t29.9/5:148\t\t0\tMARC\t0"
     ]
 
@@ -332,3 +339,13 @@ def test_boundwith_holdings(mock_dag_run, mock_okapi_variable, mock_file_system)
         bw_part_rec = [json.loads(line) for line in bwp.readlines()]
 
     assert holdings_rec[0]["id"] == bw_part_rec[0]["holdingsRecordId"]
+
+
+def test_alt_get_legacy_ids():
+    marc_record = pymarc.Record()
+    field_004 = pymarc.Field(tag='004', data='a2798312')
+    marc_record.add_field(field_004)
+    field_852 = pymarc.Field(tag='852', subfields=['b', 'SAL3', 'c', 'PAGE-GR'])
+    marc_record.add_field(field_852)
+    legacy_id = _alt_get_legacy_ids(None, None, marc_record)
+    assert legacy_id == ["a2798312 SAL3 PAGE-GR"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pydantic
 pymarc
 pytest
 pytest_mock
-folio_migration_tools == 1.7.1
+folio_migration_tools == 1.7.2


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/FOLIO-Project-Stanford/issues/292

Depends on https://github.com/sul-dlss/folio_migration/pull/48

This PR simplifies HRID generation by removing UUID generation for holdings and items because of the mappings that allow for unique UUIDs to be generated for Holdings and Items in the latest version of the `folio_migration_tools`. Also, does some DRY refactor for tests.

