### PR TITLE
Show status of in-progress and errorful files in vendor management dashboard

### DIFF
--- a/libsys_airflow/plugins/vendor_app/main.py
+++ b/libsys_airflow/plugins/vendor_app/main.py
@@ -13,11 +13,11 @@ vendor_mgt_bp = Blueprint(
 )
 
 # Vendor Management
-vendor_index_view = VendorManagementView()
-vendor_index_view_package = {
-    "name": "Vendors",
+vendor_management_view = VendorManagementView()
+vendor_management_view_package = {
+    "name": "Dashboard",
     "category": "Vendor Management",
-    "view": vendor_index_view,
+    "view": vendor_management_view,
 }
 
 
@@ -28,7 +28,7 @@ class VendorManagementPlugin(AirflowPlugin):
     hooks = []
     executors = []
     admin_views = []
-    appbuilder_views = [vendor_index_view_package]
+    appbuilder_views = [vendor_management_view_package]
     appbuilder_menu_items = []
 
 

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/_macros.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/_macros.html
@@ -1,3 +1,3 @@
-{% macro fileDownload(file) -%}
-  {% if file.status != 'purged' %}<a href="{{ url_for('VendorManagementView.download_file', file_id=file.id) }}"><span class="glyphicon glyphicon-save" aria-hidden="true" style="color: #017cee;"></span></a>{% endif %}
+{% macro fileDownload(file, link_text='<span class="glyphicon glyphicon-save" aria-hidden="true" style="color: #017cee;"></span>') -%}
+  {% if file.status != 'purged' %}<a href="{{ url_for('VendorManagementView.download_file', file_id=file.id) }}">{{ link_text|safe }}</a>{% endif %}
 {%- endmacro %}

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/dashboard.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/dashboard.html
@@ -1,0 +1,61 @@
+{% extends "airflow/main.html" %}
+{% import "vendors/_macros.html" as _macros -%}
+
+{% block content %}
+<div class="page-header">
+  <h1>Vendor Management</h1>
+</div>
+
+<ul class="nav nav-tabs">
+  <li role="presentation" class="active"><a href="{{ url_for('VendorManagementView.dashboard') }}">Dashboard</a></li>
+  <li role="presentation"><a href="{{ url_for('VendorManagementView.vendors') }}">Vendors</a></li>
+</ul>
+
+<div class="panel panel-success">
+  <div class="panel-heading"><h3>In Progress</h3></div>
+
+  <table class="table table-striped" id="inProgressTable">
+    <thead>
+      <th>Vendor</th>
+      <th>Vendor Interface</th>
+      <th>Filename</th>
+      <th>Status</th>
+    </thead>
+    <tbody>
+      {% for file in in_progress_files %}
+      <tr>
+        <td>{{ file.vendor_interface.vendor.display_name }}</td>
+        <td>{{ file.vendor_interface.display_name }}</td>
+        <td>{{ _macros.fileDownload(file, file.vendor_filename) }}</td>
+        <td>{{ file.status.value }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<div class="panel panel-danger">
+  <div class="panel-heading"><h3>Errors</h3></div>
+
+  <table class="table table-striped" id="errorsTable">
+    <thead>
+      <th>Vendor</th>
+      <th>Vendor Interface</th>
+      <th>Filename</th>
+      <th>Status</th>
+      <th>Retry</th>
+    </thead>
+    <tbody>
+      {% for file in errors_files %}
+      <tr>
+        <td>{{ file.vendor_interface.vendor.display_name }}</td>
+        <td>{{ file.vendor_interface.display_name }}</td>
+        <td>{{ _macros.fileDownload(file, file.vendor_filename) }}</td>
+        <td>{{ file.status.value }}</td>
+        <td>TBD</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/index.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/index.html
@@ -11,7 +11,19 @@
 {% endblock %}
 
 {% block content %}
-<h1>Vendors</h1>
+<div class="page-header">
+  <h1>Vendors</h1>
+</div>
+
+<ul class="nav nav-tabs">
+  <li role="presentation"><a href="{{ url_for('VendorManagementView.dashboard') }}">Dashboard</a></li>
+  <li role="presentation" class="active"><a href="{{ url_for('VendorManagementView.vendors') }}">Vendors</a></li>
+</ul>
+
+<ol class="breadcrumb">
+  <li class="active">All</li>
+</ol>
+
 <table class="table table-striped" id="vendorTable">
     <thead>
         <th>Name</th>

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/interface-edit.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/interface-edit.html
@@ -3,7 +3,21 @@
 {% block content %}
 {{ super() }}
 
-<h1>Edit Vendor Interface</h1>
+<div class="page-header">
+  <h1>Edit Vendor Interface</h1>
+</div>
+
+<ul class="nav nav-tabs">
+  <li role="presentation"><a href="{{ url_for('VendorManagementView.dashboard') }}">Dashboard</a></li>
+  <li role="presentation" class="active"><a href="{{ url_for('VendorManagementView.vendors') }}">Vendors</a></li>
+</ul>
+
+<ol class="breadcrumb">
+  <li><a href="{{ url_for('VendorManagementView.vendors') }}">All</a></li>
+  <li><a href="{{ url_for('VendorManagementView.vendor', vendor_id=interface.vendor.id) }}">{{ interface.vendor.display_name }}</a></li>
+  <li><a href="{{ url_for('VendorManagementView.interface', interface_id=interface.id) }}">{{ interface.display_name }}</a></li>
+  <li class="active">Edit</li>
+</ol>
 
 <form class="form-horizontal" method="post" action="{{ url_for('VendorManagementView.interface_edit', interface_id=interface.id) }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/interface.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/interface.html
@@ -2,7 +2,20 @@
 {% import "vendors/_macros.html" as _macros -%}
 
 {% block content %}
-<h1>Interface: {{ interface.display_name }}</h1>
+<div class="page-header">
+  <h1>Interface: {{ interface.display_name }}</h1>
+</div>
+
+<ul class="nav nav-tabs">
+  <li role="presentation"><a href="{{ url_for('VendorManagementView.dashboard') }}">Dashboard</a></li>
+  <li role="presentation" class="active"><a href="{{ url_for('VendorManagementView.vendors') }}">Vendors</a></li>
+</ul>
+
+<ol class="breadcrumb">
+  <li><a href="{{ url_for('VendorManagementView.vendors') }}">All</a></li>
+  <li><a href="{{ url_for('VendorManagementView.vendor', vendor_id=interface.vendor.id) }}">{{ interface.vendor.display_name }}</a></li>
+  <li class="active">{{ interface.display_name }}</li>
+</ol>
 
 <dl class="dl-horizontal">
   <dt>Vendor</dt>

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
@@ -46,13 +46,25 @@
    document.addEventListener('DOMContentLoaded', vendorActivityHandler)
  }
 </script>
-<h1>{{ vendor.display_name }}</h1>
+<div class="page-header">
+  <h1>{{ vendor.display_name }}</h1>
+</div>
+
+<ul class="nav nav-tabs">
+  <li role="presentation"><a href="{{ url_for('VendorManagementView.dashboard') }}">Dashboard</a></li>
+  <li role="presentation" class="active"><a href="{{ url_for('VendorManagementView.vendors') }}">Vendors</a></li>
+</ul>
+
+<ol class="breadcrumb">
+  <li><a href="{{ url_for('VendorManagementView.vendors') }}">All</a></li>
+  <li class="active">{{ vendor.display_name }}</li>
+</ol>
 
 <dl class="dl-horizontal">
     <dt>Organization ID</dt>
     <dd>{{ vendor.folio_organization_uuid }}</dd>
 </dl>
-  
+
 <h2>Vendor Interfaces</h2>
 
 <table id="vendor_interfaces" class="table table-striped">

--- a/tests/apps/vendor_app/test_interface_view.py
+++ b/tests/apps/vendor_app/test_interface_view.py
@@ -159,7 +159,7 @@ def test_interface_view(test_airflow_client, mock_db, mocker):  # noqa: F811
             'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
         )
 
