### PR TITLE
Vendor Load: Establish pattern for model development and initial database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Using and developing the vendor load plugin requires a dedicated database. Ensur
 
 #### Database migrations
 
-Until a proper databse migration process is established changing models requires removing the existing tables so **data is lost on changes**. 
+Until a proper database migration process is established, changing models requires removing the existing tables so **data is lost on changes**. 
 
 1. Add a connection in airflow:
   1. Connection Id: vendor_load

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ database being used by Okapi.
 
 ### Vendor load plugin
 
-Using and developing the vendor load plug in requires it's own database. Ensure that the `vendor_laods` database exists in your local postgres and is owned by the airflow user.
+Using and developing the vendor load plugin requires a dedicated database. Ensure that the `vendor_loads` database exists in your local postgres and is owned by the airflow user.
 
 #### Database migrations
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,28 @@ The `optimistic_locking_management` DAG requires a Postgres Airflow
 [connection](https://airflow.apache.org/docs/apache-airflow/stable/concepts/connections.html) with the host, login, and password fields matching the
 database being used by Okapi.
 
+## Development
+
+### Vendor load plugin
+
+Using and developing the vendor load plug in requires it's own database. Ensure that the `vendor_laods` database exists in your local postgres and is owned by the airflow user.
+
+#### Database migrations
+
+Until a proper databse migration process is established changing models requires removing the existing tables so **data is lost on changes**. 
+
+1. Add a connection in airflow:
+  1. Connection Id: vendor_load
+  2. Host: postgres
+  3. Schema: vendor_loads
+  4. Login: airflow
+  5. Password: airflow
+  6. Port: 5432
+2. Enable the `vendor_load_db_init` DAG
+2. Run the `vendor_load_db_init` DAG from the airflow interface or command line with: `docker compose run --rm airflow-webserver airflow dags trigger vendor_load_db_init`
+
+**Note:** The docker compose method inconsistently reports that the DAG is not found. In that case, run the DAG manually in the UI.
+
 ## Testing
 1. Install dependencies per `Dependency Management and Packaging` above
 1. Drop into the poetry virtual environment: `poetry shell` (alternatively, if you don't want to drop into `poetry shell`, you can run commands using `poetry run my_cmd`, akin to `bundle exec my_cmd`)

--- a/libsys_airflow/dags/vendor_db_init.py
+++ b/libsys_airflow/dags/vendor_db_init.py
@@ -1,0 +1,40 @@
+import logging
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.models import Variable
+from airflow.operators.python import PythonOperator
+
+from plugins.vendor.models import dbinit
+
+logger = logging.getLogger(__name__)
+
+
+default_args = {
+    "owner": "folio",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+
+with DAG(
+    "vendor_load_db_init",
+    default_args=default_args,
+    schedule_interval=None,
+    start_date=datetime(2023, 2, 22),
+    catchup=False,
+    tags=["vendor load", "database"],
+    max_active_runs=1,
+) as dag:
+
+    initialize_vendor_load_db = PythonOperator(
+        task_id="initialize-vendor-load-db",
+        python_callable=dbinit,
+        op_kwargs={},
+    )
+
+    initialize_vendor_load_db

--- a/libsys_airflow/plugins/vendor/models.py
+++ b/libsys_airflow/plugins/vendor/models.py
@@ -4,6 +4,7 @@ from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 Model = declarative_base()
 
+
 class Vendor(Model):
     __tablename__ = "vendors"
 

--- a/libsys_airflow/plugins/vendor/models.py
+++ b/libsys_airflow/plugins/vendor/models.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Text, Boolean
+from sqlalchemy.orm import declarative_base, relationship, Session
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+
+Model = declarative_base()
+
+class Vendor(Model):
+    __tablename__ = "vendors"
+
+    id = Column(Integer, primary_key=True)
+    display_name = Column(String(50), unique=True, nullable=False)
+    folio_organization_uuid = Column(String(36), unique=True, nullable=False)
+    vendor_code_from_folio = Column(String(36), unique=True, nullable=False)
+    acquisitions_unit_from_folio = Column(String(36), unique=False, nullable=False)
+    has_active_vendor_interfaces = Column(Boolean, nullable=False, default=False)
+    last_folio_update = Column(DateTime, nullable=False)
+
+    def __repr__(self) -> str:
+        return f"{self.name} - {self.uuid}"
+
+
+def dbinit():
+    pg_hook = PostgresHook("vendor_load")
+    Model.metadata.drop_all(pg_hook.get_sqlalchemy_engine())
+    Model.metadata.create_all(pg_hook.get_sqlalchemy_engine())


### PR DESCRIPTION
The goal of this PR is to setup an initial model that may be used as a pattern for the additional model tickets to follow this. The database migration/initializations here should be considered temporary until a proper migration strategy can be implemented.

Until #344 is merged, you will need to manually create the database in postgres with airflow as the owner.