### PR TITLE
Fixes holdingsStatement bug that removes ending dash

### DIFF
--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -11,6 +11,7 @@ from libsys_airflow.plugins.folio.holdings import (
     run_holdings_tranformer,
     run_mhld_holdings_transformer,
     boundwith_holdings,
+    _alt_condition_remove_ending_punc,
     _alt_get_legacy_ids,
     _wrap_additional_mapping,
 )
@@ -338,6 +339,15 @@ def test_boundwith_holdings(
         bw_part_rec = [json.loads(line) for line in bwp.readlines()]
 
     assert holdings_rec[0]["id"] == bw_part_rec[0]["holdingsRecordId"]
+
+
+def test_alt_condition_remove_ending_punc():
+    open_end_periodical_range = _alt_condition_remove_ending_punc(
+        None, None, "v.27(2014),v.32(2016)-"
+    )
+    assert open_end_periodical_range == "v.27(2014),v.32(2016)-"
+    removed_end_punc = _alt_condition_remove_ending_punc(None, None, "A note=")
+    assert removed_end_punc == "A note"
 
 
 def test_alt_get_legacy_ids():


### PR DESCRIPTION
As reported in Slack, for MHLD HoldingsStatements, the ending character for some 866 MARC field $a ends with a `-` to indicate that a periodical is ongoing but was getting striped when migrated. Comparing how the `remove_ending_punc`condition was implemented in [folio_migration_tools](https://github.com/FOLIO-FSE/folio_migration_tools/blob/a18df55de8505fb188e97561c3d92da9db88fd74/src/folio_migration_tools/marc_rules_transformation/conditions.py#L280) verses how it is being done in FOLIO [data-import-processing-core](https://github.com/folio-org/data-import-processing-core/blob/d21628c5d7517da0571e6373d3e4b8818cee339e/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java#L70), this PR overrides the `folio_migration_tools` condition for the MHLD processing to use the same character set as the `data-import-processing-core` code. 

Also added a [comment](https://github.com/FOLIO-FSE/folio_migration_tools/issues/547#issuecomment-1614890331) to an open ticket in `folio_migration_tools` with this example.