### PR TITLE
Adds excluded_reason to XCOM for task

### DIFF
--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -200,8 +200,12 @@ def transform_folio_data_task(invoice_id: str):
     folio_client = _folio_client()
     converter = models_converter()
     # Call to Okapi invoice endpoint
-    invoice, exclude = get_invoice(invoice_id, folio_client, converter)
-    return {"invoice": converter.unstructure(invoice), "exclude": exclude}
+    invoice, exclude, reason = get_invoice(invoice_id, folio_client, converter)
+    return {
+        "invoice": converter.unstructure(invoice),
+        "exclude": exclude,
+        "exclusion_reason": reason,
+    }
 
 
 @task


### PR DESCRIPTION
Fixes the following error in the `transform_folio_data_task` in the `payments_to_orafin` DAG, exclusion_reason is required for downstream email task.

```
[2023-11-07, 14:49:28 PST] {taskinstance.py:1824} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/decorators/base.py", line 220, in execute
    return_value = super().execute(context)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/operators/python.py", line 181, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/operators/python.py", line 198, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/opt/airflow/libsys_airflow/plugins/orafin/tasks.py", line 204, in transform_folio_data_task
    invoice, exclude = get_invoice(invoice_id, folio_client, converter)
ValueError: too many values to unpack (expected 2)
```