### PR TITLE
Update black github action and provide an easy way to fix black formatter violations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,12 @@
+# github action workflow to run black formatter check and linting checks for our python code
+
 name: Lint
 
-on: workflow_dispatch
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,9 @@ name: Folio Airflow CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -15,22 +15,22 @@ jobs:
   build:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-    - name: Install Airflow + dependencies
-      run: |
-        pip install -r requirements.txt
-        poetry install
-    - name: Lint with flake8
-      run: |
-        cd libsys_airflow
-        poetry run flake8 --ignore=E225,E501,F401,F811,W503 dags/ plugins/
-    - name: Test with pytest
-      run: |
-        poetry run airflow db init
-        poetry run pytest -rP
-        poetry run coverage lcov
-        poetry run coveralls --service=github
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install Airflow + dependencies
+        run: |
+          pip install -r requirements.txt
+          poetry install
+      - name: Lint with flake8
+        run: |
+          cd libsys_airflow
+          poetry run flake8 --ignore=E203,E225,E501,F401,F811,W503 dags/ plugins/
+      - name: Test with pytest
+        run: |
+          poetry run airflow db init
+          poetry run pytest -rP
+          poetry run coverage lcov
+          poetry run coveralls --service=github

--- a/README.md
+++ b/README.md
@@ -174,8 +174,21 @@ PYTHONPATH=. AIRFLOW_VAR_FOLIO_USER=<APP_USER> AIRFLOW_VAR_FOLIO_PASSWORD=<APP_U
 1. Install dependencies per `Dependency Management and Packaging` above
 1. Drop into the poetry virtual environment: `poetry shell` (alternatively, if you don't want to drop into `poetry shell`, you can run commands using `poetry run my_cmd`, akin to `bundle exec my_cmd`)
 
-Run the black formatter:
-`black .`
+### Black (Python formatter)
+
+The github action has been configured to fail if there are any violations (see `pyproject.toml`)
+
+To run the black formatter to show violations and their details:
+`black .` # if in the poetry shell
+`poetry run black .`
+
+Note that the builds merged to main will fail if there are black violations due to the lint github action.
+
+To use black to address formatting violations:
+`black --config blackupdate.toml .` # if in the poetry shell
+`poetry run black --config blackupdate.toml .`
+
+### Flake8 (Python linter)
 
 Run the flake8 linter:
 `flake8 libsys_airflow/` (_Note_: As of 2023-04-13, the `--ignore=E225,E501,F401,F811,W503` option is given in CI; you may want to do similarly to see the lint warnings that'll actually fail CI. See `Lint with flake8` `build` step in `.github/workflows/python-app.yml` for current invocation.)

--- a/blackupdate.toml
+++ b/blackupdate.toml
@@ -1,0 +1,7 @@
+# these options for black will address any violations found
+[tool.black]
+line-length = 88
+target-version = ['py310']
+include = '\.pyi?$'
+exclude = 'vendor_loads_migration'
+skip-string-normalization = true

--- a/libsys_airflow/plugins/folio/instances.py
+++ b/libsys_airflow/plugins/folio/instances.py
@@ -159,7 +159,7 @@ def post_folio_instance_records(**kwargs):
         instance_records = json.load(fo)
 
     for i in range(0, len(instance_records), batch_size):
-        instance_batch = instance_records[i: i + batch_size]
+        instance_batch = instance_records[i : i + batch_size]
         logger.info(f"Posting {len(instance_batch)} in batch {i/batch_size}")
         post_to_okapi(
             token=kwargs["task_instance"].xcom_pull(

--- a/libsys_airflow/plugins/folio/items.py
+++ b/libsys_airflow/plugins/folio/items.py
@@ -251,7 +251,7 @@ def post_folio_items_records(**kwargs):
         items_records = json.load(fo)
 
     for i in range(0, len(items_records), batch_size):
-        items_batch = items_records[i: i + batch_size]
+        items_batch = items_records[i : i + batch_size]
         logger.info(f"Posting {len(items_batch)} in batch {i/batch_size}")
         post_to_okapi(
             token=kwargs["task_instance"].xcom_pull(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ target-version = ['py310']
 include = '\.pyi?$'
 exclude = 'vendor_loads_migration'
 skip-string-normalization = true
+check = true
+diff = true
+color = true


### PR DESCRIPTION
part of #394

I believe this makes us ready for prime time with `black` formatter.

It runs in check mode by default, reporting on violations.   There are instructions in the readme for how to let black automatically fix the violations.   This is akin to rubocop, in that we do not fix the violations automatically on the build;  the build notifies, and the developer fixes them.

The way I found to do this was to create a config file with the desired options to FIX the problem, and to document the command to run black using this config file as part of the README.   


NOTE:  you will see from my inline comments that this PR will not be green, but if it is merged to main, it will be green afterwards -- flake8 and black are disagreeing on a style rule and this PR addresses it.