### PR TITLE
flake8 - restoring rules F401 and F811 about import statements and redefinitions

### DIFF
--- a/libsys_airflow/dags/vendor/purge_archive.py
+++ b/libsys_airflow/dags/vendor/purge_archive.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 import logging
 
 from airflow import DAG
-from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.vendor.purge import (
     discover_task,

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,5 @@ max-line-length = 88
 # E225 "Missing whitespace around operator"
 # E501 "Line too long"
 # W503 "Line break before binary operator"
-
-# TODO: F401 and F811 will be removed shortly
-# F401 "Imported but unused"
-# F811 "Redefinition of unused name"
-extend-ignore = E203,E225,E501,F401,F811,W503
+extend-ignore = E203,E225,E501,W503
 exclude = .git,__pycache__,circ,logs,old,vendor-data,vendor_loads_migration

--- a/tests/airflow_client.py
+++ b/tests/airflow_client.py
@@ -1,5 +1,3 @@
-import pathlib
-
 from airflow.www import app as application
 from bs4 import BeautifulSoup
 from flask.wrappers import Response

--- a/tests/apps/vendor_app/test_vendor_management_view.py
+++ b/tests/apps/vendor_app/test_vendor_management_view.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_mock_resources import create_sqlite_fixture, Rows
 
 from libsys_airflow.plugins.vendor.models import Vendor, VendorInterface
-from tests.airflow_client import test_airflow_client
+from tests.airflow_client import test_airflow_client  # noqa: F401
 
 
 rows = Rows(
@@ -64,7 +64,7 @@ def mock_db(mocker, engine):
     yield mock_hook
 
 
-def test_vendor_views(test_airflow_client, mock_db):
+def test_vendor_views(test_airflow_client, mock_db):  # noqa: F811
     response = test_airflow_client.get('/vendors/')
     assert response.status_code == 200
     assert response.html.h1.text == "Vendors"
@@ -81,7 +81,7 @@ def test_vendor_views(test_airflow_client, mock_db):
     assert link["href"] == "/vendors/2"
 
 
-def test_vendor_view(test_airflow_client, mock_db):
+def test_vendor_view(test_airflow_client, mock_db):  # noqa: F811
     response = test_airflow_client.get('/vendors/1')
     assert response.status_code == 200
     assert response.html.h1.text == "Vendor: Acme"

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -93,25 +93,28 @@ def test_create_connection_ftp(mocker):
         "ftp", "example.com", "user", "pass", None, None
     )
 
-# UNUSED per flake8 F811
-# def test_create_connection_sftp(mocker):
-#     mock_find_or_create_conn = mocker.patch(
-#         "libsys_airflow.plugins.airflow.connections.find_or_create_conn",
-#         return_value="sftp-66.151.8.124",
-#     )
-#     mocker.patch(
-#         "libsys_airflow.plugins.airflow.connections.interface_info",
-#         return_value={
-#             "uri": "sftp://66.151.8.124:10006",
-#             "username": "user",
-#             "password": "pass",
-#         },
-#     )
-#     conn_id = create_connection("1234")
-#     assert conn_id == "sftp-66.151.8.124"
-#     mock_find_or_create_conn.assert_called_once_with(
-#         "sftp", "66.151.8.124", "user", "pass", 10006, None
-#     )
+
+"""
+UNUSED per flake8 F811
+def test_create_connection_sftp(mocker):
+    mock_find_or_create_conn = mocker.patch(
+        "libsys_airflow.plugins.airflow.connections.find_or_create_conn",
+        return_value="sftp-66.151.8.124",
+    )
+    mocker.patch(
+        "libsys_airflow.plugins.airflow.connections.interface_info",
+        return_value={
+            "uri": "sftp://66.151.8.124:10006",
+            "username": "user",
+            "password": "pass",
+        },
+    )
+    conn_id = create_connection("1234")
+    assert conn_id == "sftp-66.151.8.124"
+    mock_find_or_create_conn.assert_called_once_with(
+        "sftp", "66.151.8.124", "user", "pass", 10006, None
+    )
+"""
 
 
 def test_create_connection_sftp_with_keyfile(mocker):

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -93,25 +93,25 @@ def test_create_connection_ftp(mocker):
         "ftp", "example.com", "user", "pass", None, None
     )
 
-
-def test_create_connection_sftp(mocker):
-    mock_find_or_create_conn = mocker.patch(
-        "libsys_airflow.plugins.airflow.connections.find_or_create_conn",
-        return_value="sftp-66.151.8.124",
-    )
-    mocker.patch(
-        "libsys_airflow.plugins.airflow.connections.interface_info",
-        return_value={
-            "uri": "sftp://66.151.8.124:10006",
-            "username": "user",
-            "password": "pass",
-        },
-    )
-    conn_id = create_connection("1234")
-    assert conn_id == "sftp-66.151.8.124"
-    mock_find_or_create_conn.assert_called_once_with(
-        "sftp", "66.151.8.124", "user", "pass", 10006, None
-    )
+# UNUSED per flake8 F811
+# def test_create_connection_sftp(mocker):
+#     mock_find_or_create_conn = mocker.patch(
+#         "libsys_airflow.plugins.airflow.connections.find_or_create_conn",
+#         return_value="sftp-66.151.8.124",
+#     )
+#     mocker.patch(
+#         "libsys_airflow.plugins.airflow.connections.interface_info",
+#         return_value={
+#             "uri": "sftp://66.151.8.124:10006",
+#             "username": "user",
+#             "password": "pass",
+#         },
+#     )
+#     conn_id = create_connection("1234")
+#     assert conn_id == "sftp-66.151.8.124"
+#     mock_find_or_create_conn.assert_called_once_with(
+#         "sftp", "66.151.8.124", "user", "pass", 10006, None
+#     )
 
 
 def test_create_connection_sftp_with_keyfile(mocker):

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -280,7 +280,7 @@ def test_add_additional_info_missing_barcode(
 
 
 def test_add_additional_info_hoover(
-    mock_file_system, mock_okapi_items_endpoint
+    mock_file_system, mock_okapi_items_endpoint  # noqa F811
 ):  # noqa
     pass
 


### PR DESCRIPTION
~~HOLD - creating PR to main to trigger build -- need to ensure corrections I'm making are ok~~

part of #394

Restoring flake8 rules, as we want them:
- F401 "Imported but unused"
- F811 "Redefinition of unused name" <-- possibly problematic
