### PR TITLE
Use Invoice BL Endpoint

### DIFF
--- a/libsys_airflow/plugins/folio/folio_client.py
+++ b/libsys_airflow/plugins/folio/folio_client.py
@@ -41,13 +41,13 @@ class FolioClient:
     def put(self, path, payload):
         """Performs a PUT and turns it into a json object"""
         url = self.okapi_url + path
-        resp = requests.put(url, headers=self.okapi_headers, json=payload)
+        resp = requests.put(url, headers=self.okapi_headers, json=payload, timeout=60)
         return self._handle_response(resp)
 
     def post(self, path, payload):
         """Performs a POST and turns it into a json object"""
         url = self.okapi_url + path
-        resp = requests.post(url, headers=self.okapi_headers, json=payload)
+        resp = requests.post(url, headers=self.okapi_headers, json=payload, timeout=60)
         return self._handle_response(resp)
 
     def post_file(self, path, filepath, content_type="application/octet-stream"):

--- a/libsys_airflow/plugins/orafin/reports.py
+++ b/libsys_airflow/plugins/orafin/reports.py
@@ -200,7 +200,7 @@ def update_invoice(invoice: dict, folio_client: FolioClient) -> dict:
     Updates Invoice
     """
     invoice["status"] = "Paid"
-    folio_client.put(f"/invoice-storage/invoices/{invoice['id']}", invoice)
+    folio_client.put(f"/invoice/invoices/{invoice['id']}", invoice)
     logger.info(f"Updated {invoice['id']} to status of Paid")
     return invoice
 


### PR DESCRIPTION
Fixes #819 based on comment from @shelleydoljack's [comment ](https://github.com/sul-dlss/libsys-airflow/issues/819#issuecomment-1843553677) to use the BL endpoint. Confirmed through testing on folio-test that setting the Invoice's status to "Paid" also updates the invoice lines 'invoiceLineStatus' to "Paid" as well. 

Also added a 60 second timeout for PUT and POST methods in the folio_client because of delay in return time when the Invoice had a large number of InvoiceLine during testing.