### PR TITLE
data_import: _record_status sets vendor_file.loaded_timestamp when updating .status to FileStatus.loaded

### DIFF
--- a/libsys_airflow/plugins/folio/data_import.py
+++ b/libsys_airflow/plugins/folio/data_import.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 import os
 import pathlib
@@ -151,7 +152,7 @@ def _process_files(
     )
 
 
-def _record_status(context, status):
+def _record_status(context, status: FileStatus):
     vendor_interface_uuid = context["params"]["vendor_interface_uuid"]
     filename = context["params"]["filename"]
 
@@ -161,6 +162,8 @@ def _record_status(context, status):
     with Session(pg_hook.get_sqlalchemy_engine()) as session:
         vendor_file = VendorFile.load(vendor_interface_uuid, filename, session)
         vendor_file.status = status
+        if status is FileStatus.loaded:
+            vendor_file.loaded_timestamp = datetime.utcnow()
         session.commit()
 
 

--- a/tests/test_data_import.py
+++ b/tests/test_data_import.py
@@ -248,9 +248,14 @@ def test_record_loading(context, pg_hook):
             select(VendorFile).where(VendorFile.vendor_filename == "3820230411.mrc")
         ).first()
         assert vendor_file.status == FileStatus.loading
+        assert vendor_file.loaded_timestamp is None
 
 
-def test_record_loaded(context, pg_hook):
+def test_record_loaded(context, pg_hook, mocker):
+    now = datetime(2019, 5, 18, 15, 17, 8, 132263)
+    mock_datetime = mocker.patch('libsys_airflow.plugins.folio.data_import.datetime')
+    mock_datetime.utcnow.return_value = now
+
     record_loaded(context)
 
     with Session(pg_hook()) as session:
@@ -258,6 +263,7 @@ def test_record_loaded(context, pg_hook):
             select(VendorFile).where(VendorFile.vendor_filename == "3820230411.mrc")
         ).first()
         assert vendor_file.status == FileStatus.loaded
+        assert vendor_file.loaded_timestamp == now
 
 
 def test_record_loading_error(context, pg_hook):
@@ -268,6 +274,7 @@ def test_record_loading_error(context, pg_hook):
             select(VendorFile).where(VendorFile.vendor_filename == "3820230411.mrc")
         ).first()
         assert vendor_file.status == FileStatus.loading_error
+        assert vendor_file.loaded_timestamp is None
 
 
 def test_marc_datatype(download_path):


### PR DESCRIPTION
closes #555

i haven't done a data load myself yet, so i was a bit unsure how to test this realistically.  but happy to do that either locally or in a deployed env if there or instructions or if someone wouldn't mind pairing on it?