### PR TITLE
Remove dependabot for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-


### PR DESCRIPTION
We use a diff GH workflow for updates now.