### PR TITLE
Make iteration deterministic for test

### DIFF
--- a/libsys_airflow/plugins/folio/helpers/marc.py
+++ b/libsys_airflow/plugins/folio/helpers/marc.py
@@ -287,8 +287,8 @@ def discover_srs_files(*args, **kwargs):
 
     iterations_dir = pathlib.Path(airflow) / "migration/iterations"
     srs_iterations = []
-    # Checks for SRS bibs
-    for iteration in iterations_dir.iterdir():
+    # Checks for SRS bibs, sorts to make iteration deterministic
+    for iteration in sorted(iterations_dir.iterdir()):
         srs_file = iteration / "results/folio_srs_instances_bibs-transformer.json"
         if srs_file.exists():
             srs_iterations.append(str(iteration))


### PR DESCRIPTION
With the switch to the Ubuntu image for CI workflows revealed difference in iteration with Mac image.  PR makes sorting for the `migration/iterations` directories deterministic.