### PR TITLE
Adds SFTP Task for Orafin Feeder File and sets Pending for Vouchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ seed_vendors.log
 circ/
 dist/
 .python-version
-orafin/
+orafin-files/
 vendor-data/
 virtual-env/
 vendor-keys/

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -107,7 +107,7 @@ x-airflow-common:
     - ${AIRFLOW_PROJ_DIR:-.}/circ:/opt/airflow/circ
     - ${AIRFLOW_PROJ_DIR:-.}/vendor-data:/opt/airflow/vendor-data
     - ${AIRFLOW_PROJ_DIR:-.}/vendor-keys:/opt/airflow/vendor-keys
-    - ${AIRFLOW_PROJ_DIR:-.}/orafin:/opt/airflow/orafin
+    - ${AIRFLOW_PROJ_DIR:-.}/orafin-files:/opt/airflow/orafin-files
   user: "${AIRFLOW_UID:-50000}:0"
   extra_hosts:
       - host.docker.internal:host-gateway

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -98,7 +98,7 @@ x-airflow-common:
     - ${AIRFLOW_PROJ_DIR:-.}/circ:/opt/airflow/circ
     - ${AIRFLOW_PROJ_DIR:-.}/vendor-data:/opt/airflow/vendor-data
     - ${AIRFLOW_PROJ_DIR:-.}/vendor-keys:/opt/airflow/vendor-keys
-    - ${AIRFLOW_PROJ_DIR:-.}/orafin:/opt/airflow/orafin
+    - ${AIRFLOW_PROJ_DIR:-.}/orafin-files:/opt/airflow/orafin-files
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:
     &airflow-common-depends-on

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -1,5 +1,7 @@
 import logging
 
+import httpx
+
 from airflow.decorators import task
 from airflow.models import Variable
 
@@ -31,14 +33,37 @@ def _get_ids_from_vouchers(folio_query: str, folio_client: FolioClient) -> list:
     return [row.get("invoiceId") for row in vouchers["vouchers"]]
 
 
+def _update_vouchers_to_pending(invoice_ids: list, folio_client: FolioClient) -> dict:
+    """
+    Iterates through list of invoice ids and updates disbursementNumber to Pending
+    """
+    success, failures = [], []
+    for invoice in invoice_ids:
+        logger.info(f"Invoice {invoice}")
+        voucher_result = folio_client.get(f"/voucher/vouchers?query=(invoiceId=={invoice['id']})")
+        for voucher in voucher_result.get("vouchers", []):
+            voucher_id = voucher["id"]
+            voucher["disbursementNumber"] = "Pending"
+            put_result = httpx.put(f"{folio_client.okapi_url}/voucher/vouchers/{voucher_id}",
+                                   headers=folio_client.okapi_headers,
+                                   json=voucher)
+            if put_result.status_code == 204:
+                logger.info(f"Successfully set disbursementNumber for voucher {voucher_id}")
+                success.append(voucher_id)
+            else:
+                logger.error(f"Failed to update {voucher_id} HTTP Error {put_result.status_code} {put_result.text}")
+                failures.append(voucher_id)
+    return { "success": success, "failures": failures}
+
+
 @task
 def invoices_awaiting_payment_task() -> list:
     """
     Retrieves all awaiting payment invoices uuids from vouchers endpoint
     """
     folio_client = _folio_client()
-    sul_invoices = "(acqUnitIds==*\"bd6c5f05-9ab3-41f7-8361-1c1e847196d3\"*) and exportToAccounting=true and status=\"Awaiting payment\" and cql.allRecords=1 not disbursementNumber=\"\""
-    law_invoices = "(acqUnitIds==*\"556eb26f-dbea-41c1-a1de-9a88ad950d95\"*) and exportToAccounting=true and status=\"Awaiting payment\" and cql.allRecords=1 not disbursementNumber=\"\""
+    sul_invoices = "(acqUnitIds==*\"bd6c5f05-9ab3-41f7-8361-1c1e847196d3\"*) and exportToAccounting=true and status=\"Awaiting payment\" and cql.allRecords=1 not disbursementNumber=\"Pending\""
+    law_invoices = "(acqUnitIds==*\"556eb26f-dbea-41c1-a1de-9a88ad950d95\"*) and exportToAccounting=true and status=\"Awaiting payment\" and cql.allRecords=1 not disbursementNumber=\"Pending\""
     query = f"""({sul_invoices}) or ({law_invoices})"""
     invoice_ids = _get_ids_from_vouchers(query, folio_client)
     return invoice_ids
@@ -46,4 +71,8 @@ def invoices_awaiting_payment_task() -> list:
 
 @task
 def invoices_pending_payment_task(invoice_ids: list, upload_status: bool):
