### PR TITLE
Change add_fields value matching strategy

### DIFF
--- a/libsys_airflow/dags/vendor/default_data_processor.py
+++ b/libsys_airflow/dags/vendor/default_data_processor.py
@@ -108,7 +108,7 @@ with DAG(
                 add_fields.append(
                     {
                         "tag": "590",
-                        "subfields": [{"code": "a", "value": "MARCit brief record"}],
+                        "subfields": [{"code": "a", "value": "MARCit brief record."}],
                         "unless": {
                             "tag": "035",
                             "subfields": [{"code": "a", "value": "OCoLC"}],
@@ -116,7 +116,7 @@ with DAG(
                     }
                 )
 
-            params["add_fields"] = add_fields if len(add_fields) > 0 else None
+            params["add_fields"] = add_fields or None
 
             # Not yet supported in UI.
             params["archive_regex"] = processing_options.get("archive_regex")

--- a/libsys_airflow/plugins/vendor/marc.py
+++ b/libsys_airflow/plugins/vendor/marc.py
@@ -82,7 +82,7 @@ def process_marc_task(
     ]
     add_fields example: [
             { tag: "910", indicator1: '2', subfields: [{code: "a", value: "MARCit"}] },
-            { tag: "590", subfields: [{code: "a", value: "MARCit brief record"}], unless: { tag: "035", subfields: [{code: "a", value: "OCoLC"}]} },
+            { tag: "590", subfields: [{code: "a", value: "MARCit brief record."}], unless: { tag: "035", subfields: [{code: "a", value: "OCoLC"}]} },
         ]
     """
     marc_path = pathlib.Path(download_path) / filename
@@ -304,7 +304,7 @@ def _field_match(field: MarcField, check_field: pymarc.Field):
         return False
     for subfield in field.subfields:
         check_subfield_value = ''.join(check_field.get_subfields(subfield.code))
-        if not check_subfield_value or check_subfield_value != subfield.value:
+        if not check_subfield_value or (subfield.value not in check_subfield_value):
             return False
     return True
 

--- a/tests/vendor/test_marc.py
+++ b/tests/vendor/test_marc.py
@@ -134,7 +134,7 @@ def test_add_fields_with_unless(tmp_path, marcit_path):
         [
             {
                 "tag": "590",
-                "subfields": [{"code": "a", "value": "MARCit brief record"}],
+                "subfields": [{"code": "a", "value": "MARCit brief record."}],
                 "unless": {
                     "tag": "035",
                     "subfields": [{"code": "a", "value": "OCoLC"}],
@@ -148,14 +148,14 @@ def test_add_fields_with_unless(tmp_path, marcit_path):
         marc_reader = pymarc.MARCReader(fo)
         for record in marc_reader:
             field035 = record["035"]
-            field590 = record["590"]
-            assert field035 or field590
-            if field035 and field035["a"] == "OCoLC":
-                assert not field590
-            if not field035 or field035["a"] != "OCoLC":
-                assert field590
-            if field590:
-                assert field590["a"] == "MARCit brief record"
+            field590s = record.get_fields("590")
+            assert field035 or field590s
+            if field035 and "OCoLC" in field035["a"]:
+                assert not field590s
+            if not field035 or "OCoLC" not in field035["a"]:
+                assert field590s
+            if field590s:
+                assert field590s[0]["a"] == "MARCit brief record."
 
 
 def test_bad_check_fields():


### PR DESCRIPTION
This commit fixes a bug with our strategy for matching values in `unless` fields within the `add_fields` data structure. We previously understood this to require an exact match, but at least for marcit 590 generation we need a substring match.
