### PR TITLE
Connects marc retrieval and processing to selection dags

### DIFF
--- a/libsys_airflow/dags/data_exports/gobi_selections.py
+++ b/libsys_airflow/dags/data_exports/gobi_selections.py
@@ -12,6 +12,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
     save_ids_to_fs,
 )
 
+from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+
 default_args = {
     "owner": "libsys",
     "depends_on_past": False,
@@ -30,9 +32,6 @@ with DAG(
     tags=["data export"],
 ) as dag:
     # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def folio_marc_records_for_id():
-        "Replace this with method from marc module"
-
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
@@ -52,8 +51,8 @@ with DAG(
 
     fetch_marc_records = PythonOperator(
         task_id="fetch_marc_records_from_folio",
-        python_callable=folio_marc_records_for_id,
-        op_kwargs={},
+        python_callable=marc_for_instances,
+        op_kwargs={"vendor": "gobi"},
     )
 
     transform_marc_record = PythonOperator(

--- a/libsys_airflow/dags/data_exports/google_selections.py
+++ b/libsys_airflow/dags/data_exports/google_selections.py
@@ -11,6 +11,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
     save_ids_to_fs,
 )
 
+from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+
 default_args = {
     "owner": "libsys",
     "depends_on_past": False,
@@ -29,9 +31,6 @@ with DAG(
     tags=["data export"],
 ) as dag:
     # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def folio_marc_records_for_id():
-        "Replace this with method from marc module"
-
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
@@ -51,8 +50,8 @@ with DAG(
 
     fetch_marc_records = PythonOperator(
         task_id="fetch_marc_records_from_folio",
-        python_callable=folio_marc_records_for_id,
-        op_kwargs={},
+        python_callable=marc_for_instances,
+        op_kwargs={"vendor": "google"},
     )
 
     transform_marc_record = PythonOperator(

--- a/libsys_airflow/dags/data_exports/hathi_selections.py
+++ b/libsys_airflow/dags/data_exports/hathi_selections.py
@@ -11,6 +11,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
     save_ids_to_fs,
 )
 
+from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+
 default_args = {
     "owner": "libsys",
     "depends_on_past": False,
@@ -29,9 +31,6 @@ with DAG(
     tags=["data export"],
 ) as dag:
     # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def folio_marc_records_for_id():
-        "Replace this with method from marc module"
-
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
@@ -51,8 +50,8 @@ with DAG(
 
     fetch_marc_records = PythonOperator(
         task_id="fetch_marc_records_from_folio",
-        python_callable=folio_marc_records_for_id,
-        op_kwargs={},
+        python_callable=marc_for_instances,
+        op_kwargs={"vendor": "hathi"},
     )
 
     transform_marc_record = PythonOperator(

--- a/libsys_airflow/dags/data_exports/nielsen_selections.py
+++ b/libsys_airflow/dags/data_exports/nielsen_selections.py
@@ -11,6 +11,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
     save_ids_to_fs,
 )
 
+from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+
 default_args = {
     "owner": "libsys",
     "depends_on_past": False,
@@ -29,9 +31,6 @@ with DAG(
     tags=["data export"],
 ) as dag:
     # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def folio_marc_records_for_id():
-        "Replace this with method from marc module"
-
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
@@ -51,8 +50,8 @@ with DAG(
 
     fetch_marc_records = PythonOperator(
         task_id="fetch_marc_records_from_folio",
-        python_callable=folio_marc_records_for_id,
-        op_kwargs={},
+        python_callable=marc_for_instances,
+        op_kwargs={"vendor": "nielsen"},
     )
 
     transform_marc_record = PythonOperator(

--- a/libsys_airflow/dags/data_exports/oclc_selections.py
+++ b/libsys_airflow/dags/data_exports/oclc_selections.py
@@ -11,6 +11,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
     save_ids_to_fs,
 )
 
+from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+
 default_args = {
     "owner": "libsys",
     "depends_on_past": False,
@@ -29,9 +31,6 @@ with DAG(
     tags=["data export"],
 ) as dag:
     # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def folio_marc_records_for_id():
-        "Replace this with method from marc module"
-
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
@@ -51,8 +50,8 @@ with DAG(
 
     fetch_marc_records = PythonOperator(
         task_id="fetch_marc_records_from_folio",
-        python_callable=folio_marc_records_for_id,
-        op_kwargs={},
+        python_callable=marc_for_instances,
+        op_kwargs={"vendor": "oclc"},
     )
 
     transform_marc_record = PythonOperator(

--- a/libsys_airflow/dags/data_exports/pod_selections.py
+++ b/libsys_airflow/dags/data_exports/pod_selections.py
@@ -11,6 +11,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
     save_ids_to_fs,
 )
 
+from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+
 default_args = {
     "owner": "libsys",
     "depends_on_past": False,
@@ -29,9 +31,6 @@ with DAG(
     tags=["data export"],
 ) as dag:
     # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def folio_marc_records_for_id():
-        "Replace this with method from marc module"
-
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
@@ -51,8 +50,10 @@ with DAG(
 
     fetch_marc_records = PythonOperator(
         task_id="fetch_marc_records_from_folio",
-        python_callable=folio_marc_records_for_id,
-        op_kwargs={},
+        python_callable=marc_for_instances,
+        op_kwargs={
+            "vendor": "pod",
+        },
     )
 
     transform_marc_record = PythonOperator(

--- a/libsys_airflow/dags/data_exports/sharevde_selections.py
+++ b/libsys_airflow/dags/data_exports/sharevde_selections.py
@@ -11,6 +11,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
     save_ids_to_fs,
 )
 
+from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+
 default_args = {
     "owner": "libsys",
     "depends_on_past": False,
@@ -29,9 +31,6 @@ with DAG(
     tags=["data export"],
 ) as dag:
     # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def folio_marc_records_for_id():
-        "Replace this with method from marc module"
-
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
@@ -51,8 +50,8 @@ with DAG(
 
     fetch_marc_records = PythonOperator(
         task_id="fetch_marc_records_from_folio",
-        python_callable=folio_marc_records_for_id,
-        op_kwargs={},
+        python_callable=marc_for_instances,
+        op_kwargs={"vendor": "sharevde"},
     )
 
     transform_marc_record = PythonOperator(

--- a/libsys_airflow/dags/data_exports/west_selections.py
+++ b/libsys_airflow/dags/data_exports/west_selections.py
@@ -11,6 +11,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
     save_ids_to_fs,
 )
 
+from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+
 default_args = {
     "owner": "libsys",
     "depends_on_past": False,
@@ -29,9 +31,6 @@ with DAG(
     tags=["data export"],
 ) as dag:
     # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def folio_marc_records_for_id():
-        "Replace this with method from marc module"
-
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
@@ -51,8 +50,8 @@ with DAG(
 
     fetch_marc_records = PythonOperator(
         task_id="fetch_marc_records_from_folio",
-        python_callable=folio_marc_records_for_id,
-        op_kwargs={},
+        python_callable=marc_for_instances,
+        op_kwargs={"vendor": "west"},
     )
 
     transform_marc_record = PythonOperator(

--- a/libsys_airflow/plugins/data_exports/instance_ids.py
+++ b/libsys_airflow/plugins/data_exports/instance_ids.py
@@ -1,12 +1,9 @@
 import csv
-import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 
 from airflow.operators.python import get_current_context
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
-
-logger = logging.getLogger(__name__)
 
 
 def fetch_record_ids(**kwargs):
@@ -56,9 +53,8 @@ def save_ids_to_fs(**kwargs):
 
     with open(data_path, 'w') as f:
         writer = csv.writer(f, lineterminator='\n')
-        for ids in data:
-            if ids:
-                for tuple in ids:
-                    writer.writerow(tuple)
+        for id in data:
+            if id:
+                writer.writerow(id)
 
     return str(data_path)

--- a/tests/data_exports/test_save_instance_ids.py
+++ b/tests/data_exports/test_save_instance_ids.py
@@ -20,8 +20,8 @@ def mock_xcom_pull(**kwargs):
     return [
         [],
         [
-            ('4e66ce0d-4a1d-41dc-8b35-0914df20c7fb',),
-            ('fe2e581f-9767-442a-ae3c-a421ac655fe2',),
+            ['4e66ce0d-4a1d-41dc-8b35-0914df20c7fb'],
+            ['fe2e581f-9767-442a-ae3c-a421ac655fe2'],
         ],
         [],
     ]
@@ -36,6 +36,6 @@ def test_save_ids_to_fs(tmp_path, mock_task_instance):
     assert file.exists()
 
     with file.open('r') as fo:
-        id_list = [row for row in csv.reader(fo)]
+        id_list = list(row for row in csv.reader(fo))
 
-    assert id_list[1][0] == 'fe2e581f-9767-442a-ae3c-a421ac655fe2'
+    assert id_list[0][1] == "['fe2e581f-9767-442a-ae3c-a421ac655fe2']"


### PR DESCRIPTION
Attempting to split out code in plugin so most functions perform a single task and easier to perform the operation on every csv file in the instance id paths. It may be easier to look at the fully changed files for [exports.py](https://github.com/sul-dlss/libsys-airflow/blob/a7626af5352a926057e8faab298861d2e5860a19/libsys_airflow/plugins/data_exports/marc/exports.py) and [test_marc_exports.py](https://github.com/sul-dlss/libsys-airflow/blob/a7626af5352a926057e8faab298861d2e5860a19/tests/data_exports/test_marc_exports.py) rather than looking at the diffs.