### PR TITLE
Expose the postgresql ports so we can access the database if needed

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,6 +104,8 @@ services:
       POSTGRES_USER: airflow
       POSTGRES_PASSWORD: airflow
       POSTGRES_DB: airflow
+    ports:
+      - 5432:5432
     volumes:
       - postgres-db-volume:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
Small change. No reason to avoid exposing the database ports for the dev side so we can look at the DB if we need to.