### PR TITLE
Adds test for multiple heads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ module and then run the following steps:
 1.  From the root directory, run `poetry run alembic revision --autogenerate -m "{short message describing change}"` (**NOTE:** not all changes to the model are detected, see this [note](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) in the documentation)
 1.  After the migration script is created, run `poetry run alembic upgrade head` to apply your latest changes to the database.
 
+To fix multiple heads: `poetry run alembic merge heads -m "merge <revision 1> and <revision 2>"
+
 #### Seeding Vendors
 
 Assuming that you have put Folio related environment variables in your `.env` file you can:

--- a/tests/vendor/test_alembic.py
+++ b/tests/vendor/test_alembic.py
@@ -1,0 +1,12 @@
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+# Based on https://blog.jerrycodes.com/multiple-heads-in-alembic-migrations/
+
+
+def test_only_single_head_revision_in_migrations():
+    config = Config('alembic.ini')
+    script = ScriptDirectory.from_config(config)
+
+    # This will raise if there are multiple heads
+    script.get_current_head()


### PR DESCRIPTION
closes #498

```
pytest tests/vendor/test_alembic.py
=============================================================================== test session starts ================================================================================
platform darwin -- Python 3.10.9, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/jlittman/data/libsys/libsys-airflow
configfile: setup.cfg
plugins: mock-3.10.0, requests-mock-1.10.0, mock-resources-2.6.12, cov-4.0.0, anyio-3.6.2
collected 1 item

tests/vendor/test_alembic.py F                                                                                                                                               [100%]/Users/jlittman/Library/Caches/pypoetry/virtualenvs/libsys-airflow-dh712-PM-py3.10/lib/python3.10/site-packages/coverage/control.py:801: CoverageWarning: No data was collected. (no-data-collected)
  self._warn("No data was collected.", slug="no-data-collected")
WARNING: Failed to generate report: No data to report.

/Users/jlittman/Library/Caches/pypoetry/virtualenvs/libsys-airflow-dh712-PM-py3.10/lib/python3.10/site-packages/pytest_cov/plugin.py:311: CovReportWarning: Failed to generate report: No data to report.

  warnings.warn(CovReportWarning(message))


===================================================================================== FAILURES =====================================================================================
___________________________________________________________________ test_only_single_head_revision_in_migrations ___________________________________________________________________

self = <alembic.script.base.ScriptDirectory object at 0x110678b80>, ancestor = None
multiple_heads = 'The script directory has multiple heads (due to branching).Please use get_heads(), or merge the branches using alembic merge.', start = None, end = None
resolution = None

    @contextmanager
    def _catch_revision_errors(
        self,
        ancestor: Optional[str] = None,
        multiple_heads: Optional[str] = None,
        start: Optional[str] = None,
        end: Optional[str] = None,
        resolution: Optional[str] = None,
    ) -> Iterator[None]:
        try:
>           yield

../../../Library/Caches/pypoetry/virtualenvs/libsys-airflow-dh712-PM-py3.10/lib/python3.10/site-packages/alembic/script/base.py:246:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <alembic.script.base.ScriptDirectory object at 0x110678b80>

    def get_current_head(self) -> Optional[str]:
        """Return the current head revision.

        If the script directory has multiple heads
        due to branching, an error is raised;
        :meth:`.ScriptDirectory.get_heads` should be
        preferred.

        :return: a string revision number.

        .. seealso::

            :meth:`.ScriptDirectory.get_heads`

        """
        with self._catch_revision_errors(
            multiple_heads=(
                "The script directory has multiple heads (due to branching)."
                "Please use get_heads(), or merge the branches using "
                "alembic merge."
            )
        ):
>           return self.revision_map.get_current_head()

