### PR TITLE
Add Interface view

### DIFF
--- a/libsys_airflow/plugins/vendor_app/templates/vendors/interface.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/interface.html
@@ -1,0 +1,73 @@
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+<h1><a href="{{ url_for('VendorManagementView.vendor', vendor_id=interface.vendor.id) }}">{{ interface.vendor.display_name }}</a> / {{ interface.display_name }}</h1>
+
+<dl class="dl-horizontal">
+  <dt>Interface ID</dt>
+  <dd>{{ interface.folio_interface_uuid }}</dd>
+  <dt>Import Profile</dt>
+  <dd>{{ interface.folio_data_import_profile_uuid }}</dd>
+  <dt>Processing Name</dt>
+  <dd>{{ interface.folio_data_import_processing_name }}</dd>
+  <dt>File Pattern</dt>
+  <dd>{{ interface.file_pattern }}</dd>
+  <dt>Remote Path</dt>
+  <dd>{{ interface.remote_path }}</dd>
+  <dt>Processing DAG</dt>
+  <dd>{{ interface.processing_dag }}</dd>
+  <dt>Delay (Days)</dt>
+  <dd>{{ interface.processing_delay_in_days }}</dd>
+  <dt>Active</dt>
+  <dd>{{ interface.active }}</dd>
+</dl>
+
+<h2>Pending Loads</h2>
+
+<table id="pending-files" class="table table-striped">
+  <thead>
+    <td>Created</td>
+    <td>Updated</td>
+    <td>Filename</td>
+    <td>File Size</td>
+    <td>Timestamp</td>
+    <td>Expected Load</td>
+  </thead>
+  {% for file in interface.pending_files %}
+  <tr>
+    <td>{{ file.created }}</td>
+    <td>{{ file.updated }}</td>
+    <td>{{ file.vendor_filename }}</td>
+    <td>{{ file.filesize }}</td>
+    <td>{{ file.vendor_timestamp }}</td>
+    <td>{{ file.expected_execution }}</td>
+  </tr>
+   {% endfor %}
+</table>
+
+<h2>Completed Loads</h2>
+
+<table id="loaded-files" class="table table-striped">
+  <thead>
+    <td>Created</td>
+    <td>Updated</td>
+    <td>Filename</td>
+    <td>File Size</td>
+    <td>Timestamp</td>
+    <td>Loaded</td>
+    <td>Status</td>
+  </thead>
+  {% for file in interface.processed_files %}
+  <tr>
+    <td>{{ file.created }}</td>
+    <td>{{ file.updated }}</td>
+    <td>{{ file.vendor_filename }}</td>
+    <td>{{ file.filesize }}</td>
+    <td>{{ file.vendor_timestamp }}</td>
+    <td>{{ file.loaded_timestamp }}</td>
+    <td>{{ file.status }}</td>
+  </tr>
+  {% endfor %}
+</table>
+
+{% endblock %}

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
@@ -1,7 +1,7 @@
 {% extends "appbuilder/base.html" %}
 
 {% block content %}
-<h1>Vendor: {{ vendor.display_name }}</h1>
+<h1>{{ vendor.display_name }}</h1>
 
 <h2>Vendor Interfaces</h2>
 
@@ -16,7 +16,7 @@
     </thead>
     {% for interface in vendor.vendor_interfaces %}
     <tr>
-        <td>{{ interface.display_name }}</td>
+        <td><a href="{{ url_for('VendorManagementView.interface', interface_id=interface.id) }}">{{ interface.display_name }}</a></td>
         <td>{{ interface.folio_data_import_processing_name }}</td>
         <td>{{ interface.file_pattern }}</td>
         <td>{{ interface.remote_path }}</td>

--- a/libsys_airflow/plugins/vendor_app/vendors.py
+++ b/libsys_airflow/plugins/vendor_app/vendors.py
@@ -4,7 +4,7 @@ from airflow.providers.postgres.hooks.postgres import PostgresHook
 from flask_appbuilder import expose, BaseView
 from sqlalchemy.orm import Session
 
