### PR TITLE
Initial vendor management plugin config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -69,6 +69,7 @@ x-airflow-common:
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server
     # yamllint enable rule:line-length
     AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK: 'true'
+    AIRFLOW__WEBSERVER__RELOAD_ON_PLUGIN_CHANGE: 'true'
     AIRFLOW_VAR_AEON_URL: ${AIRFLOW_VAR_AEON_URL}
     AIRFLOW_VAR_AEON_KEY: ${AIRFLOW_VAR_AEON_KEY}
     AIRFLOW_VAR_AEON_SOURCE_QUEUE_ID: ${AIRFLOW_VAR_AEON_SOURCE_QUEUE_ID}

--- a/libsys_airflow/plugins/vendor/main.py
+++ b/libsys_airflow/plugins/vendor/main.py
@@ -1,0 +1,31 @@
+from airflow.plugins_manager import AirflowPlugin
+from flask import Blueprint
+
+from plugins.vendor.vendors import VendorManagementView
+
+vendor_mgt_bp = Blueprint(
+    "vendor_management",
+    __name__,
+    template_folder="templates",
+    static_folder="static",
+    static_url_path="/static/vendor"
+)
+
+# Vendor Management
+vendor_index_view = VendorManagementView()
+vendor_index_view_package = {
+    "name": "Vendors",
+    "category": "Vendor Management",
+    "view": vendor_index_view,
+}
+
+
+class VendorManagementPlugin(AirflowPlugin):
+    name = "Vendor Management"
+    operators = []
+    flask_blueprints = [vendor_mgt_bp]
+    hooks = []
+    executors = []
+    admin_views = []
+    appbuilder_views = [vendor_index_view_package]
+    appbuilder_menu_items = []

--- a/libsys_airflow/plugins/vendor/templates/index.html
+++ b/libsys_airflow/plugins/vendor/templates/index.html
@@ -1,0 +1,14 @@
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+<h1>Vendors</h1>
+<table class="table table-striped">
+    <thead>
+        <th>Name</th>
+        <th>Code</th>
+        <th>Acquisitions Unit</th>
+    </thead>
+    <tbody>
+    </tbody>
+</table>
+{% endblock %}

--- a/libsys_airflow/plugins/vendor/vendors.py
+++ b/libsys_airflow/plugins/vendor/vendors.py
@@ -1,0 +1,14 @@
+import requests
+
+from airflow.models import Variable
+
+from flask_appbuilder import expose, BaseView as AppBuilderBaseView
+
+
+class VendorManagementView(AppBuilderBaseView):
+    default_view = "vendors_index"
+    route_base = "/vendor"
+
+    @expose("/")
+    def vendors_index(self):
+        return self.render_template("index.html")

--- a/tests/apps/test_vendor_management_view.py
+++ b/tests/apps/test_vendor_management_view.py
@@ -1,0 +1,7 @@
+import pytest
+
+from plugins.vendor.vendors import VendorManagementView
+
+def test_vendor_management_view():
+    vendor_management_app = VendorManagementView()
+    assert vendor_management_app


### PR DESCRIPTION
Partially addresses #332 to set up a vendor management plugin. Does not retrieve organizations from FOLIO yet. 

<img width="1749" alt="Screenshot 2023-04-27 at 12 01 24 PM" src="https://user-images.githubusercontent.com/1619369/234965450-591f5559-e5ab-4e47-a917-332fbbed6b88.png">
