### PR TITLE
python-app github airflow - remove flake8 step as it is in lint gh action

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,10 +24,6 @@ jobs:
         run: |
           pip install -r requirements.txt
           poetry install
-      - name: Lint with flake8
-        run: |
-          cd libsys_airflow
-          poetry run flake8 --ignore=E203,E225,E501,F401,F811,W503 dags/ plugins/
       - name: Test with pytest
         run: |
           poetry run airflow db init


### PR DESCRIPTION
part of #394, and a follow up to PR #423 -- only run flake8 once for PRs and commits to `main`