### PR TITLE
Removes newlines from Bash output to include all in single line

### DIFF
--- a/libsys_airflow/plugins/orafin/reports.py
+++ b/libsys_airflow/plugins/orafin/reports.py
@@ -94,7 +94,7 @@ def extract_rows(retrieved_csv: str) -> tuple:
 
 def filter_files(ls_output, airflow="/opt/airflow") -> tuple:
     """
-    Filters files based if they already exist in the orafin-
+    Filters files based if they already exist in the orafin-data directory
     """
     reports = [row.strip() for row in ls_output.split(",") if row.endswith(".csv")]
     existing_reports, new_reports = [], []
@@ -116,7 +116,7 @@ def find_reports() -> BashOperator:
         + ap_server_options
         + [
             "of_aplib@extxfer.stanford.edu "
-            "ls -m /home/of_aplib/OF1_PRD/outbound/data/*.csv"
+            "ls -m /home/of_aplib/OF1_PRD/outbound/data/*.csv | tr '\n' ' '"
         ]
     )
     return BashOperator(

--- a/libsys_airflow/plugins/vendor/marc.py
+++ b/libsys_airflow/plugins/vendor/marc.py
@@ -359,7 +359,7 @@ def _marc8_to_unicode(record: pymarc.Record) -> pymarc.Record:
         modified_leader = record.leader[0:9] + " " + record.leader[10:]
         record.leader = modified_leader
         raw_marc = record.as_marc()
-        new_record = pymarc.Record(data=raw_marc, to_unicode=True)
+        new_record = pymarc.Record(data=raw_marc, to_unicode=True)  # type: ignore
         # pymarc logs encoding errors to std error
         if "Unable to parse character" not in temp_stderr.getvalue():
             try:

--- a/tests/orafin/test_ap_reports.py
+++ b/tests/orafin/test_ap_reports.py
@@ -199,7 +199,7 @@ def test_find_reports():
     assert bash_operator.bash_command.startswith("ssh")
     assert ap_server_options[1] in bash_operator.bash_command
     assert bash_operator.bash_command.endswith(
-        "ls -m /home/of_aplib/OF1_PRD/outbound/data/*.csv"
+        "ls -m /home/of_aplib/OF1_PRD/outbound/data/*.csv | tr '\n' ' '"
     )
 
 


### PR DESCRIPTION
In the ap_report DAG, only the last line from bash output to stdout was being save to the XCOM, i.e. just running 
`ls -m /home/of_aplib/OF1_PRD/outbound/data/*.csv`

resulted in 
```
/home/of_aplib/OF1_PRD/outbound/data/xxdl_ap_payment_12202023153000.csv,
/home/of_aplib/OF1_PRD/outbound/data/xxdl_ap_payment_12222023153001.csv,
/home/of_aplib/OF1_PRD/outbound/data/xxdl_ap_payment_12252023153000.csv
```
and only the last line `/home/of_aplib/OF1_PRD/outbound/data/xxdl_ap_payment_12252023153000.csv` was being pushed to the XCOM. This PR replaces the newline character with a space so the entire result of the `ls` command to stdout is saved to the XCOM.

```
/home/of_aplib/OF1_PRD/outbound/data/xxdl_ap_payment_12202023153000.csv, /home/of_aplib/OF1_PRD/outbound/data/xxdl_ap_payment_12222023153001.csv, /home/of_aplib/OF1_PRD/outbound/data/xxdl_ap_payment_12252023153000.csv
```

Which is then parsed correctly in the downstream task.
 