### PR TITLE
Sort files on interface show view by last updated

### DIFF
--- a/libsys_airflow/plugins/vendor/models.py
+++ b/libsys_airflow/plugins/vendor/models.py
@@ -103,7 +103,7 @@ class VendorInterface(Model):
                     ]
                 )
             )
-            .order_by(VendorFile.created.desc())
+            .order_by(VendorFile.updated.desc())
         ).all()
 
     @property
@@ -116,7 +116,7 @@ class VendorInterface(Model):
             .filter(
                 VendorFile.status.in_([FileStatus.loaded, FileStatus.loading_error])
             )
-            .order_by(VendorFile.loaded_timestamp.desc())
+            .order_by(VendorFile.updated.desc())
         ).all()
 
     @property

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/interface.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/interface.html
@@ -3,14 +3,20 @@
 
 {% block head_css %}
 {{ super() }}
-<style type="text/css">
-  dl.dl-wide > dt {
-    width: 200px;
-  }
-  dl.dl-wide > dd {
-    margin-left: 220px;
-  }
-</style>
+    <link href="https://cdn.jsdelivr.net/npm/simple-datatables@7/dist/style.css" rel="stylesheet" type="text/css">
+    <style type="text/css">
+        dl.dl-wide > dt {
+          width: 200px;
+        }
+        dl.dl-wide > dd {
+          margin-left: 220px;
+        }
+    </style>
+{% endblock %}
+
+{% block head_js %}
+    {{ super() }}
+    <script src="https://cdn.jsdelivr.net/npm/simple-datatables@7" type="text/javascript"></script>
 {% endblock %}
 
 {% block content %}
@@ -110,65 +116,85 @@
 {% endif %}
 
 
-<h2>File Fetched</h2>
+<h2>Files Fetched</h2>
 
 <table id="pending-files" class="table table-striped table-condensed">
   <thead>
-    <td>ID</td>
-    <td>Created</td>
-    <td>Updated</td>
-    <td>Filename</td>
-    <td>File Size</td>
-    <td>File Timestamp</td>
-    <td>Expected Load</td>
-    <td>Status</td>
+    <th>ID</th>
+    <th>Created</th>
+    <th>Updated</th>
+    <th>Filename</th>
+    <th>File Size</th>
+    <th>File Timestamp</th>
+    <th>Expected Load</th>
+    <th>Status</th>
   </thead>
