### PR TITLE
Use libsys_airflow module everywhere

### DIFF
--- a/airflow.cfg
+++ b/airflow.cfg
@@ -1,2 +1,6 @@
+[core]
+dags_folder = /opt/airflow/libsys_airflow/dags
+plugins_folder = /opt/airflow/libsys_airflow/plugins
+
 [webserver]
 warn_deployment_exposure = False

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -83,9 +83,8 @@ x-airflow-common:
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
   volumes:
-    - ${AIRFLOW_PROJ_DIR:-.}/libsys_airflow/dags:/opt/airflow/dags
+    - ${AIRFLOW_PROJ_DIR:-.}/libsys_airflow:/opt/airflow/libsys_airflow
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
-    - ${AIRFLOW_PROJ_DIR:-.}/libsys_airflow/plugins:/opt/airflow/plugins
     - ${AIRFLOW_PROJ_DIR:-.}/symphony:/opt/airflow/symphony
     - ${AIRFLOW_PROJ_DIR:-.}/migration:/opt/airflow/migration
     - ${AIRFLOW_PROJ_DIR:-.}/circ:/opt/airflow/circ

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -84,9 +84,8 @@ x-airflow-common:
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
   volumes:
-    - ${AIRFLOW_PROJ_DIR:-.}/libsys_airflow/dags:/opt/airflow/dags
+    - ${AIRFLOW_PROJ_DIR:-.}/libsys_airflow:/opt/airflow/libsys_airflow
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
-    - ${AIRFLOW_PROJ_DIR:-.}/libsys_airflow/plugins:/opt/airflow/plugins
     - ${AIRFLOW_PROJ_DIR:-.}/symphony:/opt/airflow/symphony
     - ${AIRFLOW_PROJ_DIR:-.}/migration:/opt/airflow/migration
     - ${AIRFLOW_PROJ_DIR:-.}/circ:/opt/airflow/circ

--- a/libsys_airflow/conftest.py
+++ b/libsys_airflow/conftest.py
@@ -1,9 +1,0 @@
-# needed to import packages in the plugin
-
-import pathlib
-import sys
-
-root_directory = pathlib.Path(__file__).parent
-plugins_directory = root_directory / "plugins"
-
-sys.path.append(str(plugins_directory))

--- a/libsys_airflow/dags/vendor/data_fetcher.py
+++ b/libsys_airflow/dags/vendor/data_fetcher.py
@@ -8,10 +8,10 @@ from airflow.models.param import Param
 from airflow.operators.python import get_current_context
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
-from plugins.airflow.connections import create_connection_task
-from plugins.vendor.download import ftp_download_task
-from plugins.vendor.archive import archive_task
-from plugins.vendor.paths import download_path, archive_path
+from libsys_airflow.plugins.airflow.connections import create_connection_task
+from libsys_airflow.plugins.vendor.download import ftp_download_task
+from libsys_airflow.plugins.vendor.archive import archive_task
+from libsys_airflow.plugins.vendor.paths import download_path, archive_path
 
 logger = logging.getLogger(__name__)
 

--- a/libsys_airflow/dags/vendor/default_data_processor.py
+++ b/libsys_airflow/dags/vendor/default_data_processor.py
@@ -7,9 +7,9 @@ from airflow.decorators import task
 from airflow.models.param import Param
 from airflow.operators.python import get_current_context
 
-from plugins.vendor.marc import filter_fields_task, batch_task
-from plugins.vendor.paths import download_path
-from plugins.folio.data_import import data_import_task
+from libsys_airflow.plugins.vendor.marc import filter_fields_task, batch_task
+from libsys_airflow.plugins.vendor.paths import download_path
+from libsys_airflow.plugins.folio.data_import import data_import_task
 
 logger = logging.getLogger(__name__)
 

--- a/libsys_airflow/plugins/airflow/connections.py
+++ b/libsys_airflow/plugins/airflow/connections.py
@@ -5,7 +5,7 @@ from airflow.decorators import task
 from sqlalchemy.orm.session import Session
 from airflow.utils.session import NEW_SESSION, provide_session
 
-from plugins.folio.interface import interface_info
+from libsys_airflow.plugins.folio.interface import interface_info
 
 logger = logging.getLogger(__name__)
 

--- a/libsys_airflow/plugins/folio/data_import.py
+++ b/libsys_airflow/plugins/folio/data_import.py
@@ -4,7 +4,7 @@ import os
 from airflow.models import Variable
 from airflow.decorators import task
 
-from plugins.folio.folio_client import FolioClient
+from libsys_airflow.plugins.folio.folio_client import FolioClient
 
 logger = logging.getLogger(__name__)
 

--- a/libsys_airflow/plugins/folio/interface.py
+++ b/libsys_airflow/plugins/folio/interface.py
@@ -2,7 +2,7 @@ import logging
 
 from airflow.models import Variable
 
-from plugins.folio.folio_client import FolioClient
+from libsys_airflow.plugins.folio.folio_client import FolioClient
 
 logger = logging.getLogger(__name__)
 

--- a/libsys_airflow/plugins/folio/main.py
+++ b/libsys_airflow/plugins/folio/main.py
@@ -1,8 +1,8 @@
 from airflow.plugins_manager import AirflowPlugin
 from flask import Blueprint
-from plugins.folio.apps.circ_rules_tester_view import CircRulesTester
-from plugins.folio.apps.healthcheck_view import Healthcheck
-from plugins.folio.apps.folio_migration_view import FOLIOMigrationReports
+from libsys_airflow.plugins.folio.apps.circ_rules_tester_view import CircRulesTester
+from libsys_airflow.plugins.folio.apps.healthcheck_view import Healthcheck
+from libsys_airflow.plugins.folio.apps.folio_migration_view import FOLIOMigrationReports
 
 
 bp = Blueprint(

--- a/libsys_airflow/plugins/vendor_app/main.py
+++ b/libsys_airflow/plugins/vendor_app/main.py
@@ -1,7 +1,7 @@
 from airflow.plugins_manager import AirflowPlugin
 from flask import Blueprint
 
-from plugins.vendor_app.vendors import VendorManagementView
+from libsys_airflow.plugins.vendor_app.vendors import VendorManagementView
 
 vendor_mgt_bp = Blueprint(
     "vendor_management",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = --cov=libsys_airflow --cov=plugins --cov-report=xml --cov-report=term
+addopts = --cov=libsys_airflow --cov-report=xml --cov-report=term
 
 [flake8]
 exclude = vendor_loads_migration

--- a/tests/apps/vendor_app/test_vendor_management_view.py
+++ b/tests/apps/vendor_app/test_vendor_management_view.py
@@ -2,7 +2,7 @@ import pytest
 from pytest_mock import MockerFixture
 import requests
 
-from plugins.vendor_app.vendors import VendorManagementView
+from libsys_airflow.plugins.vendor_app.vendors import VendorManagementView
 from tests.mocks import mock_okapi_variable, MockFOLIOClient
 
 


### PR DESCRIPTION
This spike adapts the Docker containers to mount the `libsys_airflow` module as a volume in `/opt/airflow/` and then uses Airflow's `dags_folder` and `plugins_folder` in the `airflow.cfg` to point to the relevant locations. It also updates the remaining places that were doing an `import plugins` to `import libsys_airflow.plugins` instead.

The benefit of this approach is that our test code can import from `libsys_airflow` just like any code in `libsys_airflow` that needs to import from the root module. We could put `dags` and `plugins` at the top level, but I think it's nice to have our airflow code in a named module?
