### PR TITLE
Use simpledatatables for Vendor Pagination

### DIFF
--- a/libsys_airflow/plugins/vendor_app/templates/vendors/index.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/index.html
@@ -2,12 +2,12 @@
 
 {% block head_css %}
     {{ super() }}
-    <link href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css" rel="stylesheet" type="text/css">
+    <link href="https://cdn.jsdelivr.net/npm/simple-datatables@7/dist/style.css" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block head_js %}
     {{ super() }}
-    <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest" type="text/javascript"></script>
+    <script src="https://cdn.jsdelivr.net/npm/simple-datatables@7" type="text/javascript"></script>
 {% endblock %}
 
 {% block content %}
@@ -42,5 +42,9 @@
         searchable: true,
         fixedHeight: true
     });
+    let vendorTableSelect = document.querySelector(".datatable-selector");
+    vendorTableSelect.classList.add("form-control");
+    let vendorSearchInput = document.querySelector(".datatable-input");
+    vendorSearchInput.classList.add("form-control");
 </script>
 {% endblock %}

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/index.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/index.html
@@ -1,8 +1,18 @@
 {% extends "appbuilder/base.html" %}
 
+{% block head_css %}
+    {{ super() }}
+    <link href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css" rel="stylesheet" type="text/css">
+{% endblock %}
+
+{% block head_js %}
+    {{ super() }}
+    <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest" type="text/javascript"></script>
+{% endblock %}
+
 {% block content %}
 <h1>Vendors</h1>
-<table class="table table-striped">
+<table class="table table-striped" id="vendorTable">
     <thead>
         <th>Name</th>
         <th>Code</th>
@@ -25,4 +35,12 @@
         {% endfor %}
     </tbody>
 </table>
+
+<script type="text/javascript">
+    let vendorTable = document.querySelector("#vendorTable");
+    let dataTable = new simpleDatatables.DataTable(vendorTable, {
+        searchable: true,
+        fixedHeight: true
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
Fixes #378

This draft PR is mostly for discussion on adding support for pagination to the vendor tables in Vendor's view using client-side Javascript  [simple-datatables](https://github.com/fiduswriter/simple-datatables) library. To test the viability of this approach, all 3,258 Organizations from FOLIO test were loaded into the local Postgres database. 

When accessing the `/vendors` page, all 3K+ organizations are rendered in DOM and then the simple-datatables's DataTable javascript is applied to the table providing functional pagination and searching across the three columns. Loading and rendering all of these organizations into the DOM took about 550 ms with Javascript scripting taking 1348 ms for a total of 1.89 seconds to fully render to the user, which is under the recommend maximum rendering time of 2 seconds. 
  
![Screenshot 2023-05-22 at 3 52 21 PM](https://github.com/sul-dlss/libsys-airflow/assets/71847/a89bd123-db5b-4e04-b0ed-8f3f58fc9ff9)

## PROS
- Very easy implementation
- Javascript library provides what we need with little customization 
- Likelihood of significant increase of organizations low 
- Degrades gracefully if Javascript isn't loaded

## CONS
- Close to threshold of loading usability of 2 seconds (may be longer when run over the network)
- Entire DOM is rendered server-side (i.e. big "chunk" of HTML)
- Not scalable if number of organizations significantly increase

### TODO
- [x] Use Bootstrap styling for **entries per page** drop-down select and **Search..** box
- [x] Pin simple-datatables to specific version with CDN