### PR TITLE
Display interface UUID in interface list.

### DIFF
--- a/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
@@ -74,7 +74,10 @@
     </thead>
     {% for interface in vendor.vendor_interfaces %}
     <tr>
-        <td><a href="{{ url_for('VendorManagementView.interface', interface_id=interface.id) }}">{{ interface.display_name }}</a>{% if interface.upload_only %} <span class="badge">Upload only</span>{% endif %}</td>
+        <td>
+          <div><a href="{{ url_for('VendorManagementView.interface', interface_id=interface.id) }}">{{ interface.display_name }}</a>{% if interface.upload_only %} <span class="badge">Upload only</span>{% endif %}</div>
+          <div>{{ interface.folio_interface_uuid or "" }}</div>
+        </td>
         <td>{{ interface.folio_data_import_processing_name or "Skip import" }}</td>
         <td>{{ interface.file_pattern }}</td>
         <td>{{ interface.remote_path }}</td>


### PR DESCRIPTION
This is helpful for troubleshooting since sometimes logs only have interface UUID.

![image](https://github.com/sul-dlss/libsys-airflow/assets/588335/4ce2c268-48f7-45ce-96c6-e140c7919cdb)