-from libsys_airflow.plugins.vendor.models import Vendor
+from libsys_airflow.plugins.vendor.models import Vendor, VendorInterface
 
 
 logger = logging.getLogger(__name__)
@@ -25,6 +25,12 @@ class VendorManagementView(BaseView):
         session = self._get_session()
         vendor = session.query(Vendor).get(vendor_id)
         return self.render_template("vendors/vendor.html", vendor=vendor)
+
+    @expose("/interface/<int:interface_id>")
+    def interface(self, interface_id):
+        session = self._get_session()
+        interface = session.query(VendorInterface).get(interface_id)
+        return self.render_template("vendors/interface.html", interface=interface)
 
     def _get_session(self):
         pg_hook = PostgresHook("vendor_loads")

--- a/tests/apps/vendor_app/test_interface_view.py
+++ b/tests/apps/vendor_app/test_interface_view.py
@@ -1,0 +1,159 @@
+from datetime import datetime, timedelta
+
+import pytest
+from pytest_mock_resources import create_sqlite_fixture, Rows
+from sqlalchemy.orm import Session
+
+from libsys_airflow.plugins.vendor.models import (
+    Vendor,
+    VendorInterface,
+    VendorFile,
+    FileStatus,
+)
+from tests.airflow_client import test_airflow_client  # noqa: F401
+
+now = datetime.now()
+
+rows = Rows(
+    # set up a vendor and its "interface"
+    Vendor(
+        id=1,
+        display_name="Acme",
+        folio_organization_uuid="375C6E33-2468-40BD-A5F2-73F82FE56DB0",
+        vendor_code_from_folio="ACME",
+        acquisitions_unit_from_folio="ACMEUNIT",
+        has_active_vendor_interfaces=False,
+        last_folio_update=now,
+    ),
+    VendorInterface(
+        id=1,
+        display_name="Acme FTP",
+        vendor_id=1,
+        folio_interface_uuid="140530EB-EE54-4302-81EE-D83B9DAC9B6E",
+        folio_data_import_processing_name="Acme Profile 1",
+        file_pattern="*.mrc",
+        remote_path="stanford/outgoing/data",
+        processing_dag="acme-pull",
+        processing_delay_in_days=3,
+        active=True,
+    ),
+    # a file was fetched 10 days ago, and was loaded 9 days ago
+    VendorFile(
+        id=1,
+        created=now - timedelta(days=10),
+        updated=now - timedelta(days=10),
+        vendor_interface_id=1,
+        vendor_filename="acme-marc.dat",
+        filesize=1234,
+        vendor_timestamp=now - timedelta(days=30),
+        loaded_timestamp=now - timedelta(days=8),
+        expected_execution=now - timedelta(days=9),
+        status=FileStatus.loaded,
+        dag_run_id="EB2FD649-2B0A-4671-9BD4-309BF5197870",
+    ),
+    # a file was fetched 8 days ago but errored during load 3 days ago
+    VendorFile(
+        id=2,
+        created=now - timedelta(days=8),
+        updated=now - timedelta(days=8),
+        vendor_interface_id=1,
+        vendor_filename="acme-bad-marc.dat",
+        filesize=123456,
+        vendor_timestamp=now - timedelta(days=30),
+        loaded_timestamp=None,
+        expected_execution=now - timedelta(days=3),
+        status=FileStatus.loading_error,
+        dag_run_id="520F69D8-97BF-47CA-976A-F9CD4DB3FAD7",
+    ),
+    # a file was fetched .5 days ago, and is waiting to be loaded
+    VendorFile(
+        id=3,
+        created=now - timedelta(days=0.5),
+        updated=now - timedelta(days=0.5),
+        vendor_interface_id=1,
+        vendor_filename="acme-extra-strength-marc.dat",
+        filesize=1234567,
+        vendor_timestamp=now - timedelta(days=12),
+        loaded_timestamp=None,
+        expected_execution=now + timedelta(days=1),
+        status=FileStatus.fetched,
+    ),
+    # a file was fetched 1 day ago, and is waiting to be loaded
+    VendorFile(
+        id=4,
+        created=now - timedelta(days=1),
+        updated=now - timedelta(days=1),
+        vendor_interface_id=1,
+        vendor_filename="acme-lite-marc.dat",
+        filesize=1234567,
+        vendor_timestamp=now - timedelta(days=14),
+        loaded_timestamp=None,
+        expected_execution=now + timedelta(days=0.5),
+        status=FileStatus.fetched,
+    ),
+    # a file was that failed to fetch right now
+    VendorFile(
+        id=5,
+        created=now - timedelta(days=1),
+        updated=now,
+        vendor_interface_id=1,
+        vendor_filename="acme-ftp-broken-marc.dat",
+        filesize=24601,
+        vendor_timestamp=now - timedelta(days=14),
+        loaded_timestamp=None,
+        expected_execution=now,
+        status=FileStatus.fetching_error,
+    ),
+)
+
+engine = create_sqlite_fixture(rows)
+
+
+@pytest.fixture
+def mock_db(mocker, engine):
+    mock_hook = mocker.patch(
+        "airflow.providers.postgres.hooks.postgres.PostgresHook.get_sqlalchemy_engine"
+    )
+    mock_hook.return_value = engine
+    yield mock_hook
+
+
+def test_vendor_files(mock_db):  # noqa: F811
+    session = Session(mock_db())
+    interface = session.get(VendorInterface, 1)
+    assert len(interface.vendor_files) == 5
+
+
+def test_pending_files(mock_db):
+    session = Session(mock_db())
+    interface = session.get(VendorInterface, 1)
+    pending = interface.pending_files
+    assert len(pending) == 3
+    assert [v.vendor_filename for v in pending] == [
+        "acme-extra-strength-marc.dat",
+        "acme-lite-marc.dat",
+        "acme-ftp-broken-marc.dat",
+    ]
+
+
+def test_processed_files(mock_db):
+    session = Session(mock_db())
+    interface = session.get(VendorInterface, 1)
+    processed = interface.processed_files
+    assert len(processed) == 2
+    assert [v.vendor_filename for v in processed] == [
+        "acme-marc.dat",
+        "acme-bad-marc.dat",
+    ]
+
+
+def test_interface_view(test_airflow_client, mock_db):  # noqa: F811
+    response = test_airflow_client.get('/vendors/interface/1')
+    assert response.status_code == 200
+    pending = response.html.find(id='pending-files')
+    assert pending
+    assert len(pending.find_all('tr')) == 3
+
+    loaded = response.html.find(id='loaded-files')
+    assert loaded
+    assert len(loaded.find_all('tr')) == 2

