### PR TITLE
Optional type checking with mypy

### DIFF
--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -1,0 +1,25 @@
+name: Type Checking
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install Airflow + dependencies
+        run: |
+          pip install -r requirements.txt
+          poetry install
+      - name: Type checking with mypy
+        run: poetry run mypy libsys_airflow tests

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Type declarations are only used in testing and type checking, and do not affect 
 
 If you run into something where the type checker complains and you're sure that the usage is ok, you can comment the line with `# type: ignore` to quiet the type checker for that line.  As with linting, use your best judgement as to whether an exception is preferable to mollifying the checker.
 
-The type checker is not currently wired up in CI, but you may still find it useful for catching lurking consistency issues.
+The type checker is not currently wired up in CI as a required check, but you may still find it useful for catching lurking consistency issues.
 
 ## Symphony Mount
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ module and then run the following steps:
 
 If you prefer not to use `poetry shell` you can use `poetry run` along with `dotenv` instead: e.g. `poetry run dotenv run alembic upgrade head`. Or you can simply put the `DATABASE_*` environment variables into your shell via another means.
 
-To fix multiple heads: `poetry run alembic merge heads -m "merge <revision 1> and <revision 2>"
+To fix multiple heads: `poetry run alembic merge heads -m "merge <revision 1> and <revision 2>"`
 
 #### Seeding Vendors
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,20 @@ To run the black formatter to fix any violations:
 
 `poetry run black .`
 
+### Mypy (Python type checker)
+
+[Mypy](https://github.com/python/mypy) is a static type checker.  Configuration is in `pyproject.toml`.
+
+To run the mypy type checker on the codebase: `poetry run mypy libsys_airflow tests`.
+
+The type checker will complain if assignments, return types, parameter types, etc are inconsistently used, e.g. if an int is provided for a string param, a function doesn't return the type it claims to, etc (helpful for documenting function signatures correctly, and for sussing out issues like inconsistent types for variable assignment or function return, which can be confusing at best, and bug prone at worst).
+
+Type declarations are only used in testing and type checking, and do not affect runtime behavior.
+
+If you run into something where the type checker complains and you're sure that the usage is ok, you can comment the line with `# type: ignore` to quiet the type checker for that line.  As with linting, use your best judgement as to whether an exception is preferable to mollifying the checker.
+
+The type checker is not currently wired up in CI, but you may still find it useful for catching lurking consistency issues.
+
 ## Symphony Mount
 
 MARC data to be converted will be mounted on the sul-libsys-airflow server under `/sirsi_prod` which is a mount of `/s/SUL/Dataload/Folio` on the Symphony server.

--- a/libsys_airflow/dags/aeon_to_lobby.py
+++ b/libsys_airflow/dags/aeon_to_lobby.py
@@ -98,7 +98,7 @@ with DAG(
         task_id="post_to_lobbytrack", python_callable=lobby_post
     )
 
