### PR TITLE
AP Report Processing

### DIFF
--- a/libsys_airflow/dags/orafin/report_processing.py
+++ b/libsys_airflow/dags/orafin/report_processing.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.decorators import task_group
+from airflow.operators.empty import EmptyOperator
+
+from libsys_airflow.plugins.orafin.tasks import (
+    email_errors_task,
+    email_paid_task,
+    extract_rows_task,
+    init_processing_task,
+    retrieve_invoice_task,
+    retrieve_voucher_task,
+    update_invoices_task,
+    update_vouchers_task,
+)
+
+
+default_args = {
+    "owner": "libsys",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+
+@task_group(group_id="update-folio")
+def update_folio(record):
+    invoice_id = update_invoices_task(invoice=record)
+    voucher = retrieve_voucher_task(invoice_id)
+    update_vouchers_task(voucher=voucher)
+
+
+@task_group(group_id="email-group")
+def email_group():
+    email_errors_task()
+    email_paid_task()
+
+
+with DAG(
+    "ap_payment_report",
+    default_args=default_args,
+    schedule=None,
+    start_date=datetime(2023, 9, 19),
+    catchup=False,
+    tags=["folio", "orafin"],
+) as dag:
+    start = EmptyOperator(task_id="start")
+
+    finish_updates = EmptyOperator(task_id="end")
+
+    report_path = init_processing_task()
+
+    report_rows = extract_rows_task(report_path)
+
+    start >> report_path
+
+    invoices = retrieve_invoice_task.expand(row=report_rows)
+
+    update_folio.expand(record=invoices) >> email_group() >> finish_updates

--- a/libsys_airflow/plugins/orafin/emails.py
+++ b/libsys_airflow/plugins/orafin/emails.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 
 from jinja2 import Environment, Template
 
@@ -9,6 +10,54 @@ from libsys_airflow.plugins.orafin.models import Invoice
 from libsys_airflow.plugins.orafin.payments import models_converter
 
 logger = logging.getLogger(__name__)
+
+
+def _ap_report_errors_email_body(
+    missing_invoices: list,
+    cancelled_invoices: list,
+    paid_invoices: list,
+    folio_url: str,
+) -> str:
+    template = Template(
+        """
+        <h1>Invoices Failures from AP Report</h1>
+        {% if missing|length > 0 %}
+        <h2>Missing Invoices</h2>
+        <ul>
+        {% for folio_invoice_number in missing %}
+        <li>{{ folio_invoice_number }} found in AP Report but not in FOLIO</li>
+        {% endfor %}
+        </ul>
+        {% endif %}
+        {% if cancelled|length > 0 %}
+        <h2>Cancelled Invoices</h2>
+        <ul>
+        {% for invoice_id in cancelled %}
+        <li>
+            <a href="{{ folio_url}}/invoice/view/{{invoice_id }}">Invoice {{invoice_id }}</a>
+        </li>
+        {% endfor %}
+        </ul>
+        {% endif %}
+        {% if paid|length > 0 %}
+        <h2>Already Paid Invoices</h2>
+        <ul>
+        {% for invoice_id in paid %}
+        <li>
+          <a href="{{ folio_url}}/invoice/view/{{invoice_id }}">Invoice {{invoice_id }}</a>
+        </li>
+        {% endfor %}
+        </ul>
+        {% endif %}
+        """
+    )
+
+    return template.render(
+        missing=missing_invoices,
+        cancelled=cancelled_invoices,
+        paid=paid_invoices,
+        folio_url=folio_url,
+    )
 
 
 def _invoice_line_links(invoice: Invoice, folio_url) -> str:
@@ -36,6 +85,27 @@ def _invoice_line_links(invoice: Invoice, folio_url) -> str:
                 }
             )
     return template.render(lines=lines)
+
+
+def _ap_report_paid_email_body(
+    invoices: list, ap_report_name: str, folio_url: str
+) -> str:
+    template = Template(
+        """
+        <h2>Paid Invoices</h2>
+        <p>From ap report {{ ap_report_name }}</p>
+        <ul>
+        {% for invoice_id in invoices %}
+        <li>
+            <a href="{{ folio_url}}/invoice/view/{{invoice_id }}">Invoice {{invoice_id }}</a>
+        </li>
+        {% endfor %}
+        </ul>
+        """
+    )
+    return template.render(
+        ap_report_name=ap_report_name, invoices=invoices, folio_url=folio_url
+    )
 
 
 def _excluded_email_body(invoices: list, folio_url: str) -> str:
