### PR TITLE
Use dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,10 @@ module and then run the following steps:
 
 #### Seeding Vendors
 
+Assuming that you have put Folio related environment variables in your `.env` file you can:
+
 ```
-PYTHONPATH=. AIRFLOW_VAR_FOLIO_USER=<APP_USER> AIRFLOW_VAR_FOLIO_PASSWORD=<APP_USER_PASSWORD> poetry run bin/seed_vendors
+poetry run bin/seed_vendors
 ```
 
 ## Testing

--- a/bin/seed_vendors
+++ b/bin/seed_vendors
@@ -3,12 +3,11 @@
 # A utility for getting a vendor records from FOLIO into the database
 
 import os
-import sys
 import logging
 import argparse
 import requests
-import json
 
+from dotenv import load_dotenv
 from folioclient import FolioClient
 from signal import signal, SIGPIPE, SIG_DFL  
 from libsys_airflow.plugins.vendor.models import Vendor, VendorInterface
@@ -16,6 +15,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from datetime import datetime
 
+
+load_dotenv()
 logger = logging.getLogger(__name__)
 
 class VendorLoader:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3021,6 +3021,21 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba"},
+    {file = "python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "python-nvd3"
 version = "0.15.0"
 description = "Python NVD3 - Chart Library for d3.js"
@@ -3844,4 +3859,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "911bee6e5cb01b23dad6fdf1abb98abe75973bbc1d670635fc55183f428206ad"
+content-hash = "6a02397e277afecb17fce11d4d8a7291ae6ce4def33466177b60708e1a1dc1cc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requests = "^2.28.2"
 pyyaml = "^6.0"
 # this should ideally be kept in sync with the airflow version but client releases run behind server releases
 apache-airflow-client = "2.6.0"
+python-dotenv = "^1.0.0"
 
 [tool.poetry.group.test.dependencies]
 black = "~23.3.0"


### PR DESCRIPTION
Use python-dotenv to simplify the running of `seed_vendors`, assuming that the `.env` file is already set up (development), or the `AIRFLOW_VAR_OKAPI_URL`, `AIRFLOW_VAR_FOLIO_USER` and `AIRFLOW_VAR_FOLIO_PASSWORD` environment variables have been set up by Puppet (qa, stage, prod).
