### PR TITLE
Use pymarc default to_unicode for reading MARC records

### DIFF
--- a/libsys_airflow/plugins/vendor/marc.py
+++ b/libsys_airflow/plugins/vendor/marc.py
@@ -112,14 +112,13 @@ def process_marc(
     logger.info(f"Processing from {marc_path}")
     records = []
     with marc_path.open("rb") as fo:
-        reader = _marc_reader(fo, to_unicode=False)
+        reader = _marc_reader(fo, to_unicode=True)
         for record in reader:
             if record is None:
                 logger.info(
                     f"Error reading MARC. Current chunk: {reader.current_chunk}. Error: {reader.current_exception}"
                 )
             else:
-                record = _marc8_to_unicode(record)
                 if remove_fields:
                     record.remove_fields(*remove_fields)
                 if change_fields:
@@ -345,6 +344,12 @@ def _marc8_to_unicode(record: pymarc.Record) -> pymarc.Record:
     Handle MARC records that are encoded as MARC8 but have incorrect bit
     set for utf-8 encoding in leader or have mixed MARC8 and UTF-8 encodings
     in different fields
+
+    NOTE (8/24/2023): Keeping this function as we plan to extend the VMA
+    app by adding a new MARC Processing Rule for MARC handling for marcit
+    ckj loads that this function handled but caused errors for other vendors
+    that had parsing errors but were still utf-8 encoded.
+    https://github.com/sul-dlss/libsys-airflow/issues/744#issuecomment-1690452884
     """
     try:
         old_stderr = sys.stderr


### PR DESCRIPTION
Sorta Fixes #744, the strategy used in PR https://github.com/sul-dlss/libsys-airflow/pull/746 only works partially if the vendor file doesn't have errors parsing string values as utf-8 OR if the vendor file contains mixed utf-8 and marc8 characters that we were seeing in marcit ckj loads. At this point, the majority of vendor loads have parsing errors but are meant to be encoded as utf-8 so the current code was actually ending up with garbage values trying to encode as `ascii`. 

@ahafele  and I discussed and she will ticket maybe using a `MARC Processing Rule` for MARC handling that would allow users to specify handing at the FOLIO Interface level but would also require UI changes. I left a note in the `_marc8_to_unicode` comment for later reference.

 Fun stuff with trying to best handle GIGO from external vendor. 