### PR TITLE
Add Vendor view

### DIFF
--- a/libsys_airflow/plugins/vendor_app/templates/vendors/index.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/index.html
@@ -12,7 +12,7 @@
         {% for vendor in vendors %}
         <tr>
             <td>
-                {{ vendor.display_name }}<br>
+              <a href="{{ url_for('VendorManagementView.vendor', vendor_id=vendor.id) }}">{{ vendor.display_name }}</a><br>
                 ID: {{ vendor.folio_organization_uuid }}
             </td>
             <td>

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
@@ -1,0 +1,28 @@
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+<h1>Vendor: {{ vendor.display_name }}</h1>
+
+<h2>Vendor Interfaces</h2>
+
+<table class="table table-striped">
+    <thead>
+        <th>Name</th>
+        <th>Import Profile</th>
+        <th>File Pattern</th>
+        <th>Remote Path</th>
+        <th>Processing Delay</th>
+        <th>Processing DAG</th>
+    </thead>
+    {% for interface in vendor.vendor_interfaces %}
+    <tr>
+        <td>{{ interface.display_name }}</td>
+        <td>{{ interface.file_pattern }}</td>
+        <td>{{ interface.remote_path }}</td>
+        <td>{{ interface.processing_delay }}</td>
+        <td>{{ interface.processing_dag }}</td>
+    </tr>
+     {% endfor %}
+</table>
+
+{% endblock %}

--- a/libsys_airflow/plugins/vendor_app/vendors.py
+++ b/libsys_airflow/plugins/vendor_app/vendors.py
@@ -1,7 +1,7 @@
 import logging
 
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from flask_appbuilder import expose, BaseView as AppBuilderBaseView
+from flask_appbuilder import expose, BaseView
 from sqlalchemy.orm import Session
 
 from libsys_airflow.plugins.vendor.models import Vendor
@@ -10,19 +10,22 @@ from libsys_airflow.plugins.vendor.models import Vendor
 logger = logging.getLogger(__name__)
 
 
-class VendorManagementView(AppBuilderBaseView):
+class VendorManagementView(BaseView):
     default_view = "vendors_index"
     route_base = "/vendors"
 
-    def _get_vendors(self):
-        """
-        Retrieves vendors from vendor_loads database
-        """
-        pg_hook = PostgresHook("vendor_loads")
-        with Session(pg_hook.get_sqlalchemy_engine()) as session:
-            return session.query(Vendor).order_by(Vendor.display_name)
-
     @expose("/")
-    def vendors_index(self):
-        vendors = self._get_vendors()
+    def index(self):
+        session = self._get_session()
+        vendors = session.query(Vendor).order_by(Vendor.display_name)
         return self.render_template("vendors/index.html", vendors=vendors)
+
+    @expose("/<int:vendor_id>")
+    def vendor(self, vendor_id):
+        session = self._get_session()
+        vendor = session.query(Vendor).get(vendor_id)
+        return self.render_template("vendors/vendor.html", vendor=vendor)
+
+    def _get_session(self):
+        pg_hook = PostgresHook("vendor_loads")
+        return Session(pg_hook.get_sqlalchemy_engine())

--- a/poetry.lock
+++ b/poetry.lock
@@ -592,6 +592,25 @@ files = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.12.2"
+description = "Screen-scraping library"
+category = "dev"
+optional = false
+python-versions = ">=3.6.0"
+files = [
+    {file = "beautifulsoup4-4.12.2-py3-none-any.whl", hash = "sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a"},
+    {file = "beautifulsoup4-4.12.2.tar.gz", hash = "sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "23.3.0"
 description = "The uncompromising code formatter."
@@ -3341,6 +3360,18 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.4.1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "soupsieve-2.4.1-py3-none-any.whl", hash = "sha256:1c1bfee6819544a3447586c889157365a27e10d88cde3ad3da0cf0ddf646feb8"},
+    {file = "soupsieve-2.4.1.tar.gz", hash = "sha256:89d12b2d5dfcd2c9e8c22326da9d9aa9cb3dfab0a83a024f05704076ee8d35ea"},
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "1.4.48"
 description = "Database Abstraction Library"
@@ -3813,4 +3844,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "2ca3d50045a0a4cab884a1dc4d8f99ce0c5ef2ae1a751fab0cf29dc9c9ff86db"
+content-hash = "911bee6e5cb01b23dad6fdf1abb98abe75973bbc1d670635fc55183f428206ad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ apache-airflow = "2.6.0"
 apache-airflow-providers-postgres = "5.4.0"
 requests-mock = "^1.10.0"
 pytest-mock-resources = "^2.6.12"
+beautifulsoup4 = "^4.12.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/airflow_client.py
+++ b/tests/airflow_client.py
@@ -1,7 +1,9 @@
 import pathlib
 
-import pytest
 from airflow.www import app as application
+from bs4 import BeautifulSoup
+from flask.wrappers import Response
+import pytest
 
 from conftest import root_directory
 from libsys_airflow.plugins.vendor_app.vendors import VendorManagementView
@@ -20,6 +22,13 @@ def test_airflow_client():
         VendorManagementView, "Vendors", category="Vendor Management"
     )
     app.blueprints['VendorManagementView'].template_folder = templates_folder
+    app.response_class = HTMLResponse
 
     with app.test_client() as client:
         yield client
+
+
+class HTMLResponse(Response):
+    @property
+    def html(self):
+        return BeautifulSoup(self.get_data(), "html.parser")


### PR DESCRIPTION
Add a vendor view that lists the interfaces for a given vendor. The URL path is:

    /vendors/{vendor-id}

Initially I had this as:

    /vendors/vendor/{vendor-id}

But it looked kind of weird? We can change it later if it causes problems with subsequent views?

I moved `tests.client` to `tests.airflow_client` to avoid confusion with other clients. I also modified the test_airflow_client response so that it can provide access to a BeautifulSoup object for the response to allow the tests to operate on the parsed HTML rather than doing straight up string matching.

Closes #355