-  {% for file in interface.pending_files %}
-  <tr>
-    <td><a href="{{ url_for('VendorManagementView.file', file_id=file.id) }}">{{ file.id }}</a></td>
-    <td>{{ file.created }}</td>
-    <td>{{ file.updated }}</td>
-    <td>{{ file.vendor_filename }} {{ _macros.fileDownload(file) }}</td>
-    <td>{{ file.filesize }}</td>
-    <td>{{ file.vendor_timestamp }}</td>
-    <td>{{ file.expected_load_time }}</td>
-    <td>{{ file.status.value }}</td>
-  </tr>
-  {% endfor %}
+  <tbody>
+    {% for file in interface.pending_files %}
+    <tr>
+      <td><a href="{{ url_for('VendorManagementView.file', file_id=file.id) }}">{{ file.id }}</a></td>
+      <td>{{ file.created }}</td>
+      <td>{{ file.updated }}</td>
+      <td>{{ file.vendor_filename }} {{ _macros.fileDownload(file) }}</td>
+      <td>{{ file.filesize }}</td>
+      <td>{{ file.vendor_timestamp }}</td>
+      <td>{{ file.expected_load_time }}</td>
+      <td>{{ file.status.value }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
 </table>
 
 <h2>Sent to Data Import</h2>
 
 <table id="loaded-files" class="table table-striped table-condensed">
   <thead>
-    <td>ID</td>
-    <td>Created</td>
-    <td>Updated</td>
-    <td>Filename</td>
-    <td>File Size</td>
-    <td>File Timestamp</td>
-    <td>Loaded</td>
-    <td>Actions</td>
+    <th>ID</th>
+    <th>Created</th>
+    <th>Updated</th>
+    <th>Filename</th>
+    <th>File Size</th>
+    <th>File Timestamp</th>
+    <th>Loaded</th>
+    <th data-sortable="false">Actions</th>
   </thead>
-  {% for file in interface.processed_files %}
-  <tr>
-    <td><a href="{{ url_for('VendorManagementView.file', file_id=file.id) }}">{{ file.id }}</a></td>
-    <td>{{ file.created }}</td>
-    <td>{{ file.updated }}</td>
-    <td>{{ file.vendor_filename }} {{ _macros.fileDownload(file) }}</td>
-    <td>{{ file.filesize }}</td>
-    <td>{{ file.vendor_timestamp }}</td>
-    <td>{{ file.loaded_timestamp }}</td>
-    <td>
-      {% if interface.assigned_in_folio or interface.upload_only %}
-      <form action="{{ url_for('VendorManagementView.load_file', file_id=file.id, redirect_url=request.url) }}" method="POST">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <input class="btn btn-link" type="submit" value="Reload" style="padding: 0px;">
-      </form>
-      {% endif %}
-    </td>
-  </tr>
-  {% endfor %}
+  <tbody>
+    {% for file in interface.processed_files %}
+    <tr>
+      <td><a href="{{ url_for('VendorManagementView.file', file_id=file.id) }}">{{ file.id }}</a></td>
+      <td>{{ file.created }}</td>
+      <td>{{ file.updated }}</td>
+      <td>{{ file.vendor_filename }} {{ _macros.fileDownload(file) }}</td>
+      <td>{{ file.filesize }}</td>
+      <td>{{ file.vendor_timestamp }}</td>
+      <td>{{ file.loaded_timestamp }}</td>
+      <td>
+        {% if interface.assigned_in_folio or interface.upload_only %}
+        <form action="{{ url_for('VendorManagementView.load_file', file_id=file.id, redirect_url=request.url) }}" method="POST">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <input class="btn btn-link" type="submit" value="Reload" style="padding: 0px;">
+        </form>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
 </table>
 
+<script type="text/javascript">
+    new simpleDatatables.DataTable("#pending-files", {
+      searchable: true,
+      fixedHeight: true,
+      perPage: 100,
+      perPageSelect: false
+    });
+    new simpleDatatables.DataTable("#loaded-files", {
+      searchable: true,
+      fixedHeight: true,
+      perPage: 100,
+      perPageSelect: false
+    });
+    document.querySelector(".datatable-selector").classList.add("form-control");
+    document.querySelector(".datatable-input").classList.add("form-control");
+</script>
 {% endblock %}

--- a/tests/apps/vendor_app/test_interface_view.py
+++ b/tests/apps/vendor_app/test_interface_view.py
@@ -161,9 +161,9 @@ def test_pending_files(engine):
         pending = interface.pending_files
         assert len(pending) == 3
         assert [v.vendor_filename for v in pending] == [
+            "acme-ftp-broken-marc.dat",
             "acme-extra-strength-marc.dat",
             "acme-lite-marc.dat",
-            "acme-ftp-broken-marc.dat",
         ]
 
 
@@ -173,8 +173,8 @@ def test_processed_files(engine):
         processed = interface.processed_files
         assert len(processed) == 2
         assert [v.vendor_filename for v in processed] == [
-            "acme-marc.dat",
             "acme-bad-marc.dat",
+            "acme-marc.dat",
         ]
 
 


### PR DESCRIPTION
Fixes sul-dlss/FOLIO-Project-Stanford#449

This commit makes three changes:

1. Sets the default sort for pending and processed files for an interface to sort by updated date (descending, newest first)
2. Uses the simple-datatables client-side library to allow users to search, page, and sort these tables more flexibly
3. Corrects the `File Fetched` heading to `Files Fetched`

# Screenshot

**NOTE**: Image below does not show the default sort order set to descending updated date, since I was using dummy data (just HTML copypasta, with no vendor files in the DB).

![Screenshot from 2023-06-08 11-58-11](https://github.com/sul-dlss/libsys-airflow/assets/131982/7ab70b4a-ea77-40b1-a12a-1a953cd783ec)