../../../Library/Caches/pypoetry/virtualenvs/libsys-airflow-dh712-PM-py3.10/lib/python3.10/site-packages/alembic/script/base.py:395:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <alembic.script.revision.RevisionMap object at 0x110c68c70>, branch_label = None

    def get_current_head(
        self, branch_label: Optional[str] = None
    ) -> Optional[str]:
        """Return the current head revision.

        If the script directory has multiple heads
        due to branching, an error is raised;
        :meth:`.ScriptDirectory.get_heads` should be
        preferred.

        :param branch_label: optional branch name which will limit the
         heads considered to those which include that branch_label.

        :return: a string revision number.

        .. seealso::

            :meth:`.ScriptDirectory.get_heads`

        """
        current_heads: Sequence[str] = self.heads
        if branch_label:
            current_heads = self.filter_for_lineage(
                current_heads, branch_label
            )
        if len(current_heads) > 1:
>           raise MultipleHeads(
                current_heads,
                "%s@head" % branch_label if branch_label else "head",
            )
E           alembic.script.revision.MultipleHeads: Multiple heads are present for given argument 'head'; 35ba6262f0a0, 35c6cd1d594e

../../../Library/Caches/pypoetry/virtualenvs/libsys-airflow-dh712-PM-py3.10/lib/python3.10/site-packages/alembic/script/revision.py:491: MultipleHeads

The above exception was the direct cause of the following exception:

    def test_only_single_head_revision_in_migrations():
        config = Config('alembic.ini')
        # config.set_main_option("script_location", "libsys_airflow:vendor_loads_migration")
        script = ScriptDirectory.from_config(config)

        # This will raise if there are multiple heads
>       script.get_current_head()

tests/vendor/test_alembic.py:11:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../Library/Caches/pypoetry/virtualenvs/libsys-airflow-dh712-PM-py3.10/lib/python3.10/site-packages/alembic/script/base.py:388: in get_current_head
    with self._catch_revision_errors(
/usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/contextlib.py:153: in __exit__
    self.gen.throw(typ, value, traceback)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <alembic.script.base.ScriptDirectory object at 0x110678b80>, ancestor = None
multiple_heads = 'The script directory has multiple heads (due to branching).Please use get_heads(), or merge the branches using alembic merge.', start = None, end = None
resolution = None

    @contextmanager
    def _catch_revision_errors(
        self,
        ancestor: Optional[str] = None,
        multiple_heads: Optional[str] = None,
        start: Optional[str] = None,
        end: Optional[str] = None,
        resolution: Optional[str] = None,
    ) -> Iterator[None]:
        try:
            yield
        except revision.RangeNotAncestorError as rna:
            if start is None:
                start = cast(Any, rna.lower)
            if end is None:
                end = cast(Any, rna.upper)
            if not ancestor:
                ancestor = (
                    "Requested range %(start)s:%(end)s does not refer to "
                    "ancestor/descendant revisions along the same branch"
                )
            ancestor = ancestor % {"start": start, "end": end}
            raise util.CommandError(ancestor) from rna
        except revision.MultipleHeads as mh:
            if not multiple_heads:
                multiple_heads = (
                    "Multiple head revisions are present for given "
                    "argument '%(head_arg)s'; please "
                    "specify a specific target revision, "
                    "'<branchname>@%(head_arg)s' to "
                    "narrow to a specific head, or 'heads' for all heads"
                )
            multiple_heads = multiple_heads % {
                "head_arg": end or mh.argument,
                "heads": util.format_as_comma(mh.heads),
            }
>           raise util.CommandError(multiple_heads) from mh
E           alembic.util.exc.CommandError: The script directory has multiple heads (due to branching).Please use get_heads(), or merge the branches using alembic merge.

../../../Library/Caches/pypoetry/virtualenvs/libsys-airflow-dh712-PM-py3.10/lib/python3.10/site-packages/alembic/script/base.py:272: CommandError

---------- coverage: platform darwin, python 3.10.9-final-0 ----------

============================================================================= short test summary info ==============================================================================
FAILED tests/vendor/test_alembic.py::test_only_single_head_revision_in_migrations - alembic.util.exc.CommandError: The script directory has multiple heads (due to branching).Please use get_heads(), or merge the branches using alembic merge.
================================================================================ 1 failed in 0.45s =================================================================================
```
