### PR TITLE
Set VendorFile status to "loaded"

### DIFF
--- a/libsys_airflow/plugins/vendor/models.py
+++ b/libsys_airflow/plugins/vendor/models.py
@@ -176,6 +176,10 @@ class FileStatus(enum.Enum):
     purged = "purged"
     skipped = "skipped"  # Files on the FTP server that are not fetched because they are before the download window.
 
+    def can_set_loaded(self):
+        """Return a boolean indicating whether the FileStatus can be manually set to loaded by a user"""
+        return self not in (self.loading, self.loaded, self.purged)
+
 
 class VendorFile(Model):
     __tablename__ = "vendor_files"

--- a/libsys_airflow/plugins/vendor_app/templates/vendors/file.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/file.html
@@ -62,11 +62,18 @@
   </div>
   <div class="form-group">
     <label for="status" class="col-sm-2 col-form-label">Status:</label>
-    <div class="col-sm-8" id="status">
+    <div class="col-sm-2" id="status">
+      {% if file.status.can_set_loaded() %}
+      <select class="form-control" id="status-input" name="status">
+        <option value="{{ file.status.value }}">{{ file.status.value }}</option>
+        <option value="{{ FileStatus.loaded.value }}">{{ FileStatus.loaded.value }}</option>
+      </select>
+      {% else %}
       {{ file.status.value }}
+      {% endif %}
     </div>
   </div>
-  {% if file.dag_run_id %}
+  {% if file.dag_run_id or file.status == FileStatus.loaded %}
   <div class="form-group">
     <label for="loaded-timestamp" class="col-sm-2 col-form-label">Load Time:</label>
     <div class="col-sm-8" id="loaded-timestamp">
@@ -81,9 +88,9 @@
   </div>
   {% else %}
   <div class="form-group">
-    <label for="expected-load-time" class="col-sm-2 col-form-label">Expected Load:</label>
-    <div class="col-sm-8" id="expected-load-time">
-      <input id="expected-load-time-input" type="datetime-local" name="expected-load-time" value="{{ file.expected_processing_time.isoformat(timespec='seconds') if file.expected_processing_time else '' }}" />
+    <label for="expected-processing-time" class="col-sm-2 col-form-label">Expected Load:</label>
+    <div class="col-sm-8" id="expected-processing-time">
+      <input id="expected-processing-time-input" type="datetime-local" name="expected-processing-time" value="{{ file.expected_processing_time.isoformat(timespec='seconds') if file.expected_processing_time else '' }}" />
       UTC
     </div>
   </div>

--- a/libsys_airflow/plugins/vendor_app/vendor_management.py
+++ b/libsys_airflow/plugins/vendor_app/vendor_management.py
@@ -270,20 +270,28 @@ class VendorManagementView(BaseView):
     def file(self, file_id):
         session = Session()
         file = session.query(VendorFile).get(file_id)
-        if request.method == 'POST' and 'expected-load-time' in request.form:
-            try:
-                expected_processing_time = request.form['expected-load-time']
-                if expected_processing_time != '':
+        if request.method == 'POST':
+            # expected_processing_time can only be posted if the file hasn't been processed
+            expected_processing_time = request.form.get('expected-processing-time')
+            if expected_processing_time:
+                try:
                     file.expected_processing_time = datetime.fromisoformat(
                         expected_processing_time
                     )
-                else:
-                    file.expected_processing_time = None
-                session.commit()
-            except ValueError:
-                flash("invalid date: {request.form['expected-load-time']}")
+                except ValueError:
+                    flash("invalid date: {request.form['expected-processing-time']}")
 
-        return self.render_template("vendors/file.html", file=file)
+            # The key "status" will not be in the form if it can no longer be manually set to loaded.
+            # Also, to prevent a possible race codition ensure that the current status is allowed
+            # to transition to loaded.
+            if 'status' in request.form and file.status.can_set_loaded():
+                file.status = request.form.get('status', file.status)
+                file.loaded_timestamp = datetime.utcnow()
+
+            session.commit()
+        return self.render_template(
+            "vendors/file.html", file=file, FileStatus=FileStatus
+        )
 
     @expose("/files/<int:file_id>/load", methods=["POST"])
     def load_file(self, file_id):

--- a/tests/vendor/test_file_status.py
+++ b/tests/vendor/test_file_status.py
@@ -1,0 +1,15 @@
+from libsys_airflow.plugins.vendor.models import FileStatus
+
+
+def test_can_set_loaded():
+    assert FileStatus.not_fetched.can_set_loaded() is True
+    assert FileStatus.fetched.can_set_loaded() is True
+    assert FileStatus.uploaded.can_set_loaded() is True
+    assert FileStatus.skipped.can_set_loaded() is True
+    assert FileStatus.loading_error.can_set_loaded() is True
+
+
+def test_cant_set_loaded():
+    assert FileStatus.loading.can_set_loaded() is False
+    assert FileStatus.loaded.can_set_loaded() is False
+    assert FileStatus.purged.can_set_loaded() is False


### PR DESCRIPTION
Add the ability for the user to set the status to "loaded" for VendorFiles that have not already been loaded or purged.

The select box only allows transitioning from the current status to "loaded". Once it has been marked loaded (or it has been otherwise purged) the select box does not display and the status is displayed read-only.

I went with setting `VendorFile.loaded_timestamp` to the current time when it is marked loaded.

https://github.com/sul-dlss/libsys-airflow/assets/33829/4dbd89c6-d728-42a9-ac41-ce8177719b0f

Resolves #497