-        response = test_airflow_client.get('/vendors/interface/1')
+        response = test_airflow_client.get('/vendor_management/interfaces/1')
         assert response.status_code == 200
         pending = response.html.find(id='pending-files')
         assert pending
@@ -178,7 +178,7 @@ def test_interface_edit_view(test_airflow_client, mock_db, mocker):  # noqa: F81
         mocker.patch(
             'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
         )
-        response = test_airflow_client.get('/vendors/interface/1/edit')
+        response = test_airflow_client.get('/vendor_management/interfaces/1/edit')
         assert response.status_code == 200
 
 
@@ -190,7 +190,7 @@ def test_reload_file(test_airflow_client, mock_db, mocker):  # noqa: F811
         mocker.patch(
             'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
         )
-        response = test_airflow_client.post('/vendors/file/1/load')
+        response = test_airflow_client.post('/vendor_management/file/1/load')
         assert response.status_code == 302
 
     with Session(mock_db()) as session:
@@ -224,7 +224,7 @@ def test_upload_file(test_airflow_client, mock_db, tmp_path, mocker):  # noqa: F
             'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
         )
         response = test_airflow_client.post(
-            '/vendors/interface/1/file',
+            '/vendor_management/interfaces/1/file',
             data={
                 'file-upload': (
                     open('tests/vendor/0720230118.mrc', 'rb'),
@@ -284,7 +284,7 @@ def test_download_file(test_airflow_client, mock_db, tmp_path, mocker):  # noqa:
             'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
         )
 
-        response = test_airflow_client.get('/vendors/file/1/download')
+        response = test_airflow_client.get('/vendor_management/file/1/download')
         assert response.status_code == 200
         assert response.content_type == 'application/octet-stream'
         assert response.content_length == 35981

--- a/tests/apps/vendor_app/test_vendor_management_view.py
+++ b/tests/apps/vendor_app/test_vendor_management_view.py
@@ -65,12 +65,22 @@ def mock_db(mocker, engine):
     yield mock_hook
 
 
-def test_vendor_views(test_airflow_client, mock_db, mocker):  # noqa: F811
+def test_vendors_dashboard_view(test_airflow_client, mock_db, mocker):  # noqa: F811
     with Session(mock_db()) as session:
         mocker.patch(
             'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
         )
-        response = test_airflow_client.get('/vendors/')
+        response = test_airflow_client.get('/vendor_management/')
+        assert response.status_code == 200
+        assert response.html.h1.text == "Vendor Management"
+
+
+def test_vendors_index_view(test_airflow_client, mock_db, mocker):  # noqa: F811
+    with Session(mock_db()) as session:
+        mocker.patch(
+            'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
+        )
+        response = test_airflow_client.get('/vendor_management/vendors')
         assert response.status_code == 200
         assert response.html.h1.text == "Vendors"
 
@@ -79,19 +89,19 @@ def test_vendor_views(test_airflow_client, mock_db, mocker):  # noqa: F811
 
         link = rows[0].find_all('td')[0].a
         assert link.text == "Acme"
-        assert link["href"] == "/vendors/1"
+        assert link["href"] == "/vendor_management/vendors/1"
 
         link = rows[1].find_all('td')[0].a
         assert link.text == "Cocina Tacos"
-        assert link["href"] == "/vendors/2"
+        assert link["href"] == "/vendor_management/vendors/2"
 
 
-def test_vendor_view(test_airflow_client, mock_db, mocker):  # noqa: F811
+def test_vendor_show_view(test_airflow_client, mock_db, mocker):  # noqa: F811
     with Session(mock_db()) as session:
         mocker.patch(
             'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
         )
-        response = test_airflow_client.get('/vendors/1')
+        response = test_airflow_client.get('/vendor_management/vendors/1')
         assert response.status_code == 200
         assert response.html.h1.text == "Acme"
 


### PR DESCRIPTION
Fixes #473

This commit adds a new vendor management dashboard page to the vendor management plugin/app, so that users can quickly ascertain the current state of vendor file processing by viewing which files are in progress and which are erroring. In support of this change, the following is also included:

* Rename vendor management view in `plugins/vendor_app/main.py`
  * Be clear hat this view is not merely the index page
* Make the new dashboard the sole link in the `Vendor Management` Airflow menu
* Use navigation tabs and breadcrumbs in the UI as navigational aids
  * Give the user a clearer sense of the organization of the vendor management app
* Tweak vendor management view URLs now that dashboard is `/`
  * Use `/vendors` and `/interfaces` for vendors and their interfaces
* Extend the `fileDownload` macro to allow overriding the link markup

# TO-DO

- [x] Figure out how to write tests (good enough or nah?)
- [ ] Implement retry functionality (punt to new ticket?)
- [ ] Link to data import ID of files that hit a loading error (punt to new ticket?)

# Screencast

**NOTE**: When I was developing, I was not sure how to get actual files in the right states such that I could control which dashboard table they display in, so I uploaded a single file and temporarily changed the logic for the dashboard tables such that they each show *all* files, which is why you see the same `uploaded` file in both tables. That's not a bug in the code.

![new_vendor_management_ux](https://github.com/sul-dlss/libsys-airflow/assets/131982/ff125574-04c0-462a-93de-4d181ad57fee)

