### PR TITLE
Deploy tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cap alembic:migrate  # Run Alembic database migrations
 
 ## For subsequent deploys
 
-`cap ${env} deploy deploy:restart`
+`cap ${env} deploy`
 
 This will stop and remove the docker images for the previous release and start up a new one.
 
@@ -199,7 +199,7 @@ dotenv run bin/seed_vendors --limited
 
 In a deployed environment, the full load can be run as:
 ```
-docker exec -it 20230516183735-airflow-webserver-1 bin/seed_vendors
+docker exec -it libsys_airflow-airflow-webserver-1 bin/seed_vendors
 ```
 where `20230516183735-airflow-webserver-1` is the container id.
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,6 +23,7 @@ set :linked_dirs, %w[config vendor-data vendor-keys]
 set :keep_releases, 2
 
 before 'deploy:cleanup', 'fix_permissions'
+before 'deploy:published', 'deploy:restart'
 
 desc 'Change release directories ownership'
 task :fix_permissions do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -122,21 +122,21 @@ namespace :airflow do
   desc 'run docker compose build for airflow'
   task :build do
     on roles(:app) do
-      execute "cd #{release_path} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml build"
+      execute "cd #{release_path} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml -p libsys_airflow build"
     end
   end
 
   desc 'stop and remove all running docker containers'
   task :stop do
     on roles(:app) do
-      execute "cd #{release_path} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml stop"
+      execute "cd #{release_path} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml -p libsys_airflow stop"
     end
   end
 
   desc 'run docker compose init for airflow'
   task :init do
     on roles(:app) do
-      execute "cd #{release_path} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml up airflow-init"
+      execute "cd #{release_path} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml -p libsys_airflow up airflow-init"
     end
   end
 
@@ -145,7 +145,7 @@ namespace :airflow do
     on roles(:app) do
       invoke 'airflow:build'
       invoke 'airflow:init'
-      execute "cd #{release_path} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml up -d"
+      execute "cd #{release_path} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml -p libsys_airflow up -d"
       invoke 'db:create'
       invoke 'alembic:migrate'
     end
@@ -154,7 +154,7 @@ namespace :airflow do
   desc 'restart webserver'
   task :webserver do
     on roles(:app) do
-      execute "cd #{release_path} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml restart airflow-webserver"
+      execute "cd #{release_path} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml -p libsys_airflow restart airflow-webserver"
     end
   end
 
@@ -170,7 +170,7 @@ namespace :airflow do
   task :stop_release do
     on roles(:app) do
       execute "docker image prune -f"
-      execute "cd #{release_path} && releases=($(ls -tr ../.)) && cd ../${releases[0]} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml stop"
+      execute "cd #{release_path} && releases=($(ls -tr ../.)) && cd ../${releases[0]} && source #{fetch(:venv)} && docker compose -f docker-compose.prod.yaml -p libsys_airflow stop"
       execute "[[ $(docker ps -aq) ]] && docker ps -aq | xargs docker stop | xargs docker rm || echo 'no containers to stop'"
     end
   end


### PR DESCRIPTION
* Specify project instead of using timestamp.
* Add restart into deploy flow.

```
$ docker ps
CONTAINER ID   IMAGE                              COMMAND                  CREATED              STATUS                             PORTS                    NAMES
abcef79e5d9c   libsys_airflow-airflow-webserver   "/usr/bin/dumb-init …"   46 seconds ago       Up 31 seconds (health: starting)   0.0.0.0:3000->8080/tcp   libsys_airflow-airflow-webserver-1
64ccfba1ec18   libsys_airflow-airflow-worker      "/usr/bin/dumb-init …"   46 seconds ago       Up 30 seconds (healthy)            8080/tcp                 libsys_airflow-airflow-worker-1
5cbac78ea9ce   libsys_airflow-airflow-scheduler   "/usr/bin/dumb-init …"   46 seconds ago       Up 30 seconds (healthy)            8080/tcp                 libsys_airflow-airflow-scheduler-1
188aa08944b3   libsys_airflow-airflow-triggerer   "/usr/bin/dumb-init …"   46 seconds ago       Up 30 seconds (healthy)            8080/tcp                 libsys_airflow-airflow-triggerer-1
74ce37c47a91   redis:latest                       "docker-entrypoint.s…"   About a minute ago   Up About a minute (healthy)        6379/tcp                 libsys_airflow-redis-1
```