### PR TITLE
Boundwith DAG with Audit Module updates

### DIFF
--- a/dags/new_boundwiths.py
+++ b/dags/new_boundwiths.py
@@ -1,0 +1,51 @@
+import logging
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.models import Variable
+from airflow.operators.python import PythonOperator
+
+from plugins.folio.helpers.bw import check_add_bw, discover_bw_parts_files
+
+logger = logging.getLogger(__name__)
+
+default_args = {
+    "owner": "folio",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+parallel_posts = Variable.get("parallel_posts", 3)
+
+with DAG(
+    "boundwith_relationships",
+    default_args=default_args,
+    schedule_interval=None,
+    start_date=datetime(2023, 2, 22),
+    catchup=False,
+    tags=["bib_import", "folio"],
+    max_active_runs=1,
+) as dag:
+
+    discovery_bw_files = PythonOperator(
+        task_id="discovery-bw-parts",
+        python_callable=discover_bw_parts_files,
+        op_kwargs={"jobs": parallel_posts},
+    )
+
+    start_checks_add = EmptyOperator(task_id="start-check-add")
+
+    finished_checks_add = EmptyOperator(task_id="finished-check-add")
+
+    for i in range(int(parallel_posts)):
+        check_add_relationships = PythonOperator(
+            task_id=f"check-add-{i}", python_callable=check_add_bw, op_kwargs={"job": i}
+        )
+
+        start_checks_add >> check_add_relationships >> finished_checks_add
+
+    discovery_bw_files >> start_checks_add

--- a/plugins/folio/helpers/bw.py
+++ b/plugins/folio/helpers/bw.py
@@ -4,9 +4,6 @@ import pathlib
 
 import requests
 
-from airflow.models import Variable
-from folioclient import FolioClient
-
 logger = logging.getLogger(__name__)
 
 
@@ -39,16 +36,8 @@ def discover_bw_parts_files(**kwargs):
 
 def check_add_bw(**kwargs):
     instance = kwargs["task_instance"]
-    folio_client = kwargs.get("folio_client")
+    folio_client = kwargs["folio_client"]
     job_number = kwargs["job"]
-
-    if folio_client is None:
-        folio_client = FolioClient(
-            Variable.get("OKAPI_URL"),
-            "sul",
-            Variable.get("FOLIO_USER"),
-            Variable.get("FOLIO_PASSWORD"),
-        )
 
     bw_file_parts = instance.xcom_pull(
         task_ids="discovery-bw-parts", key=f"job-{job_number}"

--- a/plugins/folio/helpers/bw.py
+++ b/plugins/folio/helpers/bw.py
@@ -1,0 +1,82 @@
+import json
+import logging
+import pathlib
+
+import requests
+
+from airflow.models import Variable
+from folioclient import FolioClient
+
+logger = logging.getLogger(__name__)
+
+
+def discover_bw_parts_files(**kwargs):
+    airflow = kwargs.get("airflow", "/opt/airflow/")
+    jobs = int(kwargs["jobs"])
+    instance = kwargs["task_instance"]
+    iterations = pathlib.Path(airflow) / "migration/iterations"
+
+    bw_files = []
+    for iteration in iterations.iterdir():
+        bw_file = iteration / "results/boundwith_parts.json"
+        if bw_file.exists():
+            bw_files.append(str(bw_file))
+        else:
+            logger.error(f"{bw_file} doesn't exist")
+
+    shard_size = int(len(bw_files) / jobs)
+
+    for i in range(jobs):
+        start = i * shard_size
+        end = shard_size * (i + 1)
+        if i == jobs - 1:
+            end = len(bw_files)
+
+        instance.xcom_push(key=f"job-{i}", value=bw_files[start:end])
+
+    logger.info(f"Discovered {len(bw_files)} boundwidth part files for processing")
+
+
+def check_add_bw(**kwargs):
+    instance = kwargs["task_instance"]
+    folio_client = kwargs.get("folio_client")
+    job_number = kwargs["job"]
+
+    if folio_client is None:
+        folio_client = FolioClient(
+            Variable.get("OKAPI_URL"),
+            "sul",
+            Variable.get("FOLIO_USER"),
+            Variable.get("FOLIO_PASSWORD"),
+        )
+
+    bw_file_parts = instance.xcom_pull(
+        task_ids="discovery-bw-parts", key=f"job-{job_number}"
+    )
+
+    logger.info(f"Started processing {len(bw_file_parts)}")
+
+    total_bw, total_errors = 0, 0
+    for file_path in bw_file_parts:
+        logger.info(f"Starting Boundwith processing for {file_path}")
+        bw, errors = 0, 0
+        with open(file_path) as fo:
+            for line in fo.readlines():
+                record = json.loads(line)
+                post_result = requests.post(
+                    f"{folio_client.okapi_url}/inventory-storage/bound-with-parts",
+                    headers=folio_client.okapi_headers,
+                    json=record,
+                )
+                if post_result.status_code != 201:
+                    errors += 1
+                    logger.error(
+                        f"Failed to post {record['id']} from {file_path} error: {post_result.text}"
+                    )
+                bw += 1
+
+        logger.info(f"Processed {file_path} added {bw} errors {errors}")
+        total_errors += errors
+        total_bw += bw
+
+    logger.info(f"Finished added {total_bw:,} boundwidths with {total_errors:,} errors")

--- a/plugins/tests/helpers/test_boundwiths.py
+++ b/plugins/tests/helpers/test_boundwiths.py
@@ -1,0 +1,103 @@
+import json
+
+import pytest
+import requests
+
+from pytest_mock import MockerFixture
+
+from plugins.folio.helpers.bw import discover_bw_parts_files, check_add_bw
+from plugins.tests.mocks import (  # noqa
+    mock_file_system,
+    mock_dag_run,
+    MockFOLIOClient,
+    MockTaskInstance,
+)
+
+import plugins.tests.mocks as mocks
+
+
+@pytest.fixture
+def mock_okapi_boundwith(monkeypatch, mocker: MockerFixture):
+    def mock_post(*args, **kwargs):
+        post_response = mocker.stub(name="post_result")
+        if kwargs["json"]["id"] == "70980bf9-40bc-583a-8590-49b520b58b9f":
+            post_response.status_code = 422
+            post_response.text = """
+            "errors" : [ {
+    "message" : "Cannot set bound_with_part.holdingsrecordid = d89b35ba-27c9-5ba0-8c3d-9cae9eb2e9f4 because it does not exist in holdings_record.id.",
+    "type" : "1",
+    "code" : "-1",
+    "parameters" : [ {
+      "key" : "bound_with_part.holdingsrecordid",
+      "value" : "d89b35ba-27c9-5ba0-8c3d-9cae9eb2e9f4"
+    } ]
+  } ]
+}"""
+        else:
+            post_response.status_code = 201
+        return post_response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+
+
+def test_check_add_bw(mock_file_system, mock_okapi_boundwith, caplog):  # noqa
+
+    results_dir = mock_file_system[3]
+
+    boundwith_file = results_dir / "boundwith_parts.json"
+    with boundwith_file.open("w+") as fo:
+        for row in [
+            {
+                "id": "6fb73520-ea6b-5f43-a6c7-7af9063fe439",
+                "holdingsRecordId": "aa56077c-b252-53a0-9f6c-de9d209566c4",
+                "itemId": "0c8dd766-bdbd-52fc-afbd-c4a9a69c4ac4",
+            },
+            {
+                "id": "70980bf9-40bc-583a-8590-49b520b58b9f",
+                "holdingsRecordId": "d89b35ba-27c9-5ba0-8c3d-9cae9eb2e9f4",
+                "itemId": "8a840385-5eb3-51d9-bf46-8997732c4f61",
+            },
+        ]:
+            fo.write(f"{json.dumps(row)}\n")
+
+    mocks.messages["discovery-bw-parts"] = {"job-1": [str(boundwith_file)]}
+
+    check_add_bw(
+        task_instance=MockTaskInstance(), folio_client=MockFOLIOClient(), job=1
+    )
+
+    assert (
+        "Cannot set bound_with_part.holdingsrecordid = d89b35ba-27c9-5ba0-8c3d-9cae9eb2e9f4"
+        in caplog.text
+    )
+    assert "Finished added 2 boundwidths with 1 errors" in caplog.text
+    mocks.messages = {}
+
+
+def test_discover_bw_parts_files(mock_file_system, caplog):  # noqa
+    airflow = mock_file_system[0]
+
+    second_iteration = airflow / "migration/iterations/manual__2023-02-24"
+
+    second_iteration.mkdir(parents=True)
+
+    boundwith_file = mock_file_system[3] / "boundwith_parts.json"
+
+    with boundwith_file.open("w+") as fo:
+        record = {
+            "id": "6fb73520-ea6b-5f43-a6c7-7af9063fe439",
+            "holdingsRecordId": "aa56077c-b252-53a0-9f6c-de9d209566c4",
+            "itemId": "0c8dd766-bdbd-52fc-afbd-c4a9a69c4ac4",
+        }
+        fo.write(f"{json.dumps(record)}\n")
+
+    discover_bw_parts_files(airflow=airflow, jobs=2, task_instance=MockTaskInstance())
+    assert len(mocks.messages["job-0"]) == 0
+    assert mocks.messages["job-1"] == [str(boundwith_file)]
+
+    assert (
+        "manual__2023-02-24/results/boundwith_parts.json doesn't exist" in caplog.text
+    )
+    assert "Discovered 1 boundwidth part files for processing" in caplog.text
+
+    mocks.messages = {}


### PR DESCRIPTION
Fixes #219, creates a DAG to be triggered after a complete migration run, iterates through all of the directories in the `migration/iterations` directory for `boundwith_parts.json` file and then POSTs those records to Okapi. 

Adds a fix and test to the audit module in case of a duplicate JSON payload and uses the correct folio_holdings file with an instance_counter. 