### PR TITLE
SQLAlchemy Models for Datamanagement App Plugin

### DIFF
--- a/libsys_airflow/plugins/data_loading_management/data_loading.py
+++ b/libsys_airflow/plugins/data_loading_management/data_loading.py
@@ -1,0 +1,24 @@
+from airflow.models import Variable
+
+from flask_appbuilder import expose, BaseView as AppBuilderBaseView
+from flask import flash, request, redirect, Response
+from folioclient import FolioClient
+
+class DataManagementView(AppBuilderBaseView):
+    default_view = "data_home"
+    route_base = "/data_management"
+
+    def __init__(self, *args, **kwargs):
+        self.folio_client = kwargs.get("folio_client")
+        if self.folio_client is None:
+            self.folio_client = FolioClient(
+                Variable.get("okapi_url"),
+                "sul",
+                Variable.get("folio_user"),
+                Variable.get("folio_password")
+            )
+        super().__init__(*args, **kwargs)
+
+    @expose("/")
+    def data_home(self):
+        return self.render_template("index.html")

--- a/libsys_airflow/plugins/data_loading_management/main.py
+++ b/libsys_airflow/plugins/data_loading_management/main.py
@@ -2,7 +2,8 @@ from airflow.plugins_manager import AirflowPlugin
 from flask import Blueprint
 
 from plugins.data_loading_management.data_loading import DataManagementView
-from plugins.data_loading_management.vendors import VendorsView
+from plugins.data_loading_management.vendors import OrganizationView
+
 
 data_load_mgt_bp = Blueprint(
     "data_loading_management",
@@ -21,13 +22,12 @@ data_mg_view_package = {
 }
 
 # Vendor Management
-vendor_index_view = VendorsView()
+vendor_index_view = OrganizationView()
 vendor_index_view_package = {
     "name": "Vendor Management",
     "category": "Data Loading Management",
     "view": vendor_index_view,
 }
-
 
 
 class VendorDataManagementPlugin(AirflowPlugin):

--- a/libsys_airflow/plugins/data_loading_management/main.py
+++ b/libsys_airflow/plugins/data_loading_management/main.py
@@ -1,0 +1,41 @@
+from airflow.plugins_manager import AirflowPlugin
+from flask import Blueprint
+
+from plugins.data_loading_management.data_loading import DataManagementView
+from plugins.data_loading_management.vendors import VendorsView
+
+data_load_mgt_bp = Blueprint(
+    "data_loading_management",
+    __name__,
+    template_folder="templates",
+    static_folder="static",
+    static_url_path="/static/data_loading_management"
+)
+
+# Data management
+data_mgt_view = DataManagementView()
+data_mg_view_package = {
+    "name": "Data Loading Home",
+    "category": "Data Loading Management",
+    "view": data_mgt_view
+}
+
+# Vendor Management
+vendor_index_view = VendorsView()
+vendor_index_view_package = {
+    "name": "Vendor Management",
+    "category": "Data Loading Management",
+    "view": vendor_index_view,
+}
+
+
+
+class VendorDataManagementPlugin(AirflowPlugin):
+    name = "DataLoadingManagement"
+    operators = []
+    flask_blueprints = [data_load_mgt_bp]
+    hooks = []
+    executors = []
+    admin_views = []
+    appbuilder_views = [data_mg_view_package, vendor_index_view_package]
+    appbuilder_menu_items = []

--- a/libsys_airflow/plugins/data_loading_management/models.py
+++ b/libsys_airflow/plugins/data_loading_management/models.py
@@ -1,0 +1,77 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Text
+from sqlalchemy.orm import declarative_base, relationship, Session
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+
+Model = declarative_base()
+
+class Organization(Model):
+    __tablename__ = "organization"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(50), unique=True, nullable=False)
+    uuid = Column(String(36), unique=True, nullable=False)
+    last_folio_update = Column(DateTime, nullable=False)
+
+    def __repr__(self) -> str:
+        return f"{self.name} - {self.uuid}"
+
+
+class Interface(Model):
+    __tablename__ = "interface"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(50), nullable=False)
+    uuid = Column(String(36), unique=True, nullable=False)
+    file_regex = Column(String(35))
+    job_profile_uuid = Column(String(36), nullable=False)
+    last_folio_update = Column(DateTime, nullable=False)
+    vendor_id = Column(Integer, ForeignKey("organization.id"))
+    vendor = relationship("plugins.data_loading_management.models.Organization")
+
+    def __repr__(self) -> str:
+        return f"{self.name} - {self.uuid}"
+
+
+class JobStatus(Model):
+    __tablename__ = "job_status"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(50), unique=True, nullable=False)
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+class JobRun(Model):
+    __tablename__ = "job_run"
+
+    id = Column(Integer, primary_key=True)
+    dag_run_id = Column(String(40), nullable=False)
+    update = Column(DateTime, nullable=False)
+    interface_id = Column(Integer, ForeignKey("interface.id"))
+    interface = relationship("plugins.data_loading_management.models.Interface")
+    status_id = Column(Integer, ForeignKey("job_status.id"))
+    status = relationship("plugins.data_loading_management.models.JobStatus")
+
+    def __repr__(self) -> str:
+        return self.dag_run_id
+    
+
+class File(Model):
+    __tablename__ = "file"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(40), nullable=False)
+    path = Column(Text, nullable=False)
+    size = Column(Integer, nullable=False)
+    md5 = Column(String(36), nullable=False)
+    job_run_id = Column(Integer, ForeignKey("job_run.id"))
+    job_run = relationship("plugins.data_loading_management.models.JobRun")
+
+    def __repr__(self) -> str:
+        return self.name
+    
+
+pg_hook = PostgresHook("dataloading_app")
+
+Model.metadata.create_all(pg_hook.get_sqlalchemy_engine())

