### PR TITLE
Instance post-transformer updates

### DIFF
--- a/plugins/folio/instances.py
+++ b/plugins/folio/instances.py
@@ -100,8 +100,6 @@ def _adjust_records(**kwargs):
     with instances_path.open("w+") as fo:
         for record in records:
             fo.write(f"{json.dumps(record)}\n")
-    with (instances_path.parent / "instance-lookup.json").open("w+") as fo:
-        json.dump(record_lookups, fo, indent=2)
     Path(tsv_dates).unlink()
 
 

--- a/plugins/folio/instances.py
+++ b/plugins/folio/instances.py
@@ -1,3 +1,4 @@
+import csv
 import json
 import logging
 import pandas as pd
@@ -15,6 +16,34 @@ from plugins.folio.helpers import post_to_okapi, setup_data_logging
 logger = logging.getLogger(__name__)
 
 
+def _generate_record_lookups(base_tsv: Path, lookup_stat_codes: dict) -> dict:
+    """
+    Generates record lookup dictionary based on values in tsv
+    """
+    record_lookups = {}
+    logger.error(f"Base {base_tsv}")
+    with base_tsv.open() as fo:
+        tsv_reader = csv.DictReader(fo, delimiter="\t")
+        for row in tsv_reader:
+            catkey = row['CATKEY']
+            discovery_suppress = False
+            if int(row['CATALOG_SHADOW']) > 0:
+                discovery_suppress = True
+            stat_codes = []
+            for item_cat in [row['ITEM_CAT1'], row['ITEM_CAT2']]:
+                if item_cat in lookup_stat_codes:
+                    stat_codes.append(lookup_stat_codes[item_cat])
+            if catkey in record_lookups:
+                record_lookups[catkey]["stat_codes"].extend(stat_codes)
+                record_lookups[catkey]["suppress"] = discovery_suppress
+            else:
+                record_lookups[catkey] = {
+                    "stat_codes": stat_codes,
+                    "suppress": discovery_suppress
+                }
+    return record_lookups
+
+
 def _remove_dup_admin_notes(record: dict):
     """
     Removes administrativeNotes that contain duplicated HRID
@@ -24,33 +53,55 @@ def _remove_dup_admin_notes(record: dict):
             record['administrativeNotes'].pop(i)
 
 
-def _adjust_records(instances_path: Path, tsv_dates: str, instance_status: dict):
+def _set_cataloged_date(instance: dict, dates_df: pd.DataFrame, instance_status: dict):
+    ckey = instance["hrid"].removeprefix("a")
+    matched_row = dates_df.loc[dates_df["CATKEY"] == ckey]
+    if matched_row["CATALOGED_DATE"].values[0] != "0":
+        date_cat = datetime.strptime(
+            matched_row["CATALOGED_DATE"].values[0], "%Y%m%d"
+        )
+        instance["catalogedDate"] = date_cat.strftime("%Y-%m-%d")
+        instance["statusId"] = instance_status["Cataloged"]
+    else:
+        instance["statusId"] = instance_status["Uncataloged"]
+
+
+def _adjust_records(**kwargs):
+    """
+    Modifies instances records
+    """
+    instances_path: Path = kwargs["instances_record_path"]
+    tsv_dates: str = kwargs["tsv_dates"]
+    instance_status: dict = kwargs["instance_statuses"]
+    base_tsv: Path = kwargs["base_tsv"]
+    stat_codes: dict = kwargs["stat_codes"]
 
     dates_df = pd.read_csv(
         tsv_dates,
         sep="\t",
         dtype={"CATKEY": str, "CREATED_DATE": str, "CATALOGED_DATE": str},
     )
+
+    record_lookups = _generate_record_lookups(base_tsv, stat_codes)
+
     records = []
     with instances_path.open() as fo:
         for row in fo.readlines():
             record = json.loads(row)
             record["_version"] = 1  # for handling optimistic locking
-            ckey = record["hrid"].removeprefix("a")
-            matched_row = dates_df.loc[dates_df["CATKEY"] == ckey]
-            if matched_row["CATALOGED_DATE"].values[0] != "0":
-                date_cat = datetime.strptime(
-                    matched_row["CATALOGED_DATE"].values[0], "%Y%m%d"
-                )
-                record["catalogedDate"] = date_cat.strftime("%Y-%m-%d")
-                record["statusId"] = instance_status["Cataloged"]
-            else:
-                record["statusId"] = instance_status["Uncataloged"]
+            stat_codes = record_lookups.get(record["hrid"], {}).get("stat_codes", [])
+            if len(stat_codes) > 0:
+                record["statisticalCodeIds"] = list(set(stat_codes))
+            if record_lookups.get(record["hrid"], {}).get("suppress", False):
+                record["discoverySuppress"] = True
+            _set_cataloged_date(record, dates_df, instance_status)
             _remove_dup_admin_notes(record)
             records.append(record)
     with instances_path.open("w+") as fo:
         for record in records:
             fo.write(f"{json.dumps(record)}\n")
+    with (instances_path.parent / "instance-lookup.json").open("w+") as fo:
+        json.dump(record_lookups, fo, indent=2)
     Path(tsv_dates).unlink()
 
 
@@ -67,6 +118,36 @@ def _get_instance_status(folio_client: FolioClient) -> dict:
     for row in instance_statuses_result.json()["instanceStatuses"]:
         instance_statuses[row["name"]] = row["id"]
     return instance_statuses
+
+
+def _get_statistical_codes(folio_client: FolioClient) -> dict:
+    """
+    Retrieve statistical codes for instances and saves for lookups
+    """
+    # Get Instance stat code type
+    stat_code_type_result = requests.get(f"{folio_client.okapi_url}/statistical-code-types?query=name==Instance&limit=200",
+                                         headers=folio_client.okapi_headers)
+    stat_code_type_result.raise_for_status()
+    instance_code_type = stat_code_type_result.json()['statisticalCodeTypes'][0]['id']
+    instance_stat_codes_result = requests.get(
+        f"{folio_client.okapi_url}/statistical-codes?query=statisticalCodeTypeId=={instance_code_type}&limit=200",
+        headers=folio_client.okapi_headers)
+    instance_stat_codes_result.raise_for_status()
+    stat_code_lookup = {}
+    for row in instance_stat_codes_result.json()['statisticalCodes']:
+        match row['code']:
+
+            case "E-THESIS":
+                stat_code_lookup["E-THESIS"] = row["id"]
+
+            case "LEVEL3":
+                stat_code_lookup["LEVEL3-CAT"] = row["id"]
+                stat_code_lookup["LEVEL3OCLC"] = row["id"]
+
+            case "MARCIVE":
+                stat_code_lookup["MARCIVE"] = row["id"]
+
+    return stat_code_lookup
 
 
 def post_folio_instance_records(**kwargs):
@@ -143,6 +224,20 @@ def run_bibs_transformer(*args, **kwargs):
 
     instance_statuses = _get_instance_status(folio_client)
 
-    _adjust_records(instances_record_path, tsv_dates, instance_statuses)
+    base_tsv_path = (
+        iteration_dir / f"source_data/items/{marc_stem}.tsv"
+    )
+    logger.error(f"Base tsv path {base_tsv_path} {base_tsv_path.exists()}")
+
+    stat_codes = _get_statistical_codes(folio_client)
+    logger.error(f"Stat codes {stat_codes}")
+
+    _adjust_records(
+        instances_record_path=instances_record_path,
+        tsv_dates=tsv_dates,
+        instance_statuses=instance_statuses,
+        base_tsv=base_tsv_path,
+        stat_codes=stat_codes
+    )
 
     bibs_transformer.wrap_up()

--- a/plugins/tests/test_instances.py
+++ b/plugins/tests/test_instances.py
@@ -1,13 +1,19 @@
 import json
+
 import pydantic
+import pytest
+import requests
+
+from pytest_mock import MockerFixture
 
 from plugins.folio.instances import (
     _adjust_records,
+    _get_statistical_codes,
     post_folio_instance_records,
     run_bibs_transformer,
 )
 
-from plugins.tests.mocks import mock_dag_run, mock_file_system  # noqa
+from plugins.tests.mocks import mock_dag_run, mock_file_system, MockFOLIOClient  # noqa
 
 instances = [{}, {}]
 
@@ -24,24 +30,78 @@ class MockBibsTransformer(pydantic.BaseModel):
     processor = MockBibsProcessor()
 
 
+def mock_stat_codes_response():
+    return {
+        "statisticalCodes": [
+            {"code": "LEVEL3", "id": "ae9ce864-f50c-47ce-a5f1-6579f7057fc5"},
+            {"code": "MARCIVE", "id": "d3f618e2-9fa9-4623-94ae-1d95d1d66f79"},
+            {"code": "E-THESIS", "id": "0f328803-cd6a-47c0-8e76-f3a775d56884"},
+        ]
+    }
+
+
+@pytest.fixture
+def mock_okapi_requests(monkeypatch, mocker: MockerFixture):
+    def mock_get(*args, **kwargs):
+        get_response = mocker.stub(name="get_result")
+        get_response.status_code = 200
+        get_response.raise_for_status = lambda: {}
+        if "statistical-code-types" in args[0]:
+            get_response.json = lambda: {
+                "statisticalCodeTypes": [{"id": "d558cce0-cb4b-4f28-aad3-c94c7084b2e3"}]
+            }
+        else:
+            get_response.json = mock_stat_codes_response
+        return get_response
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+
 def test_adjust_records(mock_file_system, mock_dag_run):  # noqa
     instances_file = mock_file_system[3] / "folio_bib_instances.json"
     instances_file.write_text(
         """{"id": "3e815a91-8a6e-4bbf-8bd9-cf42f9f789e1", "hrid": "a123456", "administrativeNotes": ["Identifier(s) from previous system: a123456"]}
