### PR TITLE
if no vendor has no interfaces, show informative message instead of table with no rows (close 638 if this is merged)

### DIFF
--- a/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
@@ -73,42 +73,46 @@
   {% endif %}
 </div>
 
-<h2>Vendor Interfaces</h2>
+{% if vendor.vendor_interfaces | length > 0 %}
+    <h2>Vendor Interfaces</h2>
 
-<table id="vendor_interfaces" class="table table-striped">
-    <thead>
-        <th>Name</th>
-        <th>Import Profile</th>
-        <th>File Pattern</th>
-        <th>Remote Path</th>
-        <th>Processing Delay</th>
-        <th>Processing DAG</th>
-        <th>Inactive/Active</th>
-    </thead>
-    {% for interface in vendor.vendor_interfaces %}
-    <tr>
-        <td>
-          <div><a href="{{ url_for('VendorManagementView.interface', interface_id=interface.id) }}">{{ interface.display_name }}</a>{% if interface.upload_only %} <span class="badge">Upload only</span>{% endif %}</div>
-          <div>{{ interface.folio_interface_uuid or "" }}</div>
-        </td>
-        <td>{{ interface.folio_data_import_processing_name or "Skip import" }}</td>
-        <td>{{ interface.file_pattern }}</td>
-        <td>{{ interface.remote_path }}</td>
-        <td>{{ interface.processing_delay }}</td>
-        <td>{{ interface.processing_dag }}</td>
-        <td>
-          {% if interface.folio_interface_uuid and not interface.assigned_in_folio %}
-            <p>Not assigned to vendor in FOLIO</p>
-          {% else %}
-            <label class="switch-label">
-                <input class="switch-input" type="checkbox" {% if interface.active %} checked {% endif %} data-interface-url="{{ url_for('VendorManagementView.interface_edit', interface_id=interface.id) }}">
-                <span class="switch" aria-hidden="true"></span>
-            </label>
-          {% endif %}
-        </td>
-    </tr>
-    {% endfor %}
-</table>
+    <table id="vendor_interfaces" class="table table-striped">
+        <thead>
+            <th>Name</th>
+            <th>Import Profile</th>
+            <th>File Pattern</th>
+            <th>Remote Path</th>
+            <th>Processing Delay</th>
+            <th>Processing DAG</th>
+            <th>Inactive/Active</th>
+        </thead>
+        {% for interface in vendor.vendor_interfaces %}
+        <tr>
+            <td>
+              <div><a href="{{ url_for('VendorManagementView.interface', interface_id=interface.id) }}">{{ interface.display_name }}</a>{% if interface.upload_only %} <span class="badge">Upload only</span>{% endif %}</div>
+              <div>{{ interface.folio_interface_uuid or "" }}</div>
+            </td>
+            <td>{{ interface.folio_data_import_processing_name or "Skip import" }}</td>
+            <td>{{ interface.file_pattern }}</td>
+            <td>{{ interface.remote_path }}</td>
+            <td>{{ interface.processing_delay }}</td>
+            <td>{{ interface.processing_dag }}</td>
+            <td>
+              {% if interface.folio_interface_uuid and not interface.assigned_in_folio %}
+                <p>Not assigned to vendor in FOLIO</p>
+              {% else %}
+                <label class="switch-label">
+                    <input class="switch-input" type="checkbox" {% if interface.active %} checked {% endif %} data-interface-url="{{ url_for('VendorManagementView.interface_edit', interface_id=interface.id) }}">
+                    <span class="switch" aria-hidden="true"></span>
+                </label>
+              {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+{% else %}
+    <h3><em>No interfaces configured for {{ vendor.display_name }}</em></h3>
+{% endif %}
 
 <form method="POST" action="{{ url_for('VendorManagementView.create_vendor_interface', vendor_id=vendor.id) }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>


### PR DESCRIPTION
i didn't see unit tests for this page, so i just tested manually and took screenshots, but happy to revisit that if desired.

closes #590

1/2 slightly different implementations.  this one sticks a bit more literally to what the ticket asked for, but is slightly less consistent with the table headers and empty table message we show in a similar situation, when there are no vendors to list (e.g. /vendor_management/vendors?filter=active_interfaces when no interfaces are active).

fwiw, the ticket didn't ask for a placeholder message at all, but it seemed like some text would be helpful?

before:
<img width="1135" alt="Screen Shot 2023-06-13 at 12 24 55 AM" src="https://github.com/sul-dlss/libsys-airflow/assets/7741604/8127b1c2-f236-4299-a66b-bdfdb805e8db">


after:
<img width="1132" alt="Screen Shot 2023-06-13 at 12 25 29 AM" src="https://github.com/sul-dlss/libsys-airflow/assets/7741604/3ceccbf8-2684-4cb4-9b6f-c3db8774d52e">


still works when there are interfaces:
<img width="1130" alt="Screen Shot 2023-06-13 at 12 28 47 AM" src="https://github.com/sul-dlss/libsys-airflow/assets/7741604/a43bb739-1ed5-4d30-b0be-70dd9c73c25e">
