### PR TITLE
Add a db init script to create multiple dbs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,11 +103,12 @@ services:
     environment:
       POSTGRES_USER: airflow
       POSTGRES_PASSWORD: airflow
-      POSTGRES_DB: airflow
+      POSTGRES_MULTIPLE_DATABASES: airflow,vendor_loads
     ports:
       - 5432:5432
     volumes:
       - postgres-db-volume:/var/lib/postgresql/data
+      - ./docker/init-multi-postgres-dbs.sh:/docker-entrypoint-initdb.d/init-multi-postgres-dbs.sh
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "airflow"]
       interval: 5s

--- a/docker/init-multi-postgres-dbs.sh
+++ b/docker/init-multi-postgres-dbs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non zero status
+set -e
+# Treat unset variables as an error when substituting
+set -u
+
+function create_database() {
+    database=$1
+    echo "Creating database '$database'"
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+      SELECT 'CREATE DATABASE $database' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$database')\gexec
+      GRANT ALL PRIVILEGES ON DATABASE $database TO $POSTGRES_USER;
+EOSQL
+}
+
+
+if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
+  echo "Multiple database creation requested: $POSTGRES_MULTIPLE_DATABASES"
+	for db in $(echo $POSTGRES_MULTIPLE_DATABASES | tr ',' ' '); do
+		create_database $db
+	done
+	echo "Multiple databases created!"
+fi


### PR DESCRIPTION
The updates the postgres container startup (for local development) so that it creates both the airflow database as well as the vendor_loads database for our vendor management application needs.