### PR TITLE
Make interface show view definition list wider

### DIFF
--- a/libsys_airflow/plugins/vendor_app/templates/vendors/interface.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/interface.html
@@ -1,6 +1,18 @@
 {% extends "airflow/main.html" %}
 {% import "vendors/_macros.html" as _macros -%}
 
+{% block head_css %}
+{{ super() }}
+<style type="text/css">
+  dl.dl-wide > dt {
+    width: 200px;
+  }
+  dl.dl-wide > dd {
+    margin-left: 220px;
+  }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="page-header">
   <h1>Interface: {{ interface.display_name }}</h1>
@@ -17,7 +29,7 @@
   <li class="active">{{ interface.display_name }}</li>
 </ol>
 
-<dl class="dl-horizontal">
+<dl class="dl-horizontal dl-wide">
   <dt>Vendor</dt>
   <dd><a href="{{ url_for('VendorManagementView.vendor', vendor_id=interface.vendor.id) }}">{{ interface.vendor.display_name }}</a></dd>
   <dt>Interface ID</dt>


### PR DESCRIPTION
Fixes #596

This commit makes a small improvement to the interface show view: displaying the "Assigned to vendor in FOLIO" label in full (without truncation), by adding a new custom class to the surrounding `<dl>` that gives each child `<dt>` 40 additional pixels, retaining the 20px margin between each term in the list and its definition. Went this route over splitting the label onto another line since we intentionally chose a horizontal definition list for this page, and adding an additional line gives the appearance of another term/definition pair.

![Screenshot from 2023-06-08 08-54-19](https://github.com/sul-dlss/libsys-airflow/assets/131982/aa997b8c-448a-4906-b2dc-e463ea623583)

