### PR TITLE
remove the specification of Ruby version from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 
 source 'https://rubygems.org'
 
-ruby '2.7.1'
-
 group :deployment do
   gem 'capistrano'
   gem 'capistrano-bundler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,5 @@ DEPENDENCIES
   capistrano-bundler
   dlss-capistrano
 
-RUBY VERSION
-   ruby 2.7.1p83
-
 BUNDLED WITH
-   2.2.31
+   2.4.6


### PR DESCRIPTION
Ruby is only used for Capistrano deployments, most if not all of us likely default to Ruby 3.x on our laptops, and the 2.7 branch of Ruby is EOL around now, see https://www.ruby-lang.org/en/downloads/branches/

> Ruby 2.7
>
> status: security maintenance
> release date: 2019-12-25
> normal maintenance until: 2022-04-01
> EOL: 2023-03-31 (expected)