--- a/libsys_airflow/plugins/data_loading_management/templates/index.html
+++ b/libsys_airflow/plugins/data_loading_management/templates/index.html
@@ -1,0 +1,10 @@
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+<h1>Data Loading Management</h1>
+<hr>
+<h3>Your data loads</h3>
+<hr>
+<h3>System Status</h3>
+
+{% endblock %}

--- a/libsys_airflow/plugins/data_loading_management/templates/vendors.html
+++ b/libsys_airflow/plugins/data_loading_management/templates/vendors.html
@@ -4,19 +4,19 @@
 <h1>Vendor Management</h1>
 <table class="table table-striped">
     <thead>
+        <th>ID</th>
         <th>Name</th>
-        <th>Status</th>
         <th>Last Scheduled Job</th>
     </thead>
     <tbody>
-        {% for vendor in vendors.organizations %}
+        {% for vendor in vendors %}
         <tr>
             <td>
-                {{ vendor.name }}<br>
-                ID: {{ vendor.id }}
+                {{ vendor.id }}
             </td>
             <td>
-                {{ vendor.status }}
+                {{ vendor.name }}<br>
+                FOLIO UUID: {{ vendor.uuid }}
             </td>
             <td>
                 TBD

--- a/libsys_airflow/plugins/data_loading_management/templates/vendors.html
+++ b/libsys_airflow/plugins/data_loading_management/templates/vendors.html
@@ -1,0 +1,34 @@
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+<h1>Vendor Management</h1>
+<table class="table table-striped">
+    <thead>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Last Scheduled Job</th>
+    </thead>
+    <tbody>
+        {% for vendor in vendors.organizations %}
+        <tr>
+            <td>
+                {{ vendor.name }}<br>
+                ID: {{ vendor.id }}
+            </td>
+            <td>
+                {{ vendor.status }}
+            </td>
+            <td>
+                TBD
+            </td>
+            <td>
+                <div class="btn-group">
+                    <button class="btn btn-primary">Load Data</button>
+                    <button class="btn btn-danger">Disable</button>
+                </div>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/libsys_airflow/plugins/data_loading_management/vendors.py
+++ b/libsys_airflow/plugins/data_loading_management/vendors.py
@@ -1,0 +1,38 @@
+import requests
+
+from airflow.models import Variable
+
+from flask_appbuilder import expose, BaseView as AppBuilderBaseView
+from flask import flash, request, redirect, Response
+from folioclient import FolioClient
+
+class VendorsView(AppBuilderBaseView):
+    default_view = "vendors_index"
+    route_base = "/vendors_management"
+
+    def __init__(self, *args, **kwargs):
+        self.folio_client = kwargs.get("folio_client")
+        if self.folio_client is None:
+            self.folio_client = FolioClient(
+                Variable.get("okapi_url"),
+                "sul",
+                Variable.get("folio_user"),
+                Variable.get("folio_password")
+            )
+        super().__init__(*args, **kwargs)
+
+    def _get_vendors(self):
+        """
+        Returns vendors from FOLIO
+        """
+        cql_query = "(((code=YANKEE-SUL*) or (code=Harrassowitz*) or (code=CASALI-SUL*)))"
+        vendor_result = requests.get(
+            f"{self.folio_client.okapi_url}/organizations-storage/organizations?query={cql_query}",
+            headers=self.folio_client.okapi_headers)
+        vendor_result.raise_for_status()
+        return vendor_result.json()
+
+    @expose("/")
+    def vendors_index(self):
+        vendors = self._get_vendors()
+        return self.render_template("vendors.html", vendors=vendors)

