### PR TITLE
Adds prefix to moved 001 value for 035 field

### DIFF
--- a/libsys_airflow/plugins/folio/helpers/marc.py
+++ b/libsys_airflow/plugins/folio/helpers/marc.py
@@ -214,7 +214,7 @@ def _move_001_to_035(record: pymarc.Record) -> str | None:
             field035 = pymarc.Field(
                 tag="035",
                 indicators=[" ", " "],
-                subfields=[pymarc.Subfield(code="a", value=field001.data)],
+                subfields=[pymarc.Subfield(code="a", value=f"(sirsi){field001.data}")],
             )
             record.add_field(field035)
             record.remove_field(field001)

--- a/tests/helpers/test_marc_helper.py
+++ b/tests/helpers/test_marc_helper.py
@@ -459,7 +459,9 @@ def test_missing_001_to_034(mock_marc_record):
 def test_move_001_to_035(mock_marc_record):
     record = mock_marc_record
     _move_001_to_035(record)
-    assert record.get_fields("035")[0].get_subfields("a")[0] == "gls_0987654321"  # noqa
+    assert (
+        record.get_fields("035")[0].get_subfields("a")[0] == "(sirsi)gls_0987654321"
+    )  # noqa
 
 
 def test_move_authkeys():


### PR DESCRIPTION
In original ticket #26, the `(sirsi)` prefix to the value was required. 