-    return "foo"
+    if upload_status is False:
+        logger.error("Failed to upload Feeder file")
+        return
+    folio_client = _folio_client()
+    return _update_vouchers_to_pending(invoice_ids, folio_client)

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -39,7 +39,7 @@ def _update_vouchers_to_pending(invoice_ids: list, folio_client: FolioClient) ->
     """
     success, failures = [], []
     for invoice in invoice_ids:
-        logger.info(f"Invoice {invoice}")
+        logger.info(f"Processing Invoice {invoice['id']}")
         voucher_result = folio_client.get(
             f"/voucher-storage/vouchers?query=(invoiceId=={invoice['id']})"
         )

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -40,20 +40,28 @@ def _update_vouchers_to_pending(invoice_ids: list, folio_client: FolioClient) ->
     success, failures = [], []
     for invoice in invoice_ids:
         logger.info(f"Invoice {invoice}")
-        voucher_result = folio_client.get(f"/voucher/vouchers?query=(invoiceId=={invoice['id']})")
+        voucher_result = folio_client.get(
+            f"/voucher-storage/vouchers?query=(invoiceId=={invoice['id']})"
+        )
         for voucher in voucher_result.get("vouchers", []):
             voucher_id = voucher["id"]
             voucher["disbursementNumber"] = "Pending"
-            put_result = httpx.put(f"{folio_client.okapi_url}/voucher/vouchers/{voucher_id}",
-                                   headers=folio_client.okapi_headers,
-                                   json=voucher)
+            put_result = httpx.put(
+                f"{folio_client.okapi_url}/voucher-storage/vouchers/{voucher_id}",
+                headers=folio_client.okapi_headers,
+                json=voucher,
+            )
             if put_result.status_code == 204:
-                logger.info(f"Successfully set disbursementNumber for voucher {voucher_id}")
+                logger.info(
+                    f"Successfully set disbursementNumber for voucher {voucher_id}"
+                )
                 success.append(voucher_id)
             else:
-                logger.error(f"Failed to update {voucher_id} HTTP Error {put_result.status_code} {put_result.text}")
+                logger.error(
+                    f"Failed to update {voucher_id} HTTP Error {put_result.status_code} {put_result.text}"
+                )
                 failures.append(voucher_id)
-    return { "success": success, "failures": failures}
+    return {"success": success, "failures": failures}
 
 
 @task

--- a/libsys_airflow/plugins/orafin/models.py
+++ b/libsys_airflow/plugins/orafin/models.py
@@ -344,6 +344,7 @@ class FeederFile:
         for invoice in self.invoices:
             raw_file += f"{invoice.header()}\n"
             raw_file += invoice.line_data()
+            raw_file += "\n"
         raw_file += "\n"
         raw_file += "".join(
             [

--- a/libsys_airflow/plugins/orafin/payments.py
+++ b/libsys_airflow/plugins/orafin/payments.py
@@ -33,7 +33,10 @@ def _get_fund(fund_distributions: list, folio_client: FolioClient):
 def _get_invoice_lines(invoice_id: str, folio_client: FolioClient) -> tuple:
     invoice_lines_result = folio_client.get(
         "/invoice/invoice-lines",
-        params={"query": f"invoiceId=={invoice_id}", "limit": 250},
+        params={
+            "query": f"invoiceId=={invoice_id} sortBy metadata.createdDate invoiceLineNumber",
+            "limit": 250,
+        },
     )
     invoice_lines = invoice_lines_result.get("invoiceLines", [])
     exclude_invoice = False
@@ -114,5 +117,7 @@ def transfer_to_orafin(feeder_file_path: pathlib.Path, sftp_connection: str):
     sftp_hook = SFTPHook(sftp_connection)
 
     with feeder_file_path.open() as fo:
-        sftp_hook.store_file("/home/of_aplib/OF1_PRD/inbound/data/xxdl_ap_lib.dat", fo.read())
+        sftp_hook.store_file(
+            "/home/of_aplib/OF1_PRD/inbound/data/xxdl_ap_lib.dat", fo.read()
+        )
     logger.info(f"Uploaded {feeder_file_path.name} with {sftp_connection} connection")

--- a/libsys_airflow/plugins/orafin/payments.py
+++ b/libsys_airflow/plugins/orafin/payments.py
@@ -114,5 +114,5 @@ def transfer_to_orafin(feeder_file_path: pathlib.Path, sftp_connection: str):
     sftp_hook = SFTPHook(sftp_connection)
 
     with feeder_file_path.open() as fo:
-        sftp_hook.store_file("/inbound/data/xxdl_ap_lib.dat", fo.read())
+        sftp_hook.store_file("/home/of_aplib/OF1_PRD/inbound/data/xxdl_ap_lib.dat", fo.read())
     logger.info(f"Uploaded {feeder_file_path.name} with {sftp_connection} connection")

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -78,7 +78,7 @@ def feeder_file_task(invoices: list):
 def generate_feeder_file_task(feeder_file: dict, airflow: str = "/opt/airflow") -> str:
     # Initialize Feeder File Task
     folio_client = _folio_client()
-    orafin_path = pathlib.Path(f"{airflow}/orafin/data")
+    orafin_path = pathlib.Path(f"{airflow}/orafin-files/data")
     orafin_path.mkdir(exist_ok=True, parents=True)
     feeder_file_instance = generate_file(feeder_file, folio_client)
     feeder_file_path = orafin_path / feeder_file_instance.file_name


### PR DESCRIPTION
Fixes #678 
Fixes #679 

This PR enables an SFTP connection to Orafin but is currently failing because the creditials Keypair we are currently have for the AP system was generated with as an old RSA that is not recognized by the [paramiko](https://www.paramiko.org/) dependency in Airflow (error `paramiko.ssh_exception.SSHException: encountered RSA key, expected OPENSSH key`)

AP department said that they will generate a new key pair this week which we can use to test. If that approach doesn't work, we could change the using an Airflow Bash operator and pass in `-o KexAlgorithms=diffie-hellman-group14-sha1` flag to SFTP running on the docker container. 