### PR TITLE
Corrects xcom_pull calls and handles paid voucher

### DIFF
--- a/libsys_airflow/plugins/orafin/reports.py
+++ b/libsys_airflow/plugins/orafin/reports.py
@@ -167,12 +167,13 @@ def retrieve_voucher(invoice_id: str, folio_client: FolioClient) -> Union[dict, 
 
         case 1:
             voucher = voucher_result["vouchers"][0]
+            # Invoice BL endpoint sets voucher status but still needs
+            # additional data set from AP report
             if voucher["status"] == "Paid":
                 msg = f"Voucher {voucher['id']} already Paid"
                 logger.error(msg)
                 task_instance.xcom_push(key="paid", value=msg)
-            else:
-                return voucher
+            return voucher
 
         case _:
             msg = f"Multiple vouchers {','.join([voucher['id'] for voucher in voucher_result['vouchers']])} found for invoice {invoice_id}"

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -194,7 +194,9 @@ def retrieve_voucher_task(ti=None):
     """
     Retrieves voucher based on invoice id
     """
-    invoice_id: str = ti.xcom_pull(task_ids="update_folio.update_invoices_task")
+    invoice_id: str = ti.xcom_pull(
+        task_ids="update-folio.update_invoices_task", map_indexes=ti.map_index
+    )
     folio_client = _folio_client()
     return retrieve_voucher(invoice_id, folio_client)
 
@@ -242,7 +244,9 @@ def update_email_branch(update_result):
 
 @task
 def update_vouchers_task(ti=None):
-    voucher = ti.xcom_pull(task_ids="retrieve_voucher_task")
+    voucher = ti.xcom_pull(
+        task_ids="update-folio.retrieve_voucher_task", map_indexes=ti.map_index
+    )
     if voucher:
         folio_client = _folio_client()
         logger.info(f"Updating voucher {voucher['id']}")


### PR DESCRIPTION
Fixes #885 

Problem was being caused by the xcom_pull not having the correct task_ids and needed to add the map_indexes parameter. Also noticed that invoice PUT statement in an upstream task that uses the `/invoice/invoices/{uuid}` endpoint also sets the voucher status to Paid so we need to return the voucher instead of skipping for the `update_voucher_task` downstream.