### PR TITLE
More accessible download links

### DIFF
--- a/libsys_airflow/plugins/vendor_app/templates/vendors/_macros.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/_macros.html
@@ -1,9 +1,15 @@
 {% macro fileDownload(file) -%}
   {% if file.status != 'purged' %}
     (
-    original <a href="{{ url_for('VendorManagementView.download_file', file_id=file.id, type='original') }}"><span class="glyphicon glyphicon-save" aria-hidden="true" style="color: #017cee;"></span></a>
+    original 
+    <a title="Download original file" href="{{ url_for('VendorManagementView.download_file', file_id=file.id, type='original') }}">
+        <span class="glyphicon glyphicon-save" aria-hidden="true" style="color: #017cee;"></span>
+    </a>
     {% if file.processed_filename %}
-      | processed <a href="{{ url_for('VendorManagementView.download_file', file_id=file.id, type='processed') }}"><span class="glyphicon glyphicon-save" aria-hidden="true" style="color: #017cee;"></span></a>
+    | processed 
+    <a title="Download processed file" href="{{ url_for('VendorManagementView.download_file', file_id=file.id, type='processed') }}">
+        <span class="glyphicon glyphicon-save" aria-hidden="true" style="color: #017cee;"></span>
+    </a>
     {% endif %}
     )
   {% endif %}


### PR DESCRIPTION
Adds a title to the download links which will make them noticeable in a screen reader.

Here's what the screen looks like, with the downloadable file:

<img width="1612" alt="Screenshot 2023-06-13 at 5 14 01 PM" src="https://github.com/sul-dlss/libsys-airflow/assets/33829/57b88ad9-e336-4194-9375-1a93b5672475">

Here's what it sounded like in Voice Over on a Mac before the title:

https://github.com/sul-dlss/libsys-airflow/assets/33829/c0dfa2da-ab4c-43a8-87d9-7b9637de0ac7

And here's what it sounds like afterwards--notice that when reading the link it now says "Download original file":

https://github.com/sul-dlss/libsys-airflow/assets/33829/748fada1-b6f2-46d0-80e7-c9f7c14c3718

Unfortunately there is no alt-text for the bootstrap3 glyphicons which use `<span>` elements that do not have `alt` parameters.

Resolves #633
