### PR TITLE
Bug fix for AP Paid Report Email

### DIFF
--- a/libsys_airflow/plugins/orafin/emails.py
+++ b/libsys_airflow/plugins/orafin/emails.py
@@ -98,9 +98,9 @@ def _ap_report_paid_email_body(
         <h2>Paid Invoices</h2>
         <p>From ap report {{ ap_report_name }}</p>
         <ul>
-        {% for invoice_id in invoices %}
+        {% for invoice in invoices %}
         <li>
-            <a href="{{ folio_url}}/invoice/view/{{invoice_id }}">Invoice {{invoice_id }}</a>
+            <a href="{{ folio_url}}/invoice/view/{{invoice.id}}">Invoice {{invoice.id}}</a>
         </li>
         {% endfor %}
         </ul>

--- a/tests/orafin/test_generated_emails.py
+++ b/tests/orafin/test_generated_emails.py
@@ -134,7 +134,12 @@ def test_generate_ap_paid_report_email(mocker):
         if task_ids.startswith("init_processing_task"):
             return "/opt/airflow/orafin-data/reports/xxdl_ap_payment_09282023161640.csv"
         if task_ids.startswith("retrieve_invoice_task"):
-            return ["9cf2899a-c7a6-4101-bf8e-c5996ded5fd1"]
+            return [
+                {
+                    "id": "9cf2899a-c7a6-4101-bf8e-c5996ded5fd1",
+                    "accountingCode": "031134FEEDER",
+                }
+            ]
 
     mock_send_email = mocker.patch("libsys_airflow.plugins.orafin.emails.send_email")
 
@@ -162,6 +167,7 @@ def test_generate_ap_paid_report_email(mocker):
 
     li = html_body.find("li")
     assert li.find("a").text == "Invoice 9cf2899a-c7a6-4101-bf8e-c5996ded5fd1"
+    assert "031134FEEDER" not in li.find("a").text
 
 
 def test_generate_excluded_email(mocker):


### PR DESCRIPTION
Fixes bug in the AP Paid Report Email includes the entire Invoice in the hyper-link and text for each invoice:

![Screenshot 2023-12-06 at 11 07 49 AM](https://github.com/sul-dlss/libsys-airflow/assets/71847/7a8818ac-5b4e-487d-a04f-0490c43b3573)
