### PR TITLE
Generate Feeder File from Orafin Models

### DIFF
--- a/libsys_airflow/plugins/folio/helpers/orafin_models.py
+++ b/libsys_airflow/plugins/folio/helpers/orafin_models.py
@@ -127,6 +127,7 @@ class InvoiceLine:
                                 "TA",
                                 f"{-adjusted_amt:015.2f}",
                                 f"{tax_code: <20}",
+                                f"{' ': <69}",
                             ]
                         )
                     )
@@ -330,6 +331,7 @@ class FeederFile:
         for invoice in self.invoices:
             raw_file += f"{invoice.header()}\n"
             raw_file += invoice.line_data()
+        raw_file += "\n"
         raw_file += "".join(
             [
                 self.trailer_number,

--- a/libsys_airflow/plugins/folio/helpers/orafin_models.py
+++ b/libsys_airflow/plugins/folio/helpers/orafin_models.py
@@ -157,7 +157,7 @@ class Invoice:
 
     @property
     def attachment_flag(self):
-        if self.paymentTerms and self.paymentTerms.startswith("WILLCALL"):
+        if self.paymentTerms and self.paymentTerms.upper().startswith("WILLCALL"):
             return "Y"
         return " "
 

--- a/tests/helpers/test_orafin_models.py
+++ b/tests/helpers/test_orafin_models.py
@@ -518,4 +518,7 @@ def test_feeder_file(mock_invoice, mock_folio_client):
 
     raw_feeder_file = feeder_file.generate()
 
-    assert raw_feeder_file.splitlines()[-1] == "LIB9999999999TR202307131000000001442.03"
+    current_date_str = datetime.datetime.utcnow().strftime("%Y%m%d")
+    last_line = f"LIB9999999999TR{current_date_str}1000000001442.03"
+
+    assert raw_feeder_file.splitlines()[-1] == last_line

--- a/tests/test_orafin_payments.py
+++ b/tests/test_orafin_payments.py
@@ -116,7 +116,7 @@ def test_get_invoice(mock_folio_client):
     assert invoice.vendor.liableForVat is False
     assert invoice.vendor.vendor_number == "HD012957FEEDER"
     assert invoice.lines[0].tax_exempt is False
-    assert invoice.attachment_flag is None
+    assert invoice.attachment_flag == " "
     assert invoice.lines[0].tax_code(invoice.vendor.liableForVat) == "USE_CA"
 
     # Tests conditional properties
@@ -124,7 +124,7 @@ def test_get_invoice(mock_folio_client):
     assert invoice.amount == invoice.total
     invoice.total = -100.00
     assert invoice.invoice_type == "CR"
-    invoice.paymentDate = datetime.utcnow()
+    invoice.paymentDue = datetime.utcnow()
     assert invoice.terms_name == "IMMEDIATE"
     assert invoice.lines[0].tax_code(True) == "SALES_STANDARD"
     invoice.lines[0].adjustmentsTotal = 0.0


### PR DESCRIPTION
Fixes #677
Fixes #707 

This draft PR generates a Feeder File for one or more FOLIO invoices. Right now the PR generates close-to-correct lines for the invoices in the [samples ](https://docs.google.com/document/d/16ZYktSQ1JllF7oaRoClw4rl1CoQRlth0iKWLba9tlz0/edit) document.

TODO:
- [x] Confirm for invoice with split percentages for fund distributions
- [x] Fully test new feeder file generation code for `InvoiceLine` 

## Samples

1. https://folio-test.stanford.edu/invoice/view/fd6e5f34-101e-4dd2-8542-0fdaf7713a2b

```
LIB10592     HD668330FEEDER         15142 10592                             20221206000000001442.00DR                              IMMEDIATE       
LIB10592     DR000000000225.00USE_CA              1065032-101-KARFD-53245                                              
LIB10592     TX000000000020.54USE_CA              1065032-101-KARFD-53245                                              
LIB10592     TA-00000000020.54USE_CA                                                                                   
LIB10592     DR000000000225.00USE_CA              1065090-101-KATMX-53245                                              
LIB10592     TX000000000020.54USE_CA              1065090-101-KATMX-53245                                              
LIB10592     TA-00000000020.54USE_CA                                                                                   
LIB10592     DR000000000375.00USE_CA              1065031-111-KBAEW-53245                                              
LIB10592     TX000000000034.24USE_CA              1065031-111-KBAEW-53245                                              
LIB10592     TA-00000000034.24USE_CA                                                                                   
LIB10592     DR000000000325.00USE_CA              1065032-101-KARFD-53245                                              
LIB10592     TX000000000029.67USE_CA              1065032-101-KARFD-53245                                              
LIB10592     TA-00000000029.67USE_CA                                                                                   
LIB10592     DR000000000054.49USE_CA              1065090-101-KATMX-53245                                              
LIB10592     TX000000000025.11USE_CA              1065090-101-KATMX-53245                                              
LIB10592     TA-00000000025.11USE_CA                                                                                   
LIB10592     DR000000000245.62USE_CA              1065032-101-NAAUS-53245                                              
LIB10592     TX000000000025.11USE_CA              1065032-101-NAAUS-53245                                              
LIB10592     TA-00000000025.11USE_CA                                                                                   
LIB10592     DR000000000017.00TAX_EXEMPT          1065084-101-AALIB-55320 
```

2.  https://folio-test.stanford.edu/invoice/view/35500c7d-1d19-455e-b5e8-417e7d5d395a

```
LIB10593     HD094879FEEDER         9859 10593                              20230301000000003358.45DR                              IMMEDIATE       
LIB10593     DR000000001450.00SALES_STANDARD      1065090-101-KAUPC-53245                                              
LIB10593     TX000000000132.38SALES_STANDARD      1065090-101-KAUPC-53245                                              
LIB10593     DR000000000950.00SALES_STANDARD      1065090-101-KAUPC-53245                                              
LIB10593     TX000000000086.73SALES_STANDARD      1065090-101-KAUPC-53245                                              
LIB10593     DR000000000650.00SALES_STANDARD      1065090-101-KAUPC-53245                                              
LIB10593     TX000000000059.34SALES_STANDARD      1065090-101-KAUPC-53245                                              
LIB10593     DR000000000030.00TAX_EXEMPT          1065084-101-AALIB-55320
```

3.  https://folio-test.stanford.edu/invoice/view/583ef253-5649-46ab-a8b6-ac0df1cbd9d1

```
LIB10596     HD804584FEEDER         1033INV00084008 10596                   20221213000000076183.73DR                              N30             
LIB10596     DR000000050452.16TAX_EXEMPT          1065089-101-AALIB-53263                                              
LIB10596     DR000000020848.72TAX_EXEMPT          1065089-101-AALIB-53263                                              
LIB10596     DR000000004882.85TAX_EXEMPT          1065089-101-AALIB-53263 
```

4. https://folio-test.stanford.edu/invoice/view/1d8d3412-7595-43f6-b432-c6ca7d94ba18

```
LIB10597     HD012580FEEDER         38060 10597                             20230306-00000000024.00CR                              IMMEDIATE       
LIB10597     DR-00000000024.00USE_CA              1065036-111-AALIB-53245                                              
LIB10597     TX-00000000002.19USE_CA              1065036-111-AALIB-53245                                              
LIB10597     TA000000000002.19USE_CA  
```

5. https://folio-test.stanford.edu/invoice/view/7393322f-aeaa-4d51-84b6-b83d335f9a33
```
IB10599     HD895630FEEDER         NONUM-22S-79 10599                      20220307000000200000.00DR                              IMMEDIATE      Y
LIB10599     DR000000032000.00TAX_EXEMPT          1065031-105-KARVE-53245                                              
LIB10599     DR000000032000.00TAX_EXEMPT          1065032-101-NAAUS-53245                                              
LIB10599     DR000000018000.00TAX_EXEMPT          1065090-101-KBAEB-53245                                              
LIB10599     DR000000118000.00TAX_EXEMPT          1065090-101-AALIB-53245 
```
