### PR TITLE
Vendor Load: Setting up list of vendors from FOLIO

### DIFF
--- a/libsys_airflow/plugins/vendor/templates/index.html
+++ b/libsys_airflow/plugins/vendor/templates/index.html
@@ -9,6 +9,20 @@
         <th>Acquisitions Unit</th>
     </thead>
     <tbody>
+        {% for vendor in vendors.organizations %}
+        <tr>
+            <td>
+                {{ vendor.name }}<br>
+                ID: {{ vendor.id }}
+            </td>
+            <td>
+                {{ vendor.code }}
+            </td>
+            <td>
+                {{ vendor.acqUnitIds[0] }}
+            </td>
+        </tr>
+        {% endfor %}
     </tbody>
 </table>
 {% endblock %}

--- a/libsys_airflow/plugins/vendor/vendors.py
+++ b/libsys_airflow/plugins/vendor/vendors.py
@@ -1,3 +1,5 @@
+from folioclient import FolioClient
+import logging
 import requests
 
 from airflow.models import Variable
@@ -5,10 +7,39 @@ from airflow.models import Variable
 from flask_appbuilder import expose, BaseView as AppBuilderBaseView
 
 
+logger = logging.getLogger(__name__)
+
+
 class VendorManagementView(AppBuilderBaseView):
     default_view = "vendors_index"
-    route_base = "/vendor"
+    route_base = "/vendors"
+
+    @property
+    def _folio_client(self):
+        try:
+            return FolioClient(
+                Variable.get("okapi_url"),
+                "sul",
+                Variable.get("folio_user"),
+                Variable.get("folio_password")
+            )
+        except ValueError as error:
+            logger.error(error)
+            raise
+
+    def _get_vendors(self):
+        """
+        Returns vendors from FOLIO
+        """
+        vendors = ["AMALIV-SUL", "CASALI-SUL", "COUTTS-SUL", "HARRAS-SUL", "SFX", "YANKEE-SUL"]
+        cql_query = f"({' or '.join(f'(code={vendor})' for vendor in vendors)})"
+        vendor_result = requests.get(
+            f"{self._folio_client.okapi_url}/organizations-storage/organizations?query={cql_query}",
+            headers=self._folio_client.okapi_headers)
+        vendor_result.raise_for_status()
+        return vendor_result.json()
 
     @expose("/")
     def vendors_index(self):
-        return self.render_template("index.html")
+        vendors = self._get_vendors()
+        return self.render_template("index.html", vendors=vendors)

--- a/tests/apps/test_vendor_management_view.py
+++ b/tests/apps/test_vendor_management_view.py
@@ -1,7 +1,35 @@
 import pytest
+from pytest_mock import MockerFixture
+import requests
 
 from plugins.vendor.vendors import VendorManagementView
+from tests.mocks import mock_okapi_variable, MockFOLIOClient
 
-def test_vendor_management_view():
+
+@pytest.fixture
+def mock_okapi_requests(monkeypatch, mocker: MockerFixture):
+    def mock_get(*args, **kwargs):
+        get_response = mocker.stub(name="get_vendors")
+        get_response.status_code = 200
+        get_response.raise_for_status = lambda: {}
+        get_response.json = lambda: {
+            "organizations": [{"id": "d558cce0-cb4b-4f28-aad3-c94c7084b2e3",
+                               "name": "MarcMarcMarc",
+                               "code": "MMM"}]}
+        return get_response
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+
+@pytest.fixture
+def mock_get_folio_client(monkeypatch):
+    def mock_folio_client():
+        folio_client = MockFOLIOClient()
+        return folio_client
+
+    monkeypatch.setattr(VendorManagementView, "_folio_client", mock_folio_client)
+
+
+def test_vendor_management_view(mock_okapi_variable, mock_okapi_requests, mock_get_folio_client):
     vendor_management_app = VendorManagementView()
     assert vendor_management_app


### PR DESCRIPTION
Further work on #332. This sets up data in the vendor page, but is pulling from live Folio until the database vendor table is available. 

![Screenshot 2023-05-01 at 11 03 24 AM](https://user-images.githubusercontent.com/1619369/235489539-7d8065f6-9cdd-4f54-b311-a78a143917ac.png)