@@ -95,6 +165,73 @@ def _summary_email_body(invoices: list, folio_url: str):
     )
     invoice_instances = [converter.structure(invoice, Invoice) for invoice in invoices]
     return template.render(invoices=invoice_instances, folio_url=folio_url)
+
+
+def generate_ap_error_report_email(folio_url: str, ti=None) -> int:
+    """
+    Retrieves Errors from upstream tasks and emails report
+    """
+    task_instance = ti
+    logger.info("Generating Email Report")
+    missing_invoices = task_instance.xcom_pull(
+        task_ids='retrieve_invoice_task', key='missing'
+    )
+    if missing_invoices is None:
+        missing_invoices = []
+    logger.info(f"Missing {len(missing_invoices):,}")
+    cancelled_invoices = task_instance.xcom_pull(
+        task_ids='retrieve_invoice_task', key='cancelled'
+    )
+    if cancelled_invoices is None:
+        cancelled_invoices = []
+    logger.info(f"Cancelled {len(cancelled_invoices):,}")
+    paid_invoices = task_instance.xcom_pull(
+        task_ids='retrieve_invoice_task', key='paid'
+    )
+    if paid_invoices is None:
+        paid_invoices = []
+    logger.info(f"Paid {len(paid_invoices):,}")
+    total_errors = len(missing_invoices) + len(cancelled_invoices) + len(paid_invoices)
+
+    # No errors, don't send email
+    if total_errors < 1:
+        return total_errors
+
+    to_email_addr = Variable.get("ORAFIN_TO_EMAIL")
+
+    logger.info(f"Sending email to {to_email_addr} for {total_errors} error reports")
+
+    html_content = _ap_report_errors_email_body(
+        missing_invoices, cancelled_invoices, paid_invoices, folio_url
+    )
+
+    send_email(
+        to=[
+            to_email_addr,
+        ],
+        subject="Invoice Errors from AP Report",
+        html_content=html_content,
+    )
+    return total_errors
+
+
+def generate_ap_paid_report_email(folio_url: str, task_instance=None):
+    """
+    Generates emails for Paid Invoices and Vouchers from AP Report
+    """
+    ap_report_path = task_instance.xcom_pull(task_ids="init_processing_task")
+    invoices = task_instance.xcom_pull(task_ids="retrieve_invoice_task")
+    ap_report_name = pathlib.Path(ap_report_path).name
+    html_content = _ap_report_paid_email_body(invoices, ap_report_name, folio_url)
+    to_email_addr = Variable.get("ORAFIN_TO_EMAIL_SUL")
+    send_email(
+        to=[
+            to_email_addr,
+        ],
+        subject=f"Paid Invoices from {ap_report_name}",
+        html_content=html_content,
+    )
+    return len(invoices)
 
 
 def generate_summary_email(invoices: list, folio_url: str):

--- a/libsys_airflow/plugins/orafin/reports.py
+++ b/libsys_airflow/plugins/orafin/reports.py
@@ -159,3 +159,12 @@ def retrieve_reports() -> OperatorPartial:
         ]
     )
     return BashOperator.partial(task_id="scp_report", bash_command=" ".join(command))
+
+
+def update_invoice(invoice: dict, folio_client: FolioClient) -> dict:
+    """
+    Updates Invoice
+    """
+    invoice["status"] = "Paid"
+    folio_client.put(f"/invoice-storage/invoices/{invoice['id']}", invoice)
+    logger.info(f"Updated {invoice['id']} to status of Paid")

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -15,11 +15,11 @@ from libsys_airflow.plugins.orafin.emails import (
     generate_summary_email,
 )
 
-
 from libsys_airflow.plugins.orafin.reports import (
     extract_rows,
     filter_files,
     retrieve_invoice,
+    retrieve_voucher,
     update_invoice,
 )
 
