### PR TITLE
upgrade postgres image specified in docker-compose.yml to same as used in deployed envs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,7 +99,7 @@ x-airflow-common:
 
 services:
   postgres:
-    image: postgres:13
+    image: postgres:14
     environment:
       POSTGRES_USER: airflow
       POSTGRES_PASSWORD: airflow


### PR DESCRIPTION
per https://github.com/sul-dlss/operations-tasks/issues/3336#issuecomment-1502247242 we're switching to ops managed PG instances, which are currently using PG v14.