### PR TITLE
Don't display None in form

### DIFF
--- a/libsys_airflow/plugins/vendor_app/templates/vendors/interface-edit.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/interface-edit.html
@@ -52,13 +52,13 @@
   <div class="form-group">
     <label for="remote-path" class="col-sm-2 col-form-label">Remote Path</label>
     <div class="col-sm-8">
-      <input type="text" class="form-control" id="remote-path" name="remote-path" placeholder="" value="{{ interface.remote_path }}">
+      <input type="text" class="form-control" id="remote-path" name="remote-path" placeholder="" value="{{ interface.remote_path if interface.remote_path }}">
     </div>
   </div>
   <div class="form-group">
     <label for="file-pattern" class="col-sm-2 col-form-label">File Pattern</label>
     <div class="col-sm-8">
-      <input type="text" class="form-control" id="file-pattern" name="file-pattern" placeholder="" value="{{ interface.file_pattern }}">
+      <input type="text" class="form-control" id="file-pattern" name="file-pattern" placeholder="" value="{{ interface.file_pattern if interface.file_pattern }}">
     </div>
   </div>
   <div class="form-group">
@@ -80,7 +80,7 @@
   <div class="form-group">
     <label for="package-name" class="col-sm-2 col-form-label">Package Name:</label>
     <div class="col-sm-8">
-      <input type="text" class="form-control" id="package-name" name="package-name" placeholder="" value="{{ interface.package_name }}">
+      <input type="text" class="form-control" id="package-name" name="package-name" placeholder="" value="{{ interface.package_name if interface.package_name }}">
     </div>
   </div>
 


### PR DESCRIPTION
A small change to prevent the string "None" from displaying when there is no value for a VendorInterface property. Somehow this change didn't make it into #482  