@@ -171,6 +171,15 @@ def retrieve_invoice_task(row: dict):
     """
     folio_client = _folio_client()
     return retrieve_invoice(row, folio_client)
+
+
+@task
+def retrieve_voucher_task(invoice_id: str):
+    """
+    Retrieves voucher based on invoice id
+    """
+    folio_client = _folio_client()
+    return retrieve_voucher(invoice_id, folio_client)
 
 
 # @task -- When SFTP is available on AP server, uncomment this line to make a taskflow task

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -21,6 +21,7 @@ from libsys_airflow.plugins.orafin.reports import (
     retrieve_invoice,
     retrieve_voucher,
     update_invoice,
+    update_voucher,
 )
 
 from libsys_airflow.plugins.orafin.payments import (
@@ -203,10 +204,21 @@ def transform_folio_data_task(invoice_id: str):
 
 @task
 def update_invoices_task(invoice: dict):
-    folio_client = _folio_client()
     if invoice:
+        folio_client = _folio_client()
         logger.info(f"Updating Invoice {invoice['id']}")
         update_invoice(invoice, folio_client)
         return invoice['id']
     else:
         logger.error("Invoice is None")
+
+
+@task
+def update_vouchers_task(voucher: dict, ti=None):
+    if voucher:
+        folio_client = _folio_client()
+        logger.info(f"Updating voucher {voucher['id']}")
+        voucher = update_voucher(voucher, ti, folio_client)
+        return voucher['id']
+    else:
+        logger.error("Voucher is None")

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -19,6 +19,7 @@ from libsys_airflow.plugins.orafin.emails import (
 from libsys_airflow.plugins.orafin.reports import (
     extract_rows,
     filter_files,
+    retrieve_invoice,
 )
 
 from libsys_airflow.plugins.orafin.payments import (
@@ -137,6 +138,15 @@ def launch_report_processing_task(**kwargs):
                 "ap_report_path": f"{airflow}/orafin-files/reports/{report['file_name']}"
             },
         ).execute(kwargs)
+
+
+@task(max_active_tis_per_dagrun=5)
+def retrieve_invoice_task(row: dict):
+    """
+    Retrieves invoice from a row dictionary
+    """
+    folio_client = _folio_client()
+    return retrieve_invoice(row, folio_client)
 
 
 @task(max_active_tis_per_dag=5)

--- a/tests/orafin/test_ap_reports.py
+++ b/tests/orafin/test_ap_reports.py
@@ -12,6 +12,7 @@ from libsys_airflow.plugins.orafin.reports import (
     retrieve_invoice,
     retrieve_reports,
     remove_reports,
+    update_invoice,
 )
 
 
@@ -85,8 +86,12 @@ def mock_folio_client(mocker):
                     ]
                 }
 
+    def mock_put(*args, **kwargs):
+        return None
+
     mock_client = mocker.MagicMock()
     mock_client.get = mock_get
+    mock_client.put = mock_put
     return mock_client
 
 
@@ -224,3 +229,11 @@ def test_remove_reports():
     assert bash_command.startswith("ssh")
     assert ap_server_options[0] in bash_command
     assert bash_command.endswith("rm /home/of_aplib/OF1_PRD/outbound/data/$file_name")
+
+
+def test_update_invoice(mock_folio_client, caplog):
+    invoice = {"id": "3cf0ebad-6e86-4374-a21d-daf2227b09cd"}
+    update_invoice(invoice, mock_folio_client)
+    assert (
+        "Updated 3cf0ebad-6e86-4374-a21d-daf2227b09cd to status of Paid" in caplog.text
+    )

--- a/tests/orafin/test_ap_reports.py
+++ b/tests/orafin/test_ap_reports.py
@@ -11,6 +11,7 @@ from libsys_airflow.plugins.orafin.reports import (
     find_reports,
     retrieve_invoice,
     retrieve_reports,
+    retrieve_voucher,
     remove_reports,
     update_invoice,
 )
@@ -211,6 +212,34 @@ def test_retrieve_duplicate_invoices(mock_folio_client, mock_current_context, ca
     retrieve_invoice(row, mock_folio_client)
     assert (
         "Multiple invoices 91c0dd9d-d906-4f08-8321-2a2f58a9a35f,bcc5b35c-3e89-4c48-b721-9ab0cbda91a9"
+        in caplog.text
+    )
+
+
+def test_retrieve_voucher(mock_folio_client, mock_current_context):
+    voucher = retrieve_voucher(
+        "3cf0ebad-6e86-4374-a21d-daf2227b09cd", mock_folio_client
+    )
+    assert voucher["id"] == "3f94f17b-3251-4eb0-849a-d57a76ac3f03"
+
+
+def test_retrieve_paid_voucher(mock_folio_client, mock_current_context, caplog):
+    retrieve_voucher("587c922a-5be1-4de8-a268-2a5859d62779", mock_folio_client)
+    assert "Voucher d49924fd-6153-4894-bdbf-997126b0a55 already Paid" in caplog.text
+
+
+def test_retrieve_no_voucher(mock_folio_client, mock_current_context, caplog):
+    retrieve_voucher("3379cf1d-dd47-4f7f-9b04-7ace791e75c8", mock_folio_client)
+    assert (
+        "No voucher found for invoice 3379cf1d-dd47-4f7f-9b04-7ace791e75c8"
+        in caplog.text
+    )
+
+
+def test_retrieve_duplicate_vouchers(mock_folio_client, mock_current_context, caplog):
+    retrieve_voucher("e2e8344d-2ad6-44f2-bf56-f3cd04f241b3", mock_folio_client)
+    assert (
+        "Multiple vouchers b6f0407c-4929-4831-8f2b-ef1aa5a26163,0321fbc6-8714-411a-9619-9c2b43e0df05"
         in caplog.text
     )
 

--- a/tests/orafin/test_generated_emails.py
+++ b/tests/orafin/test_generated_emails.py
@@ -4,10 +4,160 @@ import pytest  # noqa
 from bs4 import BeautifulSoup
 
 from libsys_airflow.plugins.orafin.emails import (
+    generate_ap_error_report_email,
+    generate_ap_paid_report_email,
     generate_excluded_email,
     generate_summary_email,
 )
+
 from test_payments import invoice_dict, invoice_lines, vendor
+
+
+def mock_retrieve_invoice_task_xcom_pull(**kwargs):
+    key = kwargs.get("key")
+
+    output = []
+    match key:
+        case "cancelled":
+            output.extend(
+                [
+                    "759dfefa-a2d4-4977-bf31-d11da1ba1fb0",
+                    "0332b649-4415-4a63-8a6e-4b0b16b51ab0",
+                    "6c583579-146c-453b-aa05-e1ce0d8365cd",
+                ]
+            )
+
+        case "missing":
+            output.append("10440")
+
+        case "paid":
+            output.extend(
+                [
+                    "9cf2899a-c7a6-4101-bf8e-c5996ded5fd1",
+                    "e2886f5c-f7f7-4d26-aa32-afc62e2d554c",
+                ]
+            )
+
+    return output
+
+
+def test_generate_ap_error_report_email(mocker):
+    mock_send_email = mocker.patch("libsys_airflow.plugins.orafin.emails.send_email")
+
+    mocker.patch(
+        "libsys_airflow.plugins.orafin.emails.Variable.get",
+        return_value="test@stanford.edu",
+    )
+
+    task_instance = mocker.MagicMock()
+    task_instance.xcom_pull = mock_retrieve_invoice_task_xcom_pull
+
+    total_errors = generate_ap_error_report_email(
+        "http://folio.stanford.edu", task_instance
+    )
+
+    assert total_errors == 6
+    assert mock_send_email.called
+    assert mock_send_email.call_args[1]['to'] == ['test@stanford.edu']
+
+    html_body = BeautifulSoup(
+        mock_send_email.call_args[1]['html_content'], 'html.parser'
+    )
+
+    h2s = html_body.find_all("h2")
+
+    assert h2s[0].text == "Missing Invoices"
+    assert h2s[1].text == "Cancelled Invoices"
+    assert h2s[2].text == "Already Paid Invoices"
+
+    uls = html_body.find_all("ul")
+    missing_lis = uls[0].find_all("li")
+    assert missing_lis[0].text == "10440 found in AP Report but not in FOLIO"
+
+    cancelled_lis = uls[1].find_all("li")
+    assert (
+        cancelled_lis[1].find("a").get("href")
+        == "http://folio.stanford.edu/invoice/view/0332b649-4415-4a63-8a6e-4b0b16b51ab0"
+    )
+
+    paid_lis = uls[2].find_all("li")
+    assert paid_lis[0].find("a").text == "Invoice 9cf2899a-c7a6-4101-bf8e-c5996ded5fd1"
+
+
+def test_generate_ap_error_report_email_options(mocker):
+    def _no_output_xcom(**kwargs):
+        return None
+
+    def _no_missing_xcom(**kwargs):
+        key = kwargs.get("key")
+        if key.startswith("cancelled"):
+            return ["759dfefa-a2d4-4977-bf31-d11da1ba1fb0"]
+        if key.startswith("paid"):
+            return ["9cf2899a-c7a6-4101-bf8e-c5996ded5fd1"]
+        return None
+
+    mock_send_email = mocker.patch("libsys_airflow.plugins.orafin.emails.send_email")
+
+    mocker.patch(
+        "libsys_airflow.plugins.orafin.emails.Variable.get",
+        return_value="test@stanford.edu",
+    )
+
+    no_output_task_instance = mocker.MagicMock()
+    no_output_task_instance.xcom_pull = _no_output_xcom
+
+    total_errors = generate_ap_error_report_email(
+        "http://folio.stanford.edu", no_output_task_instance
+    )
+
+    assert total_errors == 0
+    assert mock_send_email.called is False
+
+    no_missing_task_instance = mocker.MagicMock()
+    no_missing_task_instance.xcom_pull = _no_missing_xcom
+
+    total_errors = generate_ap_error_report_email(
+        "http://folio.stanford.edu", no_missing_task_instance
+    )
+
+    assert total_errors == 2
+    assert mock_send_email.called
+
+
+def test_generate_ap_paid_report_email(mocker):
+    def _paid_xcom_pull(**kwargs):
+        task_ids = kwargs["task_ids"]
+        if task_ids.startswith("init_processing_task"):
+            return "/opt/airflow/orafin-data/reports/xxdl_ap_payment_09282023161640.csv"
+        if task_ids.startswith("retrieve_invoice_task"):
+            return ["9cf2899a-c7a6-4101-bf8e-c5996ded5fd1"]
+
+    mock_send_email = mocker.patch("libsys_airflow.plugins.orafin.emails.send_email")
+
+    mocker.patch(
+        "libsys_airflow.plugins.orafin.emails.Variable.get",
+        return_value="test@stanford.edu",
+    )
+
+    task_instance = mocker.MagicMock()
+    task_instance.xcom_pull = _paid_xcom_pull
+
+    total_invoices = generate_ap_paid_report_email(
+        "http://folio.stanford.edu", task_instance
+    )
+
+    assert total_invoices == 1
+    assert mock_send_email.called
+
+    html_body = BeautifulSoup(
+        mock_send_email.call_args[1]['html_content'], 'html.parser'
+    )
+
+    paragraph = html_body.find("p")
+    assert paragraph.text == "From ap report xxdl_ap_payment_09282023161640.csv"
+
+    li = html_body.find("li")
+    assert li.find("a").text == "Invoice 9cf2899a-c7a6-4101-bf8e-c5996ded5fd1"
 
 
 def test_generate_excluded_email(mocker):


### PR DESCRIPTION
Fixes #680 

This DAG takes an AP Report, parses, and then retrieves the invoices and vouchers to update the status to Paid for both while setting other properties for the voucher from the report.

![Screenshot 2023-10-24 at 5 20 09 PM](https://github.com/sul-dlss/libsys-airflow/assets/71847/8873d0c7-a36b-4ebb-bd40-9dfdb378441f)

This DAG is triggered by the `ap_report_management` DAG with the path to a locally stored AP report. 

From each row, the invoice is attempted retrieval from the `InvoiceNum` field.  If the invoice is missing or the invoice status is already *Paid* or *Cancelled* the invoice is skipped and later used in the `email_errors_task`. After all of the invoices are retrieved in the `retrieve_invoice_task`, each invoice's status is set to *Paid* and the voucher is retrieved from Folio based on the Invoice ID. Each voucher is updated based on fields in the row from the ap report and then the voucher is updated as well. All successfully updated invoices are then included in an email in the `emailed_paid_task`.