### PR TITLE
Rename vendors to vendor_management

### DIFF
--- a/libsys_airflow/plugins/vendor_app/main.py
+++ b/libsys_airflow/plugins/vendor_app/main.py
@@ -1,7 +1,7 @@
 from airflow.plugins_manager import AirflowPlugin
 from flask import Blueprint
 
-from libsys_airflow.plugins.vendor_app.vendors import VendorManagementView
+from libsys_airflow.plugins.vendor_app.vendor_management import VendorManagementView
 from libsys_airflow.plugins.vendor_app.database import Session
 
 vendor_mgt_bp = Blueprint(

--- a/libsys_airflow/plugins/vendor_app/vendor_management.py
+++ b/libsys_airflow/plugins/vendor_app/vendor_management.py
@@ -194,7 +194,7 @@ class VendorManagementView(BaseView):
         session.commit()
         return new_vendor_file
 
-    @expose("/file/<int:file_id>/load", methods=["POST"])
+    @expose("/files/<int:file_id>/load", methods=["POST"])
     def load_file(self, file_id):
         session = Session()
         file = session.query(VendorFile).get(file_id)
@@ -210,7 +210,7 @@ class VendorManagementView(BaseView):
             )
         )
 
-    @expose("/file/<int:file_id>/download", methods=["GET"])
+    @expose("/files/<int:file_id>/download", methods=["GET"])
     def download_file(self, file_id):
         session = Session()
         file = session.query(VendorFile).get(file_id)

--- a/tests/airflow_client.py
+++ b/tests/airflow_client.py
@@ -4,7 +4,7 @@ from flask.wrappers import Response
 import pytest
 
 from conftest import root_directory
-from libsys_airflow.plugins.vendor_app.vendors import VendorManagementView
+from libsys_airflow.plugins.vendor_app.vendor_management import VendorManagementView
 
 
 @pytest.fixture

--- a/tests/apps/vendor_app/test_interface_view.py
+++ b/tests/apps/vendor_app/test_interface_view.py
@@ -154,7 +154,8 @@ def test_processed_files(engine):
 def test_interface_view(test_airflow_client, mock_db, mocker):  # noqa: F811
     with Session(mock_db()) as session:
         mocker.patch(
-            'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
+            'libsys_airflow.plugins.vendor_app.vendor_management.Session',
+            return_value=session,
         )
 
         response = test_airflow_client.get('/vendor_management/interfaces/1')
@@ -174,7 +175,8 @@ def test_interface_view(test_airflow_client, mock_db, mocker):  # noqa: F811
 def test_interface_edit_view(test_airflow_client, mock_db, mocker):  # noqa: F811
     with Session(mock_db()) as session:
         mocker.patch(
-            'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
+            'libsys_airflow.plugins.vendor_app.vendor_management.Session',
+            return_value=session,
         )
         response = test_airflow_client.get('/vendor_management/interfaces/1/edit')
         assert response.status_code == 200
@@ -182,13 +184,14 @@ def test_interface_edit_view(test_airflow_client, mock_db, mocker):  # noqa: F81
 
 def test_reload_file(test_airflow_client, mock_db, mocker):  # noqa: F811
     mock_trigger_dag = mocker.patch(
-        'libsys_airflow.plugins.vendor_app.vendors.trigger_dag'
+        'libsys_airflow.plugins.vendor_app.vendor_management.trigger_dag'
     )
     with Session(mock_db()) as session:
         mocker.patch(
-            'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
+            'libsys_airflow.plugins.vendor_app.vendor_management.Session',
+            return_value=session,
         )
-        response = test_airflow_client.post('/vendor_management/file/1/load')
+        response = test_airflow_client.post('/vendor_management/files/1/load')
         assert response.status_code == 302
 
     with Session(mock_db()) as session:
@@ -208,7 +211,7 @@ def test_reload_file(test_airflow_client, mock_db, mocker):  # noqa: F811
 
 def test_upload_file(test_airflow_client, mock_db, tmp_path, mocker):  # noqa: F811
     mock_trigger_dag = mocker.patch(
-        'libsys_airflow.plugins.vendor_app.vendors.trigger_dag'
+        'libsys_airflow.plugins.vendor_app.vendor_management.trigger_dag'
     )
     mocker.patch(
         'libsys_airflow.plugins.vendor.paths.vendor_data_basepath',
@@ -220,7 +223,8 @@ def test_upload_file(test_airflow_client, mock_db, tmp_path, mocker):  # noqa: F
 
     with Session(mock_db()) as session:
         mocker.patch(
-            'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
+            'libsys_airflow.plugins.vendor_app.vendor_management.Session',
+            return_value=session,
         )
         response = test_airflow_client.post(
             '/vendor_management/interfaces/1/file',
@@ -283,10 +287,11 @@ def test_download_file(test_airflow_client, mock_db, tmp_path, mocker):  # noqa:
 
     with Session(mock_db()) as session:
         mocker.patch(
-            'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
+            'libsys_airflow.plugins.vendor_app.vendor_management.Session',
+            return_value=session,
         )
 
-        response = test_airflow_client.get('/vendor_management/file/1/download')
+        response = test_airflow_client.get('/vendor_management/files/1/download')
         assert response.status_code == 200
         assert response.content_type == 'application/octet-stream'
         assert response.content_length == 35981

--- a/tests/apps/vendor_app/test_vendor_management_view.py
+++ b/tests/apps/vendor_app/test_vendor_management_view.py
@@ -68,7 +68,8 @@ def mock_db(mocker, engine):
 def test_vendors_dashboard_view(test_airflow_client, mock_db, mocker):  # noqa: F811
     with Session(mock_db()) as session:
         mocker.patch(
-            'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
+            'libsys_airflow.plugins.vendor_app.vendor_management.Session',
+            return_value=session,
         )
         response = test_airflow_client.get('/vendor_management/')
         assert response.status_code == 200
@@ -78,7 +79,8 @@ def test_vendors_dashboard_view(test_airflow_client, mock_db, mocker):  # noqa: 
 def test_vendors_index_view(test_airflow_client, mock_db, mocker):  # noqa: F811
     with Session(mock_db()) as session:
         mocker.patch(
-            'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
+            'libsys_airflow.plugins.vendor_app.vendor_management.Session',
+            return_value=session,
         )
         response = test_airflow_client.get('/vendor_management/vendors')
         assert response.status_code == 200
@@ -99,7 +101,8 @@ def test_vendors_index_view(test_airflow_client, mock_db, mocker):  # noqa: F811
 def test_vendor_show_view(test_airflow_client, mock_db, mocker):  # noqa: F811
     with Session(mock_db()) as session:
         mocker.patch(
-            'libsys_airflow.plugins.vendor_app.vendors.Session', return_value=session
+            'libsys_airflow.plugins.vendor_app.vendor_management.Session',
+            return_value=session,
         )
         response = test_airflow_client.get('/vendor_management/vendors/1')
         assert response.status_code == 200


### PR DESCRIPTION
Since we changed the URL for the plugin it seemed like it made sense to also change the module name. Also since most of the URL paths have been pluralized (vendors, interfaces) I thought it made sense to pluralize file as well for consistency.