--- a/tests/apps/vendor_app/test_vendor_management_view.py
+++ b/tests/apps/vendor_app/test_vendor_management_view.py
@@ -84,7 +84,7 @@ def test_vendor_views(test_airflow_client, mock_db):  # noqa: F811
 def test_vendor_view(test_airflow_client, mock_db):  # noqa: F811
     response = test_airflow_client.get('/vendors/1')
     assert response.status_code == 200
-    assert response.html.h1.text == "Vendor: Acme"
+    assert response.html.h1.text == "Acme"
 
     rows = response.html.find_all('tr')
     assert len(rows) == 2


### PR DESCRIPTION
This new view at `/vendors/interface/{interface-id}` will display information about the interface as well as two tables of VendorFile listings. The first includes VendorFiles that are "pending" (no DAG Run ID) and ones that are "processed" (have a DAG Run ID).

![Screenshot 2023-05-18 at 4 59 02 PM](https://github.com/sul-dlss/libsys-airflow/assets/33829/1b7b0156-438c-4b6a-bbcb-a8213305a2bf)

The list of interfaces in the Vendor view has been updated to link to the appropriate Interface view.

![Screenshot 2023-05-18 at 5 03 51 PM](https://github.com/sul-dlss/libsys-airflow/assets/33829/171a4090-31b9-4285-b4b1-04688df9cf1a)

Resolves https://github.com/sul-dlss/libsys-airflow/issues/371
