### PR TITLE
Add alembic database migrations to deployments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,4 +47,4 @@ DEPENDENCIES
   dlss-capistrano
 
 BUNDLED WITH
-   2.4.6
+   2.4.13

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Based on the documentation, [Running Airflow in Docker](https://airflow.apache.o
 
 ### Tasks
 
-1. List all the airflow tasks using `cap -AT airflow`
+List all the airflow tasks using `cap -AT airflow`
 
 ```
 cap airflow:build          # run docker compose build for airflow
@@ -74,6 +74,14 @@ cap airflow:start          # start airflow
 cap airflow:stop           # stop and remove all running docker containers
 cap airflow:stop_release   # stop old release and remove all old running docker containers
 cap airflow:webserver      # restart webserver
+```
+
+List all the Alembic database migration tasks (see `Database migrations` below for more) using `cap -AT alembic`:
+
+```
+cap alembic:current  # Show current Alembic database migration
+cap alembic:history  # Show Alembic database migration history
+cap alembic:migrate  # Run Alembic database migrations
 ```
 
 ### Do the first time you bring up Libsys-Airflow:

--- a/poetry.lock
+++ b/poetry.lock
@@ -126,14 +126,14 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "alembic"
-version = "1.10.4"
+version = "1.11.0"
 description = "A database migration tool for SQLAlchemy."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "alembic-1.10.4-py3-none-any.whl", hash = "sha256:43942c3d4bf2620c466b91c0f4fca136fe51ae972394a0cc8b90810d664e4f5c"},
-    {file = "alembic-1.10.4.tar.gz", hash = "sha256:295b54bbb92c4008ab6a7dcd1e227e668416d6f84b98b3c4446a2bc6214a556b"},
+    {file = "alembic-1.11.0-py3-none-any.whl", hash = "sha256:f0e74af5a6ade86b72770790188aaf64122c9cba64efd1d7ff3323ac3fdb75e0"},
+    {file = "alembic-1.11.0.tar.gz", hash = "sha256:d8bf706124e96e526889ac9c87a0d50debd9ef325ef32ae5391cf0315bdab4e1"},
 ]
 
 [package.dependencies]
