### PR TITLE
Meta-programming to support MHLD 852 Map

### DIFF
--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -69,18 +69,30 @@ def _alt_get_legacy_ids(*args):
 
 def _wrap_additional_mapping(func):
     """
-    Decorator that moves the `permanentLocationId` property from the
-    holdingsStatements property to a top-level property in the Holdings
-    Record.
+    Decorator that moves the top-level properties from the holdingsStatements
+    in the Holdings Record.
     """
+    top_level_props = {
+        "callNumberTypeId",
+        "permanentLocationId",
+        "callNumber",
+        "callNumberPrefix",
+        "shelvingTitle",
+        "callNumberSuffix",
+        "copyNumber"
+    }
+
     def wrapper(*args, **kwargs):
         holdings_record = args[1]
-        if "permanentLocationId" not in holdings_record:
-            for statement in holdings_record.get("holdingsStatements", []):
-                if "permanentLocationId" in statement:
-                    holdings_record["permanentLocationId"] = statement.pop(
-                        "permanentLocationId"
-                    )
+        filtered_holdings = []
+        for statement in holdings_record.get("holdingsStatements", []):
+            existing_props = top_level_props.intersection(set(statement.keys()))
+            for prop in list(existing_props):
+                holdings_record[prop] = statement.pop(prop)
+            if len(statement) > 0:
+                filtered_holdings.append(statement)
+        if len(filtered_holdings) > 0:
+            holdings_record["holdingsStatements"] = filtered_holdings
         func(*args, **kwargs)
     return wrapper
 

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -67,7 +67,10 @@ def test_wrap_additional_mapping():
     @_wrap_additional_mapping
     def additional_mapping(placeholder, holding):
         assert holding["permanentLocationId"] == "baae3735-97c5-486d-9c6b-c87c41ae51ab"
+        assert holding["callNumberTypeId"] == "95467209-6d7b-468b-94df-0f5d7ad2747d"
+        assert holding["copyNumber"] == "1"
         assert "permanentLocationId" not in holding["holdingsStatements"]