-    route_aeon_post = PythonOperator(
+    route_aeon_post_task = PythonOperator(
         task_id="route_aeon_post",
         python_callable=route_aeon_post,
         op_kwargs={
@@ -110,5 +110,5 @@ with DAG(
     )
 
 
-aeon_user_data >> route_aeon_post
+aeon_user_data >> route_aeon_post_task
 aeon_user_data >> filtered_user_data >> transform_to_lobby_data >> post_to_lobbytrack

--- a/libsys_airflow/plugins/folio/audit.py
+++ b/libsys_airflow/plugins/folio/audit.py
@@ -114,7 +114,7 @@ def _audit_items(
     return item_count
 
 
-def _add_record(record, con, record_type):
+def _add_record(record, con, record_type) -> int:
     cur = con.cursor()
     cur.execute(
         """INSERT INTO Record (uuid, hrid, folio_type, current_version)
@@ -161,7 +161,7 @@ def add_audit_log(record_id, con, status_id):
     return log_id
 
 
-def _get_add_record(record, con, record_type):
+def _get_add_record(record, con, record_type) -> int:
     cur = con.cursor()
     cur.execute("SELECT id FROM Record WHERE uuid=?;", (record["id"],))
     record_exists = cur.fetchone()
@@ -172,7 +172,7 @@ def _get_add_record(record, con, record_type):
     return record_id
 
 
-def _check_instance_views(results_dir, pg_hook) -> dict:
+def _check_instance_views(results_dir, pg_hook) -> None:
     """
     Associates Instances to it's Holdings and Items.
     """
@@ -190,7 +190,7 @@ def _check_instance_views(results_dir, pg_hook) -> dict:
     )
 
 
-def setup_audit_db(*args, **kwargs):
+def setup_audit_db(*args, **kwargs) -> None:
     """
     Initializes the DAG Run Audit SQLITE Database
     """

--- a/libsys_airflow/plugins/folio/helpers/__init__.py
+++ b/libsys_airflow/plugins/folio/helpers/__init__.py
@@ -87,7 +87,7 @@ def get_bib_files(**kwargs):
     task_instance.xcom_push(key="bwchild-file", value=bib_file_load.get("tsv-bwchild"))
 
 
-def post_to_okapi(**kwargs) -> bool:
+def post_to_okapi(**kwargs) -> dict:
     endpoint = kwargs.get("endpoint")
     jwt = kwargs["token"]
     iteration_id = kwargs.get("iteration_id")
@@ -162,7 +162,7 @@ def put_to_okapi(**kwargs):
     logger.info(f"PUT Result status code {update_record_result.status_code}")  # noqa
 
 
-def process_records(*args, **kwargs) -> list:
+def process_records(*args, **kwargs) -> int:
     """Function creates valid json from file of FOLIO objects"""
     prefix = kwargs.get("prefix")
     dag = kwargs["dag_run"]

--- a/libsys_airflow/plugins/folio/helpers/__init__.py
+++ b/libsys_airflow/plugins/folio/helpers/__init__.py
@@ -121,7 +121,7 @@ def post_to_okapi(**kwargs) -> dict:
     if new_record_result.status_code > 399:
         logger.error(new_record_result.text)
         if iteration_id is None:
-            kwargs["iteration_id"] = kwargs.get("dag_run").run_id
+            kwargs["iteration_id"] = kwargs.get("dag_run").run_id  # type: ignore
         _save_error_record_ids(error_code=new_record_result.status_code, **kwargs)
 
     if len(new_record_result.text) < 1:
@@ -171,7 +171,7 @@ def process_records(*args, **kwargs) -> int:
 
     out_filename = f"{kwargs.get('out_filename')}-{dag.run_id}"
 
-    total_jobs = int(kwargs.get("jobs"))
+    total_jobs = int(kwargs.get("jobs"))  # type: ignore
 
     airflow = kwargs.get("airflow", "/opt/airflow")
     tmp = kwargs.get("tmp", "/tmp")

--- a/libsys_airflow/plugins/folio/helpers/marc.py
+++ b/libsys_airflow/plugins/folio/helpers/marc.py
@@ -64,7 +64,7 @@ def _add_srs_audit_record(record: dict, connection, record_type):
     return record_id
 
 
-def _check_add_srs_records(**kwargs):
+def _check_add_srs_records(**kwargs) -> None:
     srs_record: dict = kwargs["srs_record"]
     snapshot_id: str = kwargs["snapshot_id"]
     folio_client = kwargs["folio_client"]
@@ -177,11 +177,11 @@ def _get_snapshot_id(folio_client):
     return snapshot_id
 
 
-def _move_001_to_035(record: pymarc.Record) -> str:
+def _move_001_to_035(record: pymarc.Record) -> str | None:
     all001 = record.get_fields("001")
 
     if len(all001) < 1:
-        return
+        return None
 
     catkey = all001[0].data
 
@@ -198,7 +198,7 @@ def _move_001_to_035(record: pymarc.Record) -> str:
     return catkey
 
 
-def _srs_check_add(**kwargs):
+def _srs_check_add(**kwargs) -> int:
     """
     Runs audit/remediation for a single SRS file
     """

--- a/libsys_airflow/plugins/folio/holdings.py
+++ b/libsys_airflow/plugins/folio/holdings.py
@@ -43,7 +43,7 @@ def _run_transformer(transformer, airflow, dag_run_id, item_path):
     transformer.wrap_up()
 
 
-def _generate_lookups(holdings_tsv_path: pathlib.Path) -> tuple:
+def _generate_lookups(holdings_tsv_path: pathlib.Path) -> dict:
     """
     Takes FOLIO holdings file, creates a dictionary by holdings id for
     merging MHLD records with existing holdings records
@@ -387,7 +387,7 @@ def run_mhld_holdings_transformer(*args, **kwargs):
     logger.info(f"Finished transforming MHLD {filepath.name} to FOLIO holdings")
 
 
-def electronic_holdings(*args, **kwargs) -> str:
+def electronic_holdings(*args, **kwargs) -> None:
     """Generates FOLIO Holdings records from Symphony 856 fields"""
     dag = kwargs["dag_run"]
     holdings_stem = kwargs["holdings_stem"]

--- a/libsys_airflow/plugins/folio/instances.py
+++ b/libsys_airflow/plugins/folio/instances.py
@@ -20,7 +20,7 @@ def _generate_record_lookups(base_tsv: Path, lookup_stat_codes: dict) -> dict:
     """
     Generates record lookup dictionary based on values in tsv
     """
-    record_lookups = {}
+    record_lookups: dict = {}
     logger.error(f"Base {base_tsv}")
     with base_tsv.open() as fo:
         tsv_reader = csv.DictReader(fo, delimiter="\t")
@@ -44,7 +44,7 @@ def _generate_record_lookups(base_tsv: Path, lookup_stat_codes: dict) -> dict:
     return record_lookups
 
 
-def _remove_dup_admin_notes(record: dict):
+def _remove_dup_admin_notes(record: dict) -> None:
     """
     Removes administrativeNotes that contain duplicated HRID
     """
@@ -53,7 +53,9 @@ def _remove_dup_admin_notes(record: dict):
             record['administrativeNotes'].pop(i)
 
 
-def _set_cataloged_date(instance: dict, dates_df: pd.DataFrame, instance_status: dict):
+def _set_cataloged_date(
+    instance: dict, dates_df: pd.DataFrame, instance_status: dict
+) -> None:
     ckey = instance["hrid"].removeprefix("a")
     matched_row = dates_df.loc[dates_df["CATKEY"] == ckey]
     if matched_row["CATALOGED_DATE"].values[0] != "0":
@@ -64,7 +66,7 @@ def _set_cataloged_date(instance: dict, dates_df: pd.DataFrame, instance_status:
         instance["statusId"] = instance_status["Uncataloged"]
 
 
-def _adjust_records(**kwargs):
+def _adjust_records(**kwargs) -> None:
     """
     Modifies instances records
     """

--- a/libsys_airflow/plugins/folio/main.py
+++ b/libsys_airflow/plugins/folio/main.py
@@ -40,7 +40,7 @@ healthcheck_package = {
 
 class FOLIOPlugin(AirflowPlugin):
     name = "FOLIOInformation"
-    operators = []
+    operators = []  # type: ignore
     flask_blueprints = [bp]
     hooks = []
     executors = []

--- a/libsys_airflow/plugins/folio/orafin_payments.py
+++ b/libsys_airflow/plugins/folio/orafin_payments.py
@@ -41,7 +41,8 @@ def _get_invoice(invoice_id: str, folio_client: FolioClient) -> dict:
     # Retrieves Invoice Details
     # Retrieves Invoices Lines
     # Call to Okapi organization endpoint to see VAT is applicable
-    invoice["vat"] = _get_vat(invoice["vendorId"], folio_client)
+    # TODO: typechecker thinks all invoice dict values are None because of vendorId initialization, _get_vat wants a non-None str; can prob unignore typing once this is more fleshed out
+    invoice["vat"] = _get_vat(invoice["vendorId"], folio_client)  # type: ignore
     return invoice
 
 
@@ -57,6 +58,7 @@ def feeder_file_task(invoices: list):
     return "foo"
 
 
+# TODO: can un-ignore type checking here once this function is less of a stub
 @task
-def sftp_file_task(feeder_file: task):
+def sftp_file_task(feeder_file: task):  # type: ignore
     return "foo"

--- a/libsys_airflow/plugins/folio/remediate.py
+++ b/libsys_airflow/plugins/folio/remediate.py
@@ -13,16 +13,17 @@ from folio_uuid.folio_uuid import FOLIONamespaces
 logger = logging.getLogger(__name__)
 
 
-def _get_json_payload(con: sqlite3.Connection, record_id: int) -> dict:
+def _get_json_payload(con: sqlite3.Connection, record_id: int) -> dict | None:
     """Retrieves JSON Payload from Audit Database for missing Record"""
     cur = con.cursor()
     cur.execute("SELECT payload FROM JsonPayload WHERE record_id=?;", (record_id,))
     record_json = cur.fetchone()
     if record_json:
         return record_json[0]
+    return None
 
 
-def _post_record(**kwargs):
+def _post_record(**kwargs) -> None:
     post_url: str = kwargs["post_url"]
     db_id: int = kwargs["db_id"]
     con: sqlite3.Connection = kwargs["con"]

--- a/libsys_airflow/plugins/vendor/download.py
+++ b/libsys_airflow/plugins/vendor/download.py
@@ -53,7 +53,8 @@ class SFTPAdapter:
 
     def get_mod_time(self, filename: str) -> datetime:
         mod_time_str = self._file_descriptions[filename]["modify"]
-        return datetime.strptime(mod_time_str, "%Y%m%d%H%M%S")
+        # TODO: revisit this type ignore if SFTPHook.describe_directory gets better TypedDict hints, see https://peps.python.org/pep-0589/
+        return datetime.strptime(mod_time_str, "%Y%m%d%H%M%S")  # type: ignore
 
     def get_size(self, filename: str) -> int | str | None:
         return self._file_descriptions[filename]["size"]

--- a/libsys_airflow/plugins/vendor/download.py
+++ b/libsys_airflow/plugins/vendor/download.py
@@ -35,7 +35,7 @@ class FTPAdapter:
     def get_mod_time(self, filename: str) -> datetime:
         return self.hook.get_mod_time(filename)
 
-    def get_size(self, filename: str) -> int:
+    def get_size(self, filename: str) -> int | None:
         return self.hook.get_size(filename)
 
     def retrieve_file(self, filename: str, download_filepath: str):
@@ -49,13 +49,13 @@ class SFTPAdapter:
         self._file_descriptions = hook.describe_directory(remote_path)
 
     def list_directory(self) -> list[str]:
-        return self._file_descriptions.keys()
+        return list(self._file_descriptions.keys())
 
     def get_mod_time(self, filename: str) -> datetime:
         mod_time_str = self._file_descriptions[filename]["modify"]
         return datetime.strptime(mod_time_str, "%Y%m%d%H%M%S")
 
-    def get_size(self, filename: str) -> int:
+    def get_size(self, filename: str) -> int | str | None:
         return self._file_descriptions[filename]["size"]
 
     def retrieve_file(self, filename: str, download_filepath: str):
@@ -101,6 +101,7 @@ def ftp_download_task(
 
 def create_hook(conn_id: str) -> Union[FTPHook, SFTPHook]:
     """Returns an FTPHook or SFTPHook for the given connection id."""
+    hook: Optional[Union[FTPHook, SFTPHook]] = None
     if conn_id.startswith("sftp-"):
         hook = SFTPHook(ftp_conn_id=conn_id)
     else:
@@ -182,7 +183,7 @@ def _download_filepath(download_path: str, filename: str) -> str:
 
 def _record_vendor_file(
     filename: str,
-    filesize: int,
+    filesize: int | str | None,
     status: str,
     vendor_interface_uuid: str,
     vendor_timestamp: datetime,

--- a/libsys_airflow/plugins/vendor/extract.py
+++ b/libsys_airflow/plugins/vendor/extract.py
@@ -51,7 +51,7 @@ def _is_tar(file: pathlib.Path) -> bool:
     )
 
 
-def _filter_filenames(filenames: list[str], regex: str) -> list[str]:
+def _filter_filenames(filenames: list[str], regex: Optional[str]) -> str:
     filtered_filenames = filenames
     if regex:
         filtered_filenames = [

--- a/libsys_airflow/plugins/vendor/marc.py
+++ b/libsys_airflow/plugins/vendor/marc.py
@@ -172,7 +172,7 @@ def batch(download_path: str, filename: str, max_records: int) -> list[str]:
     """
     records = []
     index = 1
-    batch_filenames = []
+    batch_filenames: list[str] = []
     with open(pathlib.Path(download_path) / filename, "rb") as fo:
         reader = _marc_reader(fo)
         for record in reader:
@@ -192,19 +192,19 @@ def batch(download_path: str, filename: str, max_records: int) -> list[str]:
     return batch_filenames
 
 
-def _new_batch(download_path, filename, index, batch_filenames, records):
+def _new_batch(download_path, filename, index, batch_filenames: list[str], records):
     batch_filename = _batch_filename(filename, index)
     batch_filenames.append(batch_filename)
     _write_records(records, pathlib.Path(download_path) / batch_filename)
     return [], index + 1
 
 
-def _batch_filename(filename, index):
+def _batch_filename(filename, index) -> str:
     file_path = pathlib.Path(filename)
     return f"{file_path.stem}_{index}{file_path.suffix}"
 
 
-def _write_records(records, marc_path):
+def _write_records(records, marc_path) -> None:
     logger.info(f"Writing {len(records)} records to {marc_path}")
     with marc_path.open("wb") as fo:
         marc_writer = pymarc.MARCWriter(fo)
@@ -213,7 +213,7 @@ def _write_records(records, marc_path):
             marc_writer.write(record)
 
 
-def _to_change_fields_models(change_fields):
+def _to_change_fields_models(change_fields) -> list[ChangeField]:
     return [ChangeField(**change) for change in change_fields]
 
 

--- a/libsys_airflow/plugins/vendor/models.py
+++ b/libsys_airflow/plugins/vendor/models.py
@@ -22,7 +22,9 @@ from typing import List, Any
 Model = declarative_base()
 
 
-class Vendor(Model):
+# TODO: once airflow (and our vendor app) move to SQLAlchemy 2.x, mypy's typechecking may play better with
+# SQLAlchemy, see https://docs.sqlalchemy.org/en/20/orm/extensions/mypy.html
+class Vendor(Model):  # type: ignore
     __tablename__ = "vendors"
 
     id = Column(Integer, primary_key=True)
@@ -65,7 +67,7 @@ class Vendor(Model):
         ).unique()
 
 
-class VendorInterface(Model):
+class VendorInterface(Model):  # type: ignore
     __tablename__ = "vendor_interfaces"
 
     id = Column(Integer, primary_key=True)
@@ -188,7 +190,7 @@ class FileStatus(enum.Enum):
         return self not in (self.loading, self.loaded, self.purged)
 
 
-class VendorFile(Model):
+class VendorFile(Model):  # type: ignore
     __tablename__ = "vendor_files"
 
     id = Column(Integer, primary_key=True)

--- a/libsys_airflow/plugins/vendor/purge.py
+++ b/libsys_airflow/plugins/vendor/purge.py
@@ -65,7 +65,8 @@ def _extract_uuids(directory: str):
         for interface_path in vendor_path.iterdir():
             output[interface_path.stem] = {"date": dir_path.stem, "files": []}
             for file in interface_path.iterdir():
-                output[interface_path.stem]["files"].append(file.name)
+                # the typechecker is being a bit naive about the "files" field, and "files" being initialized to an array seems clear, so TypedDict doesn't seem worth the effort
+                output[interface_path.stem]["files"].append(file.name)  # type: ignore
     return output
 
 

--- a/libsys_airflow/plugins/vendor_app/main.py
+++ b/libsys_airflow/plugins/vendor_app/main.py
@@ -36,7 +36,7 @@ vendor_management_view_package = {
 
 class VendorManagementPlugin(AirflowPlugin):
     name = "Vendor Management"
-    operators = []
+    operators = []  # type: ignore
     flask_blueprints = [vendor_mgt_bp]
     hooks = []
     executors = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -2380,6 +2380,52 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.3.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mypy-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1eb485cea53f4f5284e5baf92902cd0088b24984f4209e25981cc359d64448d"},
+    {file = "mypy-1.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4c99c3ecf223cf2952638da9cd82793d8f3c0c5fa8b6ae2b2d9ed1e1ff51ba85"},
+    {file = "mypy-1.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:550a8b3a19bb6589679a7c3c31f64312e7ff482a816c96e0cecec9ad3a7564dd"},
+    {file = "mypy-1.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cbc07246253b9e3d7d74c9ff948cd0fd7a71afcc2b77c7f0a59c26e9395cb152"},
+    {file = "mypy-1.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:a22435632710a4fcf8acf86cbd0d69f68ac389a3892cb23fbad176d1cddaf228"},
+    {file = "mypy-1.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6e33bb8b2613614a33dff70565f4c803f889ebd2f859466e42b46e1df76018dd"},
+    {file = "mypy-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7d23370d2a6b7a71dc65d1266f9a34e4cde9e8e21511322415db4b26f46f6b8c"},
+    {file = "mypy-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:658fe7b674769a0770d4b26cb4d6f005e88a442fe82446f020be8e5f5efb2fae"},
+    {file = "mypy-1.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d29e324cdda61daaec2336c42512e59c7c375340bd202efa1fe0f7b8f8ca"},
+    {file = "mypy-1.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:d0b6c62206e04061e27009481cb0ec966f7d6172b5b936f3ead3d74f29fe3dcf"},
+    {file = "mypy-1.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:76ec771e2342f1b558c36d49900dfe81d140361dd0d2df6cd71b3db1be155409"},
+    {file = "mypy-1.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebc95f8386314272bbc817026f8ce8f4f0d2ef7ae44f947c4664efac9adec929"},
+    {file = "mypy-1.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:faff86aa10c1aa4a10e1a301de160f3d8fc8703b88c7e98de46b531ff1276a9a"},
+    {file = "mypy-1.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:8c5979d0deb27e0f4479bee18ea0f83732a893e81b78e62e2dda3e7e518c92ee"},
+    {file = "mypy-1.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c5d2cc54175bab47011b09688b418db71403aefad07cbcd62d44010543fc143f"},
+    {file = "mypy-1.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:87df44954c31d86df96c8bd6e80dfcd773473e877ac6176a8e29898bfb3501cb"},
+    {file = "mypy-1.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:473117e310febe632ddf10e745a355714e771ffe534f06db40702775056614c4"},
+    {file = "mypy-1.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:74bc9b6e0e79808bf8678d7678b2ae3736ea72d56eede3820bd3849823e7f305"},
+    {file = "mypy-1.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:44797d031a41516fcf5cbfa652265bb994e53e51994c1bd649ffcd0c3a7eccbf"},
+    {file = "mypy-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ddae0f39ca146972ff6bb4399f3b2943884a774b8771ea0a8f50e971f5ea5ba8"},
+    {file = "mypy-1.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1c4c42c60a8103ead4c1c060ac3cdd3ff01e18fddce6f1016e08939647a0e703"},
+    {file = "mypy-1.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e86c2c6852f62f8f2b24cb7a613ebe8e0c7dc1402c61d36a609174f63e0ff017"},
+    {file = "mypy-1.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f9dca1e257d4cc129517779226753dbefb4f2266c4eaad610fc15c6a7e14283e"},
+    {file = "mypy-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:95d8d31a7713510685b05fbb18d6ac287a56c8f6554d88c19e73f724a445448a"},
+    {file = "mypy-1.3.0-py3-none-any.whl", hash = "sha256:a8763e72d5d9574d45ce5881962bc8e9046bf7b375b0abf031f3e6811732a897"},
+    {file = "mypy-1.3.0.tar.gz", hash = "sha256:e1f4d16e296f5135624b34e8fb741eb0eadedca90862405b1f1fde2040b9bd11"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -3389,13 +3435,13 @@ test = ["pytest"]
 
 [[package]]
 name = "setuptools"
-version = "67.8.0"
+version = "68.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},
-    {file = "setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
 ]
 
 [package.extras]
@@ -3649,6 +3695,42 @@ python-versions = ">=3.7"
 files = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
+name = "types-markdown"
+version = "3.4.2.9"
+description = "Typing stubs for Markdown"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-Markdown-3.4.2.9.tar.gz", hash = "sha256:0930057bea0a534e06bbc021d57520720ad2a65b363612614ab0599cc7f606a9"},
+    {file = "types_Markdown-3.4.2.9-py3-none-any.whl", hash = "sha256:c23a8a4dd9313539a446ba3dc673a6a920d79580c406de10a5c85a16733890a7"},
+]
+
+[[package]]
+name = "types-requests"
+version = "2.31.0.1"
+description = "Typing stubs for requests"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-requests-2.31.0.1.tar.gz", hash = "sha256:3de667cffa123ce698591de0ad7db034a5317457a596eb0b4944e5a9d9e8d1ac"},
+    {file = "types_requests-2.31.0.1-py3-none-any.whl", hash = "sha256:afb06ef8f25ba83d59a1d424bd7a5a939082f94b94e90ab5e6116bd2559deaa3"},
+]
+
+[package.dependencies]
+types-urllib3 = "*"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.13"
+description = "Typing stubs for urllib3"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-urllib3-1.26.25.13.tar.gz", hash = "sha256:3300538c9dc11dad32eae4827ac313f5d986b8b21494801f1bf97a1ac6c03ae5"},
+    {file = "types_urllib3-1.26.25.13-py3-none-any.whl", hash = "sha256:5dbd1d2bef14efee43f5318b5d36d805a489f6600252bb53626d4bfafd95e27c"},
 ]
 
 [[package]]
@@ -3911,4 +3993,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "af842334ecc4caadcf19c70e80228c836189957aec030f343ae87e0ed4e49f7d"
+content-hash = "266fe4db883f3b3b22e7326329f7a3506e788c5f166b62b8a79b338e8e919c10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ apache-airflow-providers-sftp = "^4.2.4"
 requests-mock = "^1.10.0"
 pytest-mock-resources = "^2.6.12"
 beautifulsoup4 = "^4.12.2"
+mypy = "^1.3.0"
+types-requests = "^2.31.0.1"
+types-markdown = "^3.4.2.9"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -63,3 +66,11 @@ include = '\.pyi?$'
 exclude = 'vendor_loads_migration'
 skip-string-normalization = true
 color = true
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+explicit_package_bases = true
+warn_unreachable = true
+pretty = true
+show_error_context = true

--- a/tests/helpers/test_marc_helper.py
+++ b/tests/helpers/test_marc_helper.py
@@ -577,4 +577,5 @@ def test_missing_file_post_marc_to_srs(
 
 
 def test_process_marc():
-    assert process_marc
+    # if the import is successful, this will always pass because the function ref is truthy, hence the typechecker complaint
+    assert process_marc  # type: ignore

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -105,7 +105,7 @@ def mock_file_system(tmp_path, mock_dag_run):
 
 
 # Mock xcom messages dict
-messages = {}
+messages: dict[str, str] = {}
 
 
 # Mock xcoms

--- a/tests/test_aeon_to_lobby.py
+++ b/tests/test_aeon_to_lobby.py
@@ -121,8 +121,12 @@ def test_user_data(mock_queue_requests, mock_aeon_variable):
         aeon_url="https://aeon.example.us", aeon_key="123", queue_id="1"
     )
 
-    # assert lambda: user_data[0] == mock_aeon_queue_data[0]
-    assert lambda: user_data[0] == ["aeonuser2@gmail.com", 2]
+    aeon_queue_data = mock_aeon_queue_data()
+    assert user_data[0] == [
+        aeon_queue_data[0]["username"],
+        aeon_queue_data[0]["transactionNumber"],
+    ]
+    assert user_data[2] == ["aeonuser2@gmail.com", 2]
     assert len(user_data) == 3
 
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -34,14 +34,16 @@ class MockCursor(object):
 
 
 class MockConnection(pydantic.BaseModel):
-    cursor = lambda x: MockCursor()  # noqa
-    commit = lambda x: None  # noqa
-    close = lambda x: None  # noqa
+    cursor = lambda x: MockCursor()  # noqa: E731
+    commit = lambda x: None  # noqa: E731
+    close = lambda x: None  # noqa: E731
 
 
 class MockExtraDeJson(pydantic.BaseModel):
-    get = lambda *args: False  # noqa
-    items = lambda x: []  # noqa
+    get = lambda *args: False  # noqa: E731
+
+    def items(x) -> list:
+        return []
 
 
 class MockAirflowConnection(pydantic.BaseModel):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -21,13 +21,15 @@ class MockCursor(pydantic.BaseModel):
 
 
 class MockConnection(pydantic.BaseModel):
-    cursor = lambda x: MockCursor()  # noqa
-    commit = lambda x: None  # noqa
+    cursor = lambda x: MockCursor()  # noqa: E731
+    commit = lambda x: None  # noqa: E731
 
 
 class MockExtraDeJson(pydantic.BaseModel):
-    get = lambda *args: False  # noqa
-    items = lambda x: []  # noqa
+    get = lambda *args: False  # noqa: E731
+
+    def items(x) -> list:
+        return []
 
 
 class MockAirflowConnection(pydantic.BaseModel):

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -289,11 +289,13 @@ def test_post_folio_holding_records(
 
 
 def test_run_holdings_tranformer():
-    assert run_holdings_tranformer
+    # if the import is successful, this will always pass because the function ref is truthy, hence the typechecker complaint
+    assert run_holdings_tranformer  # type: ignore
 
 
 def test_run_mhld_holdings_transformer(mock_file_system):  # noqa
-    assert run_mhld_holdings_transformer
+    # if the import is successful, this will always pass because the function ref is truthy, hence the typechecker complaint
+    assert run_mhld_holdings_transformer  # type: ignore
 
 
 def test_boundwith_holdings(

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -15,8 +15,6 @@ from libsys_airflow.plugins.folio.instances import (
 
 from mocks import mock_dag_run, mock_file_system, MockFOLIOClient  # noqa
 
-instances = [{}, {}]
-
 
 class MockResultsFile(pydantic.BaseModel):
     name = ""

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -128,8 +128,10 @@ def test_get_statistical_codes(mock_okapi_requests):  # noqa
 
 
 def test_post_folio_instance_records():
-    assert post_folio_instance_records
+    # if the import is successful, this will always pass because the function ref is truthy, hence the typechecker complaint
+    assert post_folio_instance_records  # type: ignore
 
 
 def test_run_bibs_transformer():
-    assert run_bibs_transformer
+    # if the import is successful, this will always pass because the function ref is truthy, hence the typechecker complaint
+    assert run_bibs_transformer  # type: ignore

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -20,11 +20,13 @@ from libsys_airflow.plugins.folio.items import (
 
 
 def test_post_folio_items_records():
-    assert post_folio_items_records
+    # if the import is successful, this will always pass because the function ref is truthy, hence the typechecker complaint
+    assert post_folio_items_records  # type: ignore
 
 
 def test_items_transformers():
-    assert run_items_transformer
+    # if the import is successful, this will always pass because the function ref is truthy, hence the typechecker complaint
+    assert run_items_transformer  # type: ignore
 
 
 item_note_types = {

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -2,4 +2,5 @@ from libsys_airflow.plugins.folio.login import folio_login
 
 
 def test_folio_login():
-    assert folio_login
+    # if the import is successful, this will always pass because the function ref is truthy, hence the typechecker complaint
+    assert folio_login  # type: ignore

--- a/tests/test_remediate.py
+++ b/tests/test_remediate.py
@@ -40,7 +40,7 @@ class MockFolioClient(pydantic.BaseModel):
     okapi_url = "https://okapi-folio.dev.edu"
     password = "abdccde"
     username = "folio_admin"
-    okapi_headers = {}
+    okapi_headers: dict = {}
 
 
 def test_with_no_missing_records(mock_dag_run, mock_file_system, caplog):  # noqa


### PR DESCRIPTION
* adds dependencies to allow type checking if people wish
* adds a workflow to CI to run type checking (not necessarily intended to be a required check, seems worth discussing what seems most useful to people)
* fixes up our code so that it passes type checking
* updates readme with relevant info for running the type checker
* some other opportunistic fixups i noticed along the way

starting this off as a draft PR for discussion, since i'm not sure we want to do this?  mypy was useful for finding issues in dlme-airflow and ils-middleware, and i played with this just a bit during the WC, but mostly tried to stay away from it as it didn't seem like critical path work at the time.  but this did seem like a good experiment to finish off during the first day and a half of unscheduled week.