### PR TITLE
flake8 runs in lint github action and is configured only in setup.cfg

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           poetry install
+      - name: Lint with flake8
+        run: poetry run flake8
       - name: Format with black
-        run: |
-          poetry run black --check --diff .
+        run: poetry run black --check --diff .

--- a/README.md
+++ b/README.md
@@ -174,19 +174,6 @@ PYTHONPATH=. AIRFLOW_VAR_FOLIO_USER=<APP_USER> AIRFLOW_VAR_FOLIO_PASSWORD=<APP_U
 1. Install dependencies per `Dependency Management and Packaging` above
 1. Drop into the poetry virtual environment: `poetry shell` (alternatively, if you don't want to drop into `poetry shell`, you can run commands using `poetry run my_cmd`, akin to `bundle exec my_cmd`)
 
-### Black (Python formatter)
-
-The Github action has been configured to fail if there are any violations (see `pyproject.toml`)
-
-To run the black formatter to fix any violations:
-
-`poetry run black .`
-
-### Flake8 (Python linter)
-
-Run the flake8 linter:
-`flake8 libsys_airflow/` (_Note_: As of 2023-04-13, the `--ignore=E225,E501,F401,F811,W503` option is given in CI; you may want to do similarly to see the lint warnings that'll actually fail CI. See `Lint with flake8` `build` step in `.github/workflows/python-app.yml` for current invocation.)
-
 Install the test database (sqlite):
 `airflow db init`
 
@@ -195,6 +182,24 @@ Then, to run the test suite, use [pytest](https://docs.pytest.org/).
 
 To see stdout or stderr add the `-rP` flag:
 `pytest -rP`
+
+### Flake8 (Python linter)
+
+Flake8 configuration is in `setup.cfg` (flake8 cannot be configured with `pyproject.toml`).
+
+For CI, see the `Lint with flake8` step in `.github/workflows/lint.yml`.
+
+To run the flake8 linter: `poetry run flake8`
+
+### Black (Python formatter)
+
+Black configuration is in `pyproject.toml`.
+
+For CI, see the `Format with black` step in `.github/workflows/lint.yml` github action. It has been configured to fail if there are any violations.
+
+To run the black formatter to fix any violations:
+
+`poetry run black .`
 
 ## Symphony Mount
 

--- a/libsys_airflow/.flake8
+++ b/libsys_airflow/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-ignore = E225,E501,W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,15 @@
 addopts = --cov=libsys_airflow --cov-report=xml --cov-report=term
 
 [flake8]
-exclude = vendor_loads_migration
+# Flake8 cannot be configured via pyproject.toml  see https://pypi.org/project/Flake8-pyproject/
+max-line-length = 88
+# E203 "Whitespace before ':'" conflicts with black
+# E225 "Missing whitespace around operator"
+# E501 "Line too long"
+# W503 "Line break before binary operator"
+
+# TODO: F401 and F811 will be removed shortly
+# F401 "Imported but unused"
+# F811 "Redefinition of unused name"
+extend-ignore = E203,E225,E501,F401,F811,W503
+exclude = .git,__pycache__,circ,logs,old,vendor-data,vendor_loads_migration


### PR DESCRIPTION
part of #394 

This PR:
- puts all the flake8 configuration in setup.cfg
- runs flake8 in the `lint` github action

I ran flake8 from the command line, top directory of project and confirmed it works properly.

(I) WILL DO AFTER this is merged
- remove flake8 step from the `python-app` github action.
- remove the exceptions about import statement rules from the current flake8 definition
