### PR TITLE
replacement ci build for github action - linux, more recent versions of secondary github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+# github action workflow to run tests for libsys-airflow
+
+name: Tests with Coverage
+
+on:
+  workflow_dispatch
+  # push:
+  #   branches: [main]
+  # pull_request:
+  #   branches: [main]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  run_tests_with_coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install Airflow + dependencies via poetry
+        run: |
+          pip install -r requirements.txt
+          poetry install
+      - name: Test with pytest
+        run: |
+          poetry run airflow db init
+          poetry run pytest -rP
+          poetry run coverage lcov
+          poetry run coveralls --service=github


### PR DESCRIPTION
part of #447

I don't want to muck about with the currently working CI build until this one is proven.

I will 
- trigger this manually and make sure it works
- remove python-app.yml once it is working and running on merges to main and PRs.