### PR TITLE
Add ability to disable and enable vendor interfaces in UI

### DIFF
--- a/libsys_airflow/plugins/vendor/models.py
+++ b/libsys_airflow/plugins/vendor/models.py
@@ -27,7 +27,9 @@ class Vendor(Model):
     acquisitions_unit_from_folio = Column(String(36), unique=False, nullable=False)
     has_active_vendor_interfaces = Column(Boolean, nullable=False, default=False)
     last_folio_update = Column(DateTime, nullable=False)
-    vendor_interfaces = relationship("VendorInterface", back_populates="vendor")
+    vendor_interfaces = relationship(
+        "VendorInterface", back_populates="vendor", order_by='VendorInterface.id'
+    )
 
     def __repr__(self) -> str:
         return f"{self.display_name} - {self.folio_organization_uuid}"

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/interface-edit.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/interface-edit.html
@@ -61,6 +61,17 @@
       <input type="text" class="form-control" id="file-pattern" name="file-pattern" placeholder="" value="{{ interface.file_pattern }}">
     </div>
   </div>
+  <div class="form-group">
+    <label for="active" class="col-sm-2 col-form-label">Active</label>
+    <div class="col-sm-8">
+      <label class="radio-inline">
+        <input type="radio" id="true" name="active" value="true" {% if interface.active %}checked{% endif %}> True
+      </label>
+      <label class="radio-inline">
+        <input type="radio" id="false" name="active" value="false" {% if not interface.active %}checked{% endif %}> False
+      </label>
+    </div>
+  </div>
 
   <hr>
 
@@ -213,7 +224,7 @@
   }
 
   addEventListener("load", main);
-  
+
 </script>
 
 {% endblock %}

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
@@ -1,11 +1,56 @@
 {% extends "appbuilder/base.html" %}
 
 {% block content %}
+<script>
+ const vendorActivityHandler = () => {
+   document
+     .querySelectorAll('#vendor_interfaces .btn-toggle')
+     .forEach(buttonGroup => {
+       buttonGroup.addEventListener('click', (event) => {
+         // The `interfaceActive` data attr is set on an HTML element, so bools are strings
+         const newActiveValue = buttonGroup.dataset.interfaceActive === "true" ? "false" : "true"
+
+         // The interface endpoint does not currently distinguish between form
+         // POSTs and JSON POSTs, so until we feel it's worth the effort to make
+         // the endpoint more API-friendly, pretend we're a form.
+         const form = new FormData()
+         form.append("active", newActiveValue)
+         form.append("csrf_token", csrfToken) // NOTE: Airflow sets this variable for us.
+
+         fetch(buttonGroup.dataset.interfaceUrl, {
+           method: 'POST',
+           body: form
+         }).then(response => {
+           if (!response.ok) {
+             console.dir(response)
+             return
+           }
+           buttonGroup.dataset.interfaceActive = newActiveValue
+           buttonGroup
+             .querySelectorAll('.btn')
+             .forEach(button => {
+               button.classList.toggle('active')
+               button.classList.toggle('btn-danger')
+               button.classList.toggle('btn-default')
+             })
+         }).catch(error => {
+           console.dir(error)
+         })
+       })
+     })
+ }
+
+ if (document.readyState !== 'loading') {
+   vendorActivityHandler()
+ } else {
+   document.addEventListener('DOMContentLoaded', vendorActivityHandler)
+ }
+</script>
 <h1>{{ vendor.display_name }}</h1>
 
 <h2>Vendor Interfaces</h2>
 
-<table class="table table-striped">
+<table id="vendor_interfaces" class="table table-striped">
     <thead>
         <th>Name</th>
         <th>Import Profile</th>
@@ -13,6 +58,7 @@
         <th>Remote Path</th>
         <th>Processing Delay</th>
         <th>Processing DAG</th>
+        <th>Active/Inactive</th>
     </thead>
     {% for interface in vendor.vendor_interfaces %}
     <tr>
@@ -22,6 +68,17 @@
         <td>{{ interface.remote_path }}</td>
         <td>{{ interface.processing_delay }}</td>
         <td>{{ interface.processing_dag }}</td>
+        <td>
+            <div class="btn-group btn-toggle" data-interface-url="{{ url_for('VendorManagementView.interface_edit', interface_id=interface.id) }}" data-interface-active="{{ interface.active|string|lower }}">
+                {% if interface.active %}
+                <button class="btn btn-danger active">Active</button>
+                <button class="btn btn-default">Inactive</button>
+                {% else %}
+                <button class="btn btn-default">Active</button>
+                <button class="btn btn-danger active">Inactive</button>
+                {% endif %}
+            </div>
+        </td>
     </tr>
     {% endfor %}
 </table>

--- a/libsys_airflow/plugins/vendor_app/vendors.py
+++ b/libsys_airflow/plugins/vendor_app/vendors.py
@@ -63,26 +63,29 @@ class VendorManagementView(BaseView):
         VendorInterface object.
         """
 
-        if form['folio-data-import-profile-uuid']:
+        if 'folio-data-import-profile-uuid' in form.keys():
             interface.folio_data_import_profile_uuid = form[
                 'folio-data-import-profile-uuid'
             ]
 
-        if form['folio-data-import-processing-name']:
+        if 'folio-data-import-processing-name' in form.keys():
             interface.folio_data_import_processing_name = form[
                 'folio-data-import-processing-name'
             ]
 
-        if form['processing-delay-in-days']:
+        if 'processing-delay-in-days' in form.keys():
             interface.processing_delay_in_days = int(form['processing-delay-in-days'])
 
-        if form['remote-path']:
+        if 'remote-path' in form.keys():
             interface.remote_path = form['remote-path']
 
-        if form['file-pattern']:
+        if 'file-pattern' in form.keys():
             interface.file_pattern = form['file-pattern']
 
-        if form['package-name']:
+        if 'active' in form.keys():
+            interface.active = form['active'] == 'true'
+
+        if 'package-name' in form.keys():
             processing_options = {}
             processing_options['package_name'] = form['package-name']
             processing_options['change_marc'] = []


### PR DESCRIPTION
Fixes #479

This commit changes the vendor load application so that users can disable and enable vendor interfaces, both from the vendor show view and the vendor interface edit view.

![enable_disable_vendor_interfaces](https://github.com/sul-dlss/libsys-airflow/assets/131982/5a87e2a8-73b8-4211-8f9f-97f42c570a42)