--- a/libsys_airflow/plugins/data_loading_management/vendors.py
+++ b/libsys_airflow/plugins/data_loading_management/vendors.py
@@ -1,12 +1,24 @@
+import logging
 import requests
 
 from airflow.models import Variable
+from airflow.providers.postgres.hooks.postgres import PostgresHook
 
-from flask_appbuilder import expose, BaseView as AppBuilderBaseView
+from flask_appbuilder import expose, ModelView, BaseView as AppBuilderBaseView
+from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask import flash, request, redirect, Response
 from folioclient import FolioClient
 
-class VendorsView(AppBuilderBaseView):
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from plugins.data_loading_management.models import Organization, Interface
+
+logger = logging.getLogger(__name__)
+
+class InterfaceView(ModelView):
+    datamodel=SQLAInterface(Interface)
+
+class OrganizationView(AppBuilderBaseView):
     default_view = "vendors_index"
     route_base = "/vendors_management"
 
@@ -25,14 +37,47 @@ class VendorsView(AppBuilderBaseView):
         """
         Returns vendors from FOLIO
         """
-        cql_query = "(((code=YANKEE-SUL*) or (code=Harrassowitz*) or (code=CASALI-SUL*)))"
-        vendor_result = requests.get(
-            f"{self.folio_client.okapi_url}/organizations-storage/organizations?query={cql_query}",
-            headers=self.folio_client.okapi_headers)
-        vendor_result.raise_for_status()
-        return vendor_result.json()
+        pg_hook = PostgresHook("dataloading_app")
+        vendors_stmt = select(Organization).order_by(Organization.name)
+        vendors = []
+        with Session(pg_hook.get_sqlalchemy_engine()) as session:
+            for vendor in session.execute(vendors_stmt).scalars():
+                vendors.append( {"id": vendor.id,
+                                 "uuid": vendor.uuid,
+                                 "name": vendor.name,
+                                 "last_updated": vendor.last_folio_update })
+        return vendors
+
 
     @expose("/")
     def vendors_index(self):
         vendors = self._get_vendors()
         return self.render_template("vendors.html", vendors=vendors)
+
+
+    @expose("/retrieve")
+    def vendor_retrival(self):
+        """
+        Retrieves specific vendors from FOLIO and adds/updates to Database
+        """
+        cql_query = "(((code=YANKEE-SUL*) or (code=Harrassowitz*) or (code=CASALI-SUL*)))"
+        vendor_result = requests.get(
+            f"{self.folio_client.okapi_url}/organizations-storage/organizations?query={cql_query}",
+            headers=self.folio_client.okapi_headers)
+        vendor_result.raise_for_status()
+        
+        update_vendors = []
+        for vendor in vendor_result.json().get('organizations', []):
+            update_vendors.append(
+                Organization(name=vendor['name'],
+                                uuid=vendor['id'],
+                                last_folio_update=vendor['metadata']['updatedDate'])
+            )
+        pg_hook = PostgresHook("dataloading_app")
+        with Session(pg_hook.get_sqlalchemy_engine()) as session:
+            session.add_all(update_vendors)
+            session.commit()
+        return f"Added/Updated {len(update_vendors)}"
+
+    
+


### PR DESCRIPTION
Taking a slightly different approach, this branch uses a new database ( running as a separate "database" within the Postgres Airflow Postgres environment) with ORM models for Organizations, Interfaces, JobRuns, Files, and JobStatus for managing the state of data loading. 

Would like to be able to use the [Flask Appbuilder](https://flask-appbuilder.readthedocs.io/en/latest/quickhowto.html) to build not only the Models but the CRUD views as well but was getting an error trying to run under Airflow. Instead, just uses the plain SQLAlchemy Models but could also look to use the [Flask SQLAlchmey](https://flask-sqlalchemy.palletsprojects.com/) for better integration with the plugin.