### PR TITLE
[README] fix vault kv list typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Based on the documentation, [Running Airflow in Docker](https://airflow.apache.o
 - `AIRFLOW_VAR_MIGRATION_USER`
 - `AIRFLOW_VAR_MIGRATION_PASSWORD`
 
-  These environment variables must be prefixed with `AIRFLOW_VAR_` to be accessible to DAGs. (See [Airflow env var documentation](https://airflow.apache.org/docs/apache-airflow/stable/howto/variable.html#storing-variables-in-environment-variables and `docker-compose.yml`).) They can have placeholder values. The secrets are in vault, not prefixed by `AIRFLOW_VAR_`: `vault kv list puppet/application/libsys-airflow/{env}`.
+  These environment variables must be prefixed with `AIRFLOW_VAR_` to be accessible to DAGs. (See [Airflow env var documentation](https://airflow.apache.org/docs/apache-airflow/stable/howto/variable.html#storing-variables-in-environment-variables and `docker-compose.yml`).) They can have placeholder values. The secrets are in vault, not prefixed by `AIRFLOW_VAR_`: `vault kv list puppet/application/libsys_airflow/{env}`.
 
   **NOTE** In order to connect to the OKAPI_URL you must be connected to the VPN or the on-campus network.
 


### PR DESCRIPTION
small tweak to fix the vault path suggested in the README (tested from my laptop, where the updated command worked, but the original got a "No value found" error)