### PR TITLE
if no vendor has no interfaces, show informative message where table rows would be (close 637 if this is merged)

### DIFF
--- a/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/vendor.html
@@ -85,29 +85,33 @@
         <th>Processing DAG</th>
         <th>Inactive/Active</th>
     </thead>
-    {% for interface in vendor.vendor_interfaces %}
-    <tr>
-        <td>
-          <div><a href="{{ url_for('VendorManagementView.interface', interface_id=interface.id) }}">{{ interface.display_name }}</a>{% if interface.upload_only %} <span class="badge">Upload only</span>{% endif %}</div>
-          <div>{{ interface.folio_interface_uuid or "" }}</div>
-        </td>
-        <td>{{ interface.folio_data_import_processing_name or "Skip import" }}</td>
-        <td>{{ interface.file_pattern }}</td>
-        <td>{{ interface.remote_path }}</td>
-        <td>{{ interface.processing_delay }}</td>
-        <td>{{ interface.processing_dag }}</td>
-        <td>
-          {% if interface.folio_interface_uuid and not interface.assigned_in_folio %}
-            <p>Not assigned to vendor in FOLIO</p>
-          {% else %}
-            <label class="switch-label">
-                <input class="switch-input" type="checkbox" {% if interface.active %} checked {% endif %} data-interface-url="{{ url_for('VendorManagementView.interface_edit', interface_id=interface.id) }}">
-                <span class="switch" aria-hidden="true"></span>
-            </label>
-          {% endif %}
-        </td>
-    </tr>
-    {% endfor %}
+    {% if vendor.vendor_interfaces %}
+        {% for interface in vendor.vendor_interfaces %}
+            <tr>
+                <td>
+                  <div><a href="{{ url_for('VendorManagementView.interface', interface_id=interface.id) }}">{{ interface.display_name }}</a>{% if interface.upload_only %} <span class="badge">Upload only</span>{% endif %}</div>
+                  <div>{{ interface.folio_interface_uuid or "" }}</div>
+                </td>
+                <td>{{ interface.folio_data_import_processing_name or "Skip import" }}</td>
+                <td>{{ interface.file_pattern }}</td>
+                <td>{{ interface.remote_path }}</td>
+                <td>{{ interface.processing_delay }}</td>
+                <td>{{ interface.processing_dag }}</td>
+                <td>
+                  {% if interface.folio_interface_uuid and not interface.assigned_in_folio %}
+                    <p>Not assigned to vendor in FOLIO</p>
+                  {% else %}
+                    <label class="switch-label">
+                        <input class="switch-input" type="checkbox" {% if interface.active %} checked {% endif %} data-interface-url="{{ url_for('VendorManagementView.interface_edit', interface_id=interface.id) }}">
+                        <span class="switch" aria-hidden="true"></span>
+                    </label>
+                  {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+    {% else %}
+        <tr><td colspan="7" class="text-center"><em>No interfaces configured for {{ vendor.display_name }}</em></td></tr>
+    {% endif %}
 </table>
 
 <form method="POST" action="{{ url_for('VendorManagementView.create_vendor_interface', vendor_id=vendor.id) }}">


### PR DESCRIPTION
i didn't see unit tests for this page, so i just tested manually and took screenshots, but happy to revisit that if desired.

closes #590

2/2 slightly different implementations.  this one deviates a bit more from what the ticket literally asked for, but i think is more consistent with the table headers and empty table message we show in a similar situation, when there are no vendors to list (e.g. /vendor_management/vendors?filter=active_interfaces when no interfaces are active).

fwiw, the ticket didn't ask for a placeholder message at all, but it seemed like some text would be helpful?

before:
<img width="1135" alt="Screen Shot 2023-06-13 at 12 24 55 AM" src="https://github.com/sul-dlss/libsys-airflow/assets/7741604/e0ce482c-a13d-4d96-ad7f-ba16a7ac3e48">


after:
<img width="1131" alt="Screen Shot 2023-06-13 at 12 26 12 AM" src="https://github.com/sul-dlss/libsys-airflow/assets/7741604/90a0bd29-a179-428c-9609-3ed928b0bf34">


still works when there are interfaces:
<img width="1132" alt="Screen Shot 2023-06-13 at 12 29 41 AM" src="https://github.com/sul-dlss/libsys-airflow/assets/7741604/88058950-93ad-4604-b28c-8977f12517c4">