-{"id": "123326dd-9924-498f-9ca3-4fa00dda6c90", "hrid": "a98765"}"""
+{"id": "123326dd-9924-498f-9ca3-4fa00dda6c90", "hrid": "a98765"}
+{"id": "6193afd3-d42f-4051-ad56-273f3ae67e53", "hrid": "a347891"}"""
     )
     tsv_dates_file = mock_file_system[3] / "libr.ckeys.001.dates.tsv"
     tsv_dates_file.write_text(
         """CATKEY\tCREATED_DATE\tCATALOGED_DATE
 123456\t19900927\t19950710
-98765\t20220101\t0""")
+98765\t20220101\t0
+347891\t20230310\t20230321"""
+    )
 
     instance_statuses = {
         "Cataloged": "9634a5ab-9228-4703-baf2-4d12ebc77d56",
-        "Uncataloged": "26f5208e-110a-4394-be29-1569a8c84a65"
+        "Uncataloged": "26f5208e-110a-4394-be29-1569a8c84a65",
     }
 
-    _adjust_records(instances_file, str(tsv_dates_file), instance_statuses)
+    base_tsv = mock_file_system[2] / "source_data/items/sample.tsv"
+
+    with base_tsv.open("w+") as fo:
+        for line in [
+            "CATKEY\tITEM_CAT1\tITEM_CAT2\tCATALOG_SHADOW",
+            "a123456\tE-THESIS\tLEVEL3-CAT\t0",
+            "a98765\tMARCIVE\t\t1",
+            "a347891\tDIGI-SCAN\t\t0",
+        ]:
+            fo.write(f"{line}\n")
+
+    statistical_code_ids = {
+        "LEVEL3-CAT": "ae9ce864-f50c-47ce-a5f1-6579f7057fc5",
+        "LEVEL3OCLC": "ae9ce864-f50c-47ce-a5f1-6579f7057fc5",
+        "MARCIVE": "d3f618e2-9fa9-4623-94ae-1d95d1d66f79",
+        "E-THESIS": "0f328803-cd6a-47c0-8e76-f3a775d56884",
+    }
+
+    _adjust_records(
+        instances_record_path=instances_file,
+        tsv_dates=str(tsv_dates_file),
+        instance_statuses=instance_statuses,
+        stat_codes=statistical_code_ids,
+        base_tsv=base_tsv,
+    )
 
     with instances_file.open() as fo:
         instance_records = [json.loads(row) for row in fo.readlines()]
@@ -50,9 +110,21 @@ def test_adjust_records(mock_file_system, mock_dag_run):  # noqa
     assert instance_records[0]["catalogedDate"] == "1995-07-10"
     assert instance_records[0]["statusId"] == "9634a5ab-9228-4703-baf2-4d12ebc77d56"
     assert instance_records[0]["administrativeNotes"] == []
+    assert len(instance_records[0]["statisticalCodeIds"]) == 2
     assert "catalogedDate" not in instance_records[1]
     assert instance_records[1]["statusId"] == "26f5208e-110a-4394-be29-1569a8c84a65"
+    assert instance_records[1]["statisticalCodeIds"] == [
+        statistical_code_ids["MARCIVE"]
+    ]
+    assert instance_records[1]["discoverySuppress"] is True
+    assert "statisticalCodeIds" not in instance_records[2]
     assert not tsv_dates_file.exists()
+
+
+def test_get_statistical_codes(mock_okapi_requests):  # noqa
+    stat_codes = _get_statistical_codes(MockFOLIOClient())
+
+    assert stat_codes["LEVEL3-CAT"] == "ae9ce864-f50c-47ce-a5f1-6579f7057fc5"
 
 
 def test_post_folio_instance_records():


### PR DESCRIPTION
Fixes #236 
Fixes #241 

- Adds statistical codes for Instances based on `ITEM_CAT1` and `ITEM_CAT2` columns in the tsv
- Sets `discoverySuppress` property in Instance based on `CATALOG_SHADOW` column in tsv