@@ -1664,7 +1664,7 @@ test = ["coverage", "mock (>=4)", "pytest (>=7)", "pytest-cov", "pytest-mock (>=
 name = "greenlet"
 version = "2.0.2"
 description = "Lightweight in-process concurrent programming"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 files = [
@@ -2047,7 +2047,7 @@ files = [
 name = "mako"
 version = "1.2.4"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2107,7 +2107,7 @@ testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 name = "markupsafe"
 version = "2.1.2"
 description = "Safely add untrusted strings to HTML/XML markup."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2646,7 +2646,7 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 name = "psycopg2-binary"
 version = "2.9.6"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -3390,7 +3390,7 @@ files = [
 name = "sqlalchemy"
 version = "1.4.48"
 description = "Database Abstraction Library"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
@@ -3859,4 +3859,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "6a02397e277afecb17fce11d4d8a7291ae6ce4def33466177b60708e1a1dc1cc"
+content-hash = "881fd158346e45a6c63b23b47cc4db3707fac12ea37b587a563f7fdb958f0537"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ pyyaml = "^6.0"
 # this should ideally be kept in sync with the airflow version but client releases run behind server releases
 apache-airflow-client = "2.6.0"
 python-dotenv = "^1.0.0"
+alembic = "^1.10.4"
+psycopg2-binary = "^2.9.6"
 
 [tool.poetry.group.test.dependencies]
 black = "~23.3.0"


### PR DESCRIPTION
Fixes #372

This commit instructs Capistrano to ensure the necessary databases are created and then run database migrations as part of the `deploy:restart` task. To accomplish this, a few parts are added:

* A custom `db:create` task in `config/deploy.rb` that adapts the code in `docker/init-multi-postgres-dbs.sh`
* New DB migration-related tasks:
  * `alembic:migrate`: to apply migrations
  * `alembic:current`: to show the current migration (for troubleshooting)
  * `alembic:history`: to show the migration history (for troubleshooting)
* Add alembic and psycopg2 as Python dependencies (above tasks fail without this)

# Demonstration

I successfully ran `cap stage deploy deploy:restart` and it finished with the following:

```shell
...
01:05 db:create
      01 psql         -v ON_ERROR_STOP=1 postgresql://$DATABASE_USERNAME:$DATABASE_PASSWORD@$DATABASE_HOSTNAME <<-SQL
        SELECT…
      01 GRANT
      01 GRANT
    ✔ 01 libsys@sul-libsys-airflow-stage.stanford.edu 0.153s
01:05 alembic:migrate
      01 cd /home/libsys/libsys-airflow/releases/20230515191421 && source /home/libsys/virtual-env/bin/activate && poetry run alembi…
      01 INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
      01 INFO  [alembic.runtime.migration] Will assume transactional DDL.
      01 INFO  [alembic.runtime.migration] Running upgrade  -> 965229094874, Create vendors table
      01 INFO  [alembic.runtime.migration] Running upgrade 965229094874 -> 55557ab268c9, add vendor_interface model
    ✔ 01 libsys@sul-libsys-airflow-stage.stanford.edu 1.058s
```

After the deployment ran, I tested the DB migration tasks one-by-one to confirm the server was in the state I expected:

```shell
$ cap stage alembic:migrate    
00:00 alembic:migrate
      01 cd /home/libsys/libsys-airflow/current && source /home/libsys/virtual-env/bin/activate && poetry run alembic upgrade head
      01 INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
      01 INFO  [alembic.runtime.migration] Will assume transactional DDL.
    ✔ 01 libsys@sul-libsys-airflow-stage.stanford.edu 1.286s

$ cap stage alembic:current
00:00 alembic:current
      01 cd /home/libsys/libsys-airflow/current && source /home/libsys/virtual-env/bin/activate && poetry run alembic current
      01 INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
      01 INFO  [alembic.runtime.migration] Will assume transactional DDL.
      01 55557ab268c9 (head)
    ✔ 01 libsys@sul-libsys-airflow-stage.stanford.edu 1.274s

$ cap stage alembic:history
00:00 alembic:history
      01 cd /home/libsys/libsys-airflow/current && source /home/libsys/virtual-env/bin/activate && poetry run alembic history --verb…
      01 Rev: 55557ab268c9 (head) 
      01 Parent: 965229094874
      01 Path: /home/libsys/libsys-airflow/releases/20230515191421/vendor_loads_migration/versions/55557ab268c9_add_vendor_interface…
      01
      01     add vendor_interface model
      01
      01     Revision ID: 55557ab268c9
      01     Revises: 965229094874
      01     Create Date: 2023-05-03 10:21:46.652162
      01
      01 Rev: 965229094874
      01 Parent: <base>
      01 Path: /home/libsys/libsys-airflow/releases/20230515191421/vendor_loads_migration/versions/965229094874_create_vendors_table…
      01
      01     Create vendors table 
      01
      01     Revision ID: 965229094874
      01     Revises:
      01     Create Date: 2023-05-01 14:45:09.973516
      01
    ✔ 01 libsys@sul-libsys-airflow-stage.stanford.edu 1.200s
```

# Complication?

Not sure if this is a consequence of this PR, or not, but I am now seeing some errors when the `airflow-init` docker-compose container starts (happens immediately before the new DB-related tasks):

```shell
01 Attaching to 20230515205921-airflow-init-1                                                                                  
      01 20230515205921-airflow-init-1  | /home/airflow/.local/lib/python3.10/site-packages/airflow/configuration.py:454 Deprecation…
      01 20230515205921-airflow-init-1  | /home/airflow/.local/lib/python3.10/site-packages/airflow/configuration.py:380 Deprecation…
      01 20230515205921-airflow-init-1  | /home/airflow/.local/lib/python3.10/site-packages/airflow/settings.py:188 DeprecationWarni…
      01 20230515205921-airflow-init-1  | The container is run as root user. For security, consider using a regular user account.    
      01 20230515205921-airflow-init-1  |                                                                                            
      01 20230515205921-airflow-init-1  | /home/airflow/.local/lib/python3.10/site-packages/airflow/configuration.py:454 Deprecation…
      01 20230515205921-airflow-init-1  | /home/airflow/.local/lib/python3.10/site-packages/airflow/configuration.py:380 Deprecation…
      01 20230515205921-airflow-init-1  | /home/airflow/.local/lib/python3.10/site-packages/airflow/settings.py:188 DeprecationWarni…
      01 20230515205921-airflow-init-1  | /home/airflow/.local/lib/python3.10/site-packages/airflow/models/base.py:70 DeprecationWar…
      01 20230515205921-airflow-init-1  | /home/airflow/.local/lib/python3.10/site-packages/airflow/utils/sqlalchemy.py:47 Deprecati…
      01 20230515205921-airflow-init-1  | DB: postgresql+psycopg2://libsys:***@sul-libsys-airflow-db-stage-a.stanford.edu/libsys     
      01 20230515205921-airflow-init-1  | Performing upgrade with database postgresql+psycopg2://libsys:***@sul-libsys-airflow-db-st…
      01 20230515205921-airflow-init-1  | [2023-05-15T21:00:07.951+0000] {migration.py:207} INFO - Context impl PostgresqlImpl.      
      01 20230515205921-airflow-init-1  | [2023-05-15T21:00:07.954+0000] {migration.py:210} INFO - Will assume transactional DDL.    
      01 20230515205921-airflow-init-1  | [2023-05-15T21:00:07.963+0000] {db.py:1588} INFO - Creating tables                         
      01 20230515205921-airflow-init-1  | INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.                             
      01 20230515205921-airflow-init-1  | INFO  [alembic.runtime.migration] Will assume transactional DDL.                           
      01 20230515205921-airflow-init-1  | /home/airflow/.local/lib/python3.10/site-packages/airflow/models/dagbag.py:346 RemovedInAi…
      01 20230515205921-airflow-init-1  | ERROR [airflow.models.dagbag.DagBag] Failed to import: /opt/airflow/libsys_airflow/dags/bi…
      01 20230515205921-airflow-init-1  | Traceback (most recent call last):                                                         
      01 20230515205921-airflow-init-1  |   File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/dagbag.py", line …
      01 20230515205921-airflow-init-1  |     loader.exec_module(new_module)                                                         
      01 20230515205921-airflow-init-1  |   File "<frozen importlib._bootstrap_external>", line 883, in exec_module                  
      01 20230515205921-airflow-init-1  |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed             
      01 20230515205921-airflow-init-1  |   File "/opt/airflow/libsys_airflow/dags/bib_records.py", line 66, in <module>             
      01 20230515205921-airflow-init-1  |     sul_config = LibraryConfiguration(                                                     
      01 20230515205921-airflow-init-1  |   File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__                   
      01 20230515205921-airflow-init-1  | pydantic.error_wrappers.ValidationError: 1 validation error for LibraryConfiguration       
      01 20230515205921-airflow-init-1  | base_folder                                                                                
      01 20230515205921-airflow-init-1  |   file or directory at path "/opt/airflow/migration" does not exist (type=value_error.path…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): setup>, filter_…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): filter_fields_t…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): setup>, batch_t…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): batch_task>, se…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): setup>, data_im…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): data_import_tas…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): setup>, ftp_dow…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): ftp_download_ta…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): setup>, ftp_dow…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): ftp_download_ta…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): setup>, ftp_dow…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): ftp_download_ta…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): setup>, ftp_dow…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): ftp_download_ta…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): setup>, archive…
      01 20230515205921-airflow-init-1  | WARNI [airflow.task.operators] Dependency <Task(_PythonDecoratedOperator): archive_task>, …
      01 20230515205921-airflow-init-1  | WARNI [airflow.decorators.base.DecoratedMappedOperator] Dependency <Task(_PythonDecoratedO…
      01 20230515205921-airflow-init-1  | WARNI [airflow.decorators.base.DecoratedMappedOperator] Dependency <Mapped(_PythonDecorate…
      01 20230515205921-airflow-init-1  | WARNI [airflow.decorators.base.DecoratedMappedOperator] Dependency <Task(_PythonDecoratedO…
      01 20230515205921-airflow-init-1  | WARNI [airflow.decorators.base.DecoratedMappedOperator] Dependency <Mapped(_PythonDecorate…
      01 20230515205921-airflow-init-1  | WARNI [airflow.decorators.base.DecoratedMappedOperator] Dependency <Task(_PythonDecoratedO…
      01 20230515205921-airflow-init-1  | WARNI [airflow.decorators.base.DecoratedMappedOperator] Dependency <Mapped(_PythonDecorate…
      01 20230515205921-airflow-init-1  | WARNI [airflow.decorators.base.DecoratedMappedOperator] Dependency <Task(_PythonDecoratedO…
      01 20230515205921-airflow-init-1  | WARNI [airflow.decorators.base.DecoratedMappedOperator] Dependency <Mapped(_PythonDecorate…
      01 20230515205921-airflow-init-1  | Upgrades done
```

Happy to take advice on whether to handle that here, elsewhere, or ignore it.