### PR TITLE
Allow black to fix files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
           poetry install
       - name: Format with black
         run: |
-          poetry run black .
+          poetry run black --check --diff .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,4 @@ target-version = ['py310']
 include = '\.pyi?$'
 exclude = 'vendor_loads_migration'
 skip-string-normalization = true
-check = true
-diff = true
 color = true


### PR DESCRIPTION
With these options in our `pyproject.toml` I couldn't find a way to run black so that it would fix problems:

        check = true
        diff = true

Usually you can run `black .` on the command line to automatically reformat all the problems, but it seems like the `pyproject.toml` settings won't allow that, and black only will "check"?

So I removed the options from `pyproject.toml` and modified the Github action to use them instead, so it will fail if there is a formatting probem, and the diff should get displayed -- and we can run black on the command line to fix things when there are problems.
