### PR TITLE
Removes noop template_searchpath from gobi dag

### DIFF
--- a/libsys_airflow/dags/data_exports/gobi_selections.py
+++ b/libsys_airflow/dags/data_exports/gobi_selections.py
@@ -26,7 +26,6 @@ with DAG(
     default_args=default_args,
     schedule=timedelta(days=int(Variable.get("schedule_gobi_days", 7))),
     start_date=datetime(2024, 2, 26),
-    template_searchpath="/opt/airflow/libsys_airflow/plugins/data-export/sql",
     catchup=False,
     tags=["data export"],
 ) as dag:


### PR DESCRIPTION
This arg seems to only work if the sql operator is called as a dag task and not as a function, and it won't work the way we are checking all of the sql files as enumerated.