### PR TITLE
Uses BashOperator to scp feeder file to AP server

### DIFF
--- a/libsys_airflow/dags/payments_to_orafin.py
+++ b/libsys_airflow/dags/payments_to_orafin.py
@@ -51,8 +51,12 @@ with DAG(
 
     generate_file = generate_feeder_file_task(feeder_file)
 
-    upload_status = sftp_file_task(generate_file, "sftp-orafin")
+    upload_status = sftp_file_task(generate_file)
 
     email_excluded_invoices = email_excluded_task(filtered_invoices["excluded"])
 
-    invoices_pending_payment_task(filtered_invoices["feed"], upload_status)
+    (
+        generate_file
+        >> upload_status
+        >> invoices_pending_payment_task(filtered_invoices["feed"])
+    )

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -78,9 +78,6 @@ def invoices_awaiting_payment_task() -> list:
 
 
 @task
-def invoices_pending_payment_task(invoice_ids: list, upload_status: bool):
-    if upload_status is False:
-        logger.error("Failed to upload Feeder file")
-        return
+def invoices_pending_payment_task(invoice_ids: list):
     folio_client = _folio_client()
     return _update_vouchers_to_pending(invoice_ids, folio_client)

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -84,12 +84,11 @@ def generate_feeder_file_task(feeder_file: dict, airflow: str = "/opt/airflow") 
     feeder_file_path = orafin_path / feeder_file_instance.file_name
     with feeder_file_path.open("w+") as fo:
         fo.write(feeder_file_instance.generate())
+    logger.info(f"Feeder-file {feeder_file_path.resolve()}")
     return str(feeder_file_path.resolve())
 
 
-@task
-def sftp_file_task(feeder_file_path: str, sftp_connection: str):  # type: ignore
-    transfer_status = transfer_to_orafin(
-        pathlib.Path(feeder_file_path), sftp_connection
-    )
-    return transfer_status
+# @task -- When SFTP is available on AP server, uncomment this line to make a taskflow task
+def sftp_file_task(feeder_file_path: str, sftp_connection: str = None):  # type: ignore
+    bash_operator = transfer_to_orafin(feeder_file_path)
+    return bash_operator

--- a/tests/orafin/test_payments.py
+++ b/tests/orafin/test_payments.py
@@ -215,13 +215,14 @@ def mock_sftp_hook(mocker):
     return mock_hook
 
 
-def test_transfer_to_orafin(mock_sftp_hook, tmp_path):
+def test_transfer_to_orafin(mock_sftp_hook, tmp_path, caplog):
     feeder_file_path = tmp_path / "feeder20210823_202309240000"
     feeder_file_path.write_text(
         """LIB376992    HD006169FEEDER         23-13094 376992                         20230503000000000385.52DR                              N30
 LIB376992    DR000000000023.95USE_CA              1065087-101-AALIB-53245
 LIB376992    TX000000000002.19USE_CA              1065087-101-AALIB-53245"""
     )
-    transfer_to_orafin(feeder_file_path, "sftp-orafin")
+    transfer_to_orafin(str(feeder_file_path))
 
     assert feeder_file_path.exists()
+    assert """Command ['scp', '-i /opt/airflow/vendor-keys/""" in caplog.text


### PR DESCRIPTION
Until the AP server upgrades OpenSSH, we need to use the BashOperator and `scp` to copy the feeder-file to the remote server. 