### PR TITLE
Update dependencies with Github Action

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,37 @@
+name: Update Dependencies
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Update Poetry dependencies
+      run: |
+        git config user.name "dlss-infra-bot"
+        git config user.email "dlss-infrastructure-team-owner@lists.stanford.edu"
+        git checkout -b update-dependencies
+        pip install -r requirements.txt
+
+        # Update *only* the dependencies in the "main" section of pyproject.toml 
+        # so that apache-airflow (a test dependency) isn't upgraded. The
+        # apache-airflow version is managed by the Docker image.
+        poetry update --only main
+
+        # if something was committed push it and create a pull request
+        git commit -m "Updated Python dependencies" poetry.lock
+        if [ $? -eq 0 ]; then
+          git push origin update-dependencies
+          gh pr create --base main --head update-dependencies --title "Updated Python dependencies" --body "Updated Poetry dependencies via Github Action"
+        else
+          echo "No Python dependencies need updating"
+        fi


### PR DESCRIPTION
This Github Action will run every Monday at 3am UTC and use Poetry to update the "main" dependencies. If there are any changes it will use the github command line tool to create a "dependency updates" pull request.

Only dependencies in the "main" section of `pyproject.toml` are updated because `apache-airflow` is installed by the tests, and we are using an Airflow Docker image for deployment. If we let Poetry update `apache-airflow` it can potentially install a newer version on top of the one that we are using in the Docker container.

You can see a PR it created (as a test) here: https://github.com/sul-dlss/libsys-airflow/pull/315

Fixes #257