+        assert len(holding["holdingsStatements"]) == 1
 
     incorrect_holding = {
         "holdingsStatements": [

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -11,7 +11,8 @@ from plugins.folio.holdings import (
     run_holdings_tranformer,
     run_mhld_holdings_transformer,
     boundwith_holdings,
-    _alt_get_legacy_ids
+    _alt_get_legacy_ids,
+    _wrap_additional_mapping,
 )
 
 from plugins.tests.mocks import (  # noqa
@@ -60,6 +61,25 @@ def test_electronic_holdings_missing_file(mock_dag_run, caplog):  # noqa
         f"Electronic Holdings /opt/airflow/migration/iterations/{mock_dag_run.run_id}/source_data/items/holdings-transformers.electronic.tsv does not exist"
         in caplog.text
     )
+
+
+def test_wrap_additional_mapping():
+    @_wrap_additional_mapping
+    def additional_mapping(placeholder, holding):
+        assert holding["permanentLocationId"] == "baae3735-97c5-486d-9c6b-c87c41ae51ab"
+        assert "permanentLocationId" not in holding["holdingsStatements"]
+
+    incorrect_holding = {
+        "holdingsStatements": [
+            {
+                "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+                "permanentLocationId": "baae3735-97c5-486d-9c6b-c87c41ae51ab",
+                "copyNumber": "1",
+            },
+            {"statement": "1988;1994;1999"},
+        ]
+    }
+    additional_mapping(None, incorrect_holding)
 
 
 def test_merge_update_holdings_no_holdings(
@@ -178,19 +198,19 @@ instances_holdings_items_map = {
                 "hrid": "ah123345_1",
                 "permanentLocationId": "0edeef57-074a-4f07-aee2-9f09d55e65c3",
                 "merged": False,
-                "items": []
+                "items": [],
             },
             "exyqdf123345": {
                 "hrid": "ah123345_2",
                 "permanentLocationId": "21b7083b-1013-440e-8e62-64169824dcb8",
                 "merged": False,
-                "items": []
+                "items": [],
             },
             "nweoasdf42425": {  # Stand-in for Electronic Holding
                 "hrid": "ah123345_3",
                 "permanentLocationId": "b0a1a8c3-cc9a-487c-a2ed-308fc3a49a91",
                 "merged": False,
-                "items": []
+                "items": [],
             },
         },
     }
@@ -285,15 +305,17 @@ def test_run_mhld_holdings_transformer(mock_file_system):  # noqa
     assert run_mhld_holdings_transformer
 
 
-def test_boundwith_holdings(mock_dag_run, mock_okapi_variable, mock_file_system):  # noqa
+def test_boundwith_holdings(
+    mock_dag_run, mock_okapi_variable, mock_file_system  # noqa
+):
     dag = mock_dag_run
 
     bw_tsv = mock_file_system[1] / "ckeys_.tsv.bwchild.tsv"
     mocks.messages["bib-files-group"] = {"bwchild-file": str(bw_tsv)}
 
-    bw_tsv_lines=[
+    bw_tsv_lines = [
         "CATKEY\tCALL_SEQ\tCOPY\tBARCODE\tLIBRARY\tHOMELOCATION\tCURRENTLOCATION\tITEM_TYPE\tITEM_CAT1\tITEM_CAT2\tITEM_SHADOW\tCALL_NUMBER_TYPE\tBASE_CALL_NUMBER\tVOLUME_INFO\tCALL_SHADOW\tFORMAT\tCATALOG_SHADOW",
-        "2956972\t2\t1\t36105127895816\tGREEN\tSEE-OTHER\tSEE-OTHER\tGOVSTKS\tBW-CHILD\t\t0\tSUDOC\tI\t29.9/5:148\t\t0\tMARC\t0"
+        "2956972\t2\t1\t36105127895816\tGREEN\tSEE-OTHER\tSEE-OTHER\tGOVSTKS\tBW-CHILD\t\t0\tSUDOC\tI\t29.9/5:148\t\t0\tMARC\t0",
     ]
 
     with bw_tsv.open("w+") as fo:
@@ -303,11 +325,16 @@ def test_boundwith_holdings(mock_dag_run, mock_okapi_variable, mock_file_system)
     holdings_json = mock_file_system[3] / "folio_holdings_boundwith.json"
 
     mock_folio_client = MockFOLIOClient(
-        locations=[{"id": "0edeef57-074a-4f07-aee2-9f09d55e65c3", "code": "GRE-SEE-OTHER"}]
+        locations=[
+            {"id": "0edeef57-074a-4f07-aee2-9f09d55e65c3", "code": "GRE-SEE-OTHER"}
+        ]
     )
 
     boundwith_holdings(
-        airflow=mock_file_system[0], dag_run=dag, folio_client=mock_folio_client, task_instance=MockTaskInstance()
+        airflow=mock_file_system[0],
+        dag_run=dag,
+        folio_client=mock_folio_client,
+        task_instance=MockTaskInstance(),
     )
 
     with holdings_json.open() as hld:
@@ -322,9 +349,9 @@ def test_boundwith_holdings(mock_dag_run, mock_okapi_variable, mock_file_system)
 
 def test_alt_get_legacy_ids():
     marc_record = pymarc.Record()
-    field_001 = pymarc.Field(tag='001', data='1964746')
+    field_001 = pymarc.Field(tag="001", data="1964746")
     marc_record.add_field(field_001)
-    field_852 = pymarc.Field(tag='852', subfields=['b', 'SAL3', 'c', 'PAGE-GR'])
+    field_852 = pymarc.Field(tag="852", subfields=["b", "SAL3", "c", "PAGE-GR"])
     marc_record.add_field(field_852)
     legacy_id = _alt_get_legacy_ids(None, None, marc_record)
     assert legacy_id == ["1964746 SAL3 PAGE-GR"]


### PR DESCRIPTION
This PR overrides the upstream `folio_migration_tools` package's `fix_853_bug_in_rules` method that was stripping out the 852 rule, subfield 'z' for setting a HoldingsStatement note that fixed a bug where the mapping was a creating a `permanentLocationId` property in the holdings statement. 

To fix now re-introduced bug, created a decorator function  `_wrap_additional_mapping`, that wraps the RuleMapperBase.perform_additional_mapping to move the `permanentLocationId` property to the top-level in the Holdings record. 

**NOTE** other changes are the result of running the Black code formatter and not intentional changes 🥲 