### PR TITLE
Refactor plugins, connects selection dags to transformers

### DIFF
--- a/libsys_airflow/dags/data_exports/gobi_selections.py
+++ b/libsys_airflow/dags/data_exports/gobi_selections.py
@@ -13,6 +13,10 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 )
 
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+from libsys_airflow.plugins.data_exports.marc.transforms import (
+    add_holdings_items_to_marc_files,
+    remove_marc_fields
+    )
 
 default_args = {
     "owner": "libsys",
@@ -31,11 +35,6 @@ with DAG(
     catchup=False,
     tags=["data export"],
 ) as dag:
-    # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def sample_marc_transform_1():
-        "Replace this with method from marc processing module"
-
-
     fetch_folio_record_ids = PythonOperator(
         task_id="fetch_record_ids_from_folio",
         python_callable=fetch_record_ids,
@@ -55,8 +54,18 @@ with DAG(
 
     transform_marc_record = PythonOperator(
         task_id="transform_folio_marc_record",
-        python_callable=sample_marc_transform_1,
-        op_kwargs={},
+        python_callable=add_holdings_items_to_marc_files,
+        op_kwargs={
+            "marc_file_list": "{{ ti.xcom_pull('fetch_marc_records_from_folio') }}"
+        },
+    )
+
+    transform_marc_fields = PythonOperator(
+        task_id="transform_folio_remove_marc_fields",
+        python_callable=remove_marc_fields,
+        op_kwargs={
+            "marc_file_list": "{{ ti.xcom_pull('fetch_marc_records_from_folio') }}"
+        },
     )
 
     send_to_vendor = TriggerDagRunOperator(
@@ -71,5 +80,6 @@ with DAG(
 
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
-fetch_marc_records >> transform_marc_record >> send_to_vendor
-send_to_vendor >> finish_processing_marc
+fetch_marc_records >> transform_marc_record >> transform_marc_fields
+transform_marc_fields >> send_to_vendor >> finish_processing_marc
+

--- a/libsys_airflow/dags/data_exports/gobi_selections.py
+++ b/libsys_airflow/dags/data_exports/gobi_selections.py
@@ -35,8 +35,6 @@ with DAG(
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
-    def save_transformed_marc():
-        "Replace this with method from marc writing module"
 
     fetch_folio_record_ids = PythonOperator(
         task_id="fetch_record_ids_from_folio",
@@ -61,23 +59,17 @@ with DAG(
         op_kwargs={},
     )
 
-    write_marc_to_fs = PythonOperator(
-        task_id="write_marc_record_to_file",
-        python_callable=save_transformed_marc,
-        op_kwargs={},
-    )
-
     send_to_vendor = TriggerDagRunOperator(
         task_id="send_ybp_records",
         trigger_dag_id="send_ybp_records",
-        conf={"iteration_id": "{{ dag_run.run_id }}"},
+        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
     )
 
-    finish_fetching_marc = EmptyOperator(
+    finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
 
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
-fetch_marc_records >> transform_marc_record >> write_marc_to_fs
-write_marc_to_fs >> finish_fetching_marc >> send_to_vendor
+fetch_marc_records >> transform_marc_record >> send_to_vendor
+send_to_vendor >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/gobi_selections.py
+++ b/libsys_airflow/dags/data_exports/gobi_selections.py
@@ -15,8 +15,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
 from libsys_airflow.plugins.data_exports.marc.transforms import (
     add_holdings_items_to_marc_files,
-    remove_marc_fields
-    )
+    remove_marc_fields,
+)
 
 default_args = {
     "owner": "libsys",
@@ -82,4 +82,3 @@ with DAG(
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
 fetch_marc_records >> transform_marc_record >> transform_marc_fields
 transform_marc_fields >> send_to_vendor >> finish_processing_marc
-

--- a/libsys_airflow/dags/data_exports/google_selections.py
+++ b/libsys_airflow/dags/data_exports/google_selections.py
@@ -14,8 +14,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
 from libsys_airflow.plugins.data_exports.marc.transforms import (
     add_holdings_items_to_marc_files,
-    remove_marc_fields
-    )
+    remove_marc_fields,
+)
 
 default_args = {
     "owner": "libsys",

--- a/libsys_airflow/dags/data_exports/hathi_selections.py
+++ b/libsys_airflow/dags/data_exports/hathi_selections.py
@@ -14,8 +14,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
 from libsys_airflow.plugins.data_exports.marc.transforms import (
     add_holdings_items_to_marc_files,
-    remove_marc_fields
-    )
+    remove_marc_fields,
+)
 
 default_args = {
     "owner": "libsys",

--- a/libsys_airflow/dags/data_exports/hathi_selections.py
+++ b/libsys_airflow/dags/data_exports/hathi_selections.py
@@ -34,8 +34,6 @@ with DAG(
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
-    def save_transformed_marc():
-        "Replace this with method from marc writing module"
 
     fetch_folio_record_ids = PythonOperator(
         task_id="fetch_record_ids_from_folio",
@@ -60,23 +58,17 @@ with DAG(
         op_kwargs={},
     )
 
-    write_marc_to_fs = PythonOperator(
-        task_id="write_marc_record_to_file",
-        python_callable=save_transformed_marc,
-        op_kwargs={},
-    )
-
     send_to_vendor = TriggerDagRunOperator(
         task_id="send_hathi_records",
         trigger_dag_id="send_hathi_records",
-        conf={"iteration_id": "{{ dag_run.run_id }}"},
+        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
     )
 
-    finish_fetching_marc = EmptyOperator(
+    finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
 
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
-fetch_marc_records >> transform_marc_record >> write_marc_to_fs
-write_marc_to_fs >> finish_fetching_marc >> send_to_vendor
+fetch_marc_records >> transform_marc_record >> send_to_vendor
+send_to_vendor >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/nielsen_selections.py
+++ b/libsys_airflow/dags/data_exports/nielsen_selections.py
@@ -14,8 +14,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
 from libsys_airflow.plugins.data_exports.marc.transforms import (
     add_holdings_items_to_marc_files,
-    remove_marc_fields
-    )
+    remove_marc_fields,
+)
 
 default_args = {
     "owner": "libsys",

--- a/libsys_airflow/dags/data_exports/nielsen_selections.py
+++ b/libsys_airflow/dags/data_exports/nielsen_selections.py
@@ -34,8 +34,6 @@ with DAG(
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
-    def save_transformed_marc():
-        "Replace this with method from marc writing module"
 
     fetch_folio_record_ids = PythonOperator(
         task_id="fetch_record_ids_from_folio",
@@ -60,23 +58,17 @@ with DAG(
         op_kwargs={},
     )
 
-    write_marc_to_fs = PythonOperator(
-        task_id="write_marc_record_to_file",
-        python_callable=save_transformed_marc,
-        op_kwargs={},
-    )
-
     send_to_vendor = TriggerDagRunOperator(
         task_id="send_nielson_records",
         trigger_dag_id="send_nielson_records",
-        conf={"iteration_id": "{{ dag_run.run_id }}"},
+        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
     )
 
-    finish_fetching_marc = EmptyOperator(
+    finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
 
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
-fetch_marc_records >> transform_marc_record >> write_marc_to_fs
-write_marc_to_fs >> finish_fetching_marc >> send_to_vendor
+fetch_marc_records >> transform_marc_record >> send_to_vendor
+send_to_vendor >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/oclc_selections.py
+++ b/libsys_airflow/dags/data_exports/oclc_selections.py
@@ -14,8 +14,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
 from libsys_airflow.plugins.data_exports.marc.transforms import (
     add_holdings_items_to_marc_files,
-    remove_marc_fields
-    )
+    remove_marc_fields,
+)
 
 default_args = {
     "owner": "libsys",

--- a/libsys_airflow/dags/data_exports/oclc_selections.py
+++ b/libsys_airflow/dags/data_exports/oclc_selections.py
@@ -34,8 +34,6 @@ with DAG(
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
-    def save_transformed_marc():
-        "Replace this with method from marc writing module"
 
     fetch_folio_record_ids = PythonOperator(
         task_id="fetch_record_ids_from_folio",
@@ -60,23 +58,17 @@ with DAG(
         op_kwargs={},
     )
 
-    write_marc_to_fs = PythonOperator(
-        task_id="write_marc_record_to_file",
-        python_callable=save_transformed_marc,
-        op_kwargs={},
-    )
-
     send_to_vendor = TriggerDagRunOperator(
         task_id="send_oclc_records",
         trigger_dag_id="send_oclc_records",
-        conf={"iteration_id": "{{ dag_run.run_id }}"},
+        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
     )
 
-    finish_fetching_marc = EmptyOperator(
+    finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
 
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
-fetch_marc_records >> transform_marc_record >> write_marc_to_fs
-write_marc_to_fs >> finish_fetching_marc >> send_to_vendor
+fetch_marc_records >> transform_marc_record >> send_to_vendor
+send_to_vendor >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/pod_selections.py
+++ b/libsys_airflow/dags/data_exports/pod_selections.py
@@ -14,8 +14,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
 from libsys_airflow.plugins.data_exports.marc.transforms import (
     add_holdings_items_to_marc_files,
-    remove_marc_fields
-    )
+    remove_marc_fields,
+)
 
 default_args = {
     "owner": "libsys",

--- a/libsys_airflow/dags/data_exports/pod_selections.py
+++ b/libsys_airflow/dags/data_exports/pod_selections.py
@@ -12,6 +12,10 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 )
 
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+from libsys_airflow.plugins.data_exports.marc.transforms import (
+    add_holdings_items_to_marc_files,
+    remove_marc_fields
+    )
 
 default_args = {
     "owner": "libsys",
@@ -30,13 +34,6 @@ with DAG(
     catchup=False,
     tags=["data export"],
 ) as dag:
-    # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def sample_marc_transform_1():
-        "Replace this with method from marc processing module"
-
-    def save_transformed_marc():
-        "Replace this with method from marc writing module"
-
     fetch_folio_record_ids = PythonOperator(
         task_id="fetch_record_ids_from_folio",
         python_callable=fetch_record_ids,
@@ -58,27 +55,31 @@ with DAG(
 
     transform_marc_record = PythonOperator(
         task_id="transform_folio_marc_record",
-        python_callable=sample_marc_transform_1,
-        op_kwargs={},
+        python_callable=add_holdings_items_to_marc_files,
+        op_kwargs={
+            "marc_file_list": "{{ ti.xcom_pull('fetch_marc_records_from_folio') }}"
+        },
     )
 
-    write_marc_to_fs = PythonOperator(
-        task_id="write_marc_record_to_file",
-        python_callable=save_transformed_marc,
-        op_kwargs={},
+    transform_marc_fields = PythonOperator(
+        task_id="transform_folio_remove_marc_fields",
+        python_callable=remove_marc_fields,
+        op_kwargs={
+            "marc_file_list": "{{ ti.xcom_pull('fetch_marc_records_from_folio') }}"
+        },
     )
 
     send_to_vendor = TriggerDagRunOperator(
         task_id="send_pod_records",
         trigger_dag_id="send_pod_records",
-        conf={"iteration_id": "{{ dag_run.run_id }}"},
+        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
     )
 
-    finish_fetching_marc = EmptyOperator(
+    finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
 
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
-fetch_marc_records >> transform_marc_record >> write_marc_to_fs
-write_marc_to_fs >> finish_fetching_marc >> send_to_vendor
+fetch_marc_records >> transform_marc_record >> transform_marc_fields
+transform_marc_fields >> send_to_vendor >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/sharevde_selections.py
+++ b/libsys_airflow/dags/data_exports/sharevde_selections.py
@@ -14,8 +14,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
 from libsys_airflow.plugins.data_exports.marc.transforms import (
     add_holdings_items_to_marc_files,
-    remove_marc_fields
-    )
+    remove_marc_fields,
+)
 
 default_args = {
     "owner": "libsys",

--- a/libsys_airflow/dags/data_exports/sharevde_selections.py
+++ b/libsys_airflow/dags/data_exports/sharevde_selections.py
@@ -12,6 +12,7 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 )
 
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
+from libsys_airflow.plugins.data_exports.marc.transforms import add_holdings_items_to_marc_files
 
 default_args = {
     "owner": "libsys",
@@ -30,13 +31,6 @@ with DAG(
     catchup=False,
     tags=["data export"],
 ) as dag:
-    # Sample methods to be removed and replaced by real methods, along with imports when they are coded.
-    def sample_marc_transform_1():
-        "Replace this with method from marc processing module"
-
-    def save_transformed_marc():
-        "Replace this with method from marc writing module"
-
     fetch_folio_record_ids = PythonOperator(
         task_id="fetch_record_ids_from_folio",
         python_callable=fetch_record_ids,
@@ -56,27 +50,23 @@ with DAG(
 
     transform_marc_record = PythonOperator(
         task_id="transform_folio_marc_record",
-        python_callable=sample_marc_transform_1,
-        op_kwargs={},
-    )
-
-    write_marc_to_fs = PythonOperator(
-        task_id="write_marc_record_to_file",
-        python_callable=save_transformed_marc,
-        op_kwargs={},
+        python_callable=add_holdings_items_to_marc_files,
+        op_kwargs={
+            "marc_file_list": "{{ ti.xcom_pull('fetch_marc_records_from_folio') }}"
+        },
     )
 
     send_to_vendor = TriggerDagRunOperator(
         task_id="send_sharevde_records",
         trigger_dag_id="send_sharevde_records",
-        conf={"iteration_id": "{{ dag_run.run_id }}"},
+        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
     )
 
-    finish_fetching_marc = EmptyOperator(
+    finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
 
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
-fetch_marc_records >> transform_marc_record >> write_marc_to_fs
-write_marc_to_fs >> finish_fetching_marc >> send_to_vendor
+fetch_marc_records >> transform_marc_record >> send_to_vendor
+send_to_vendor >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/west_selections.py
+++ b/libsys_airflow/dags/data_exports/west_selections.py
@@ -14,8 +14,8 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
 from libsys_airflow.plugins.data_exports.marc.transforms import (
     add_holdings_items_to_marc_files,
-    remove_marc_fields
-    )
+    remove_marc_fields,
+)
 
 default_args = {
     "owner": "libsys",

--- a/libsys_airflow/dags/data_exports/west_selections.py
+++ b/libsys_airflow/dags/data_exports/west_selections.py
@@ -34,8 +34,6 @@ with DAG(
     def sample_marc_transform_1():
         "Replace this with method from marc processing module"
 
-    def save_transformed_marc():
-        "Replace this with method from marc writing module"
 
     fetch_folio_record_ids = PythonOperator(
         task_id="fetch_record_ids_from_folio",
@@ -60,23 +58,17 @@ with DAG(
         op_kwargs={},
     )
 
-    write_marc_to_fs = PythonOperator(
-        task_id="write_marc_record_to_file",
-        python_callable=save_transformed_marc,
-        op_kwargs={},
-    )
-
     send_to_vendor = TriggerDagRunOperator(
         task_id="send_west_records",
         trigger_dag_id="send_west_records",
-        conf={"iteration_id": "{{ dag_run.run_id }}"},
+        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
     )
 
-    finish_fetching_marc = EmptyOperator(
+    finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
 
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
-fetch_marc_records >> transform_marc_record >> write_marc_to_fs
-write_marc_to_fs >> finish_fetching_marc >> send_to_vendor
+fetch_marc_records >> transform_marc_record >> send_to_vendor
+send_to_vendor >> finish_processing_marc

--- a/libsys_airflow/plugins/data_exports/marc/exporter.py
+++ b/libsys_airflow/plugins/data_exports/marc/exporter.py
@@ -10,127 +10,121 @@ logger = logging.getLogger(__name__)
 
 
 class Exporter(object):
-  def __init__(self):
-    self.folio_client = folio_client()
+    def __init__(self):
+        self.folio_client = folio_client()
 
+    def check_001(self, field001s: list) -> bool:
+        reject = False
+        for field in field001s:
+            if field.value() == "gls":
+                reject = True
+        return reject
 
-  def check_001(self, field001s: list) -> bool:
-    reject = False
-    for field in field001s:
-        if field.value() == "gls":
-            reject = True
-    return reject
+    def check_008(self, fields008: list) -> bool:
+        reject = False
+        for field in fields008:
+            lang_code = field.value()[35:37]
+            if lang_code not in ["eng", "fre"]:
+                reject = True
+        return reject
 
+    def check_590(self, field590s: list) -> bool:
+        reject = False
+        for field in field590s:
+            if "MARCit brief record" in field.get_subfields("a"):
+                reject = True
+        return reject
 
-  def check_008(self, fields008: list) -> bool:
-      reject = False
-      for field in fields008:
-          lang_code = field.value()[35:37]
-          if lang_code not in ["eng", "fre"]:
-              reject = True
-      return reject
+    def check_915(self, fields915: list) -> bool:
+        reject = False
+        for field in fields915:
+            if "NO EXPORT" in field.get_subfields(
+                "a"
+            ) and "FOR SU ONLY" in field.get_subfields("b"):
+                reject = True
+        return reject
 
+    def exclude_marc_by_vendor(self, marc_record: pymarc.Record, vendor: str):
+        """
+        Filters MARC record by Vendor
+        """
+        exclude = False
+        match vendor:
+            case "gobi":
+                exclude = any(
+                    [
+                        self.check_001(marc_record.get_fields("001")),
+                        self.check_008(marc_record.get_fields("008")),
+                    ]
+                )
 
-  def check_590(self, field590s: list) -> bool:
-      reject = False
-      for field in field590s:
-          if "MARCit brief record" in field.get_subfields("a"):
-              reject = True
-      return reject
+            case "oclc" | "pod" | "sharevde":
+                exclude = any(
+                    [
+                        self.check_590(marc_record.get_fields("590")),
+                        self.check_915(marc_record.get_fields("915")),
+                    ]
+                )
 
+        return exclude
 
-  def check_915(self, fields915: list) -> bool:
-      reject = False
-      for field in fields915:
-          if "NO EXPORT" in field.get_subfields(
-              "a"
-          ) and "FOR SU ONLY" in field.get_subfields("b"):
-              reject = True
-      return reject
+    def retrieve_marc_for_instances(self, instance_file: pathlib.Path) -> None:
+        """
+        Writes and returns converted MARC from SRS
+        """
+        if not instance_file.exists():
+            raise ValueError(
+                "Instance file does not exist for retrieve_marc_for_instances"
+            )
 
+        vendor_name = instance_file.parent.parent.name
 
-  def exclude_marc_by_vendor(self, marc_record: pymarc.Record, vendor: str):
-      """
-      Filters MARC record by Vendor
-      """
-      exclude = False
-      match vendor:
-          case "gobi":
-              exclude = any(
-                  [
-                      self.check_001(marc_record.get_fields("001")),
-                      self.check_008(marc_record.get_fields("008")),
-                  ]
-              )
+        with instance_file.open() as fo:
+            instance_reader = csv.reader(fo)
+            for row in instance_reader:
+                uuid = row[0]
+                try:
+                    marc_record = self.marc21(uuid)
+                except Exception as e:
+                    logger.warning(e)
+                    continue
 
-          case "oclc" | "pod" | "sharevde":
-              exclude = any(
-                  [
-                      self.check_590(marc_record.get_fields("590")),
-                      self.check_915(marc_record.get_fields("915")),
-                  ]
-              )
+                if self.exclude_marc_by_vendor(marc_record, vendor_name):
+                    logger.info(f"Excluding {vendor_name}")
+                    continue
 
-      return exclude
+                self.write_marc(instance_file, instance_file.parent.parent, marc_record)
 
+    def marc21(self, instance_uuid: str) -> pymarc.Record:
+        json_handler = pymarc.JSONHandler()
 
-  def retrieve_marc_for_instances(self, instance_file: pathlib.Path) -> None:
-    """
-    Writes and returns converted MARC from SRS
-    """
-    if not instance_file.exists():
-        raise ValueError("Instance file does not exist for retrieve_marc_for_instances")
+        json_handler.elements(self.marc_json_from_srs(instance_uuid))
 
-    vendor_name = instance_file.parent.parent.name
+        marc21 = json_handler.records[0]
 
-    with instance_file.open() as fo:
-        instance_reader = csv.reader(fo)
-        for row in instance_reader:
-            uuid = row[0]
-            try:
-                marc_record = self.marc21(uuid)
-            except Exception as e:
-                logger.warning(e)
-                continue
+        return marc21
 
-            if self.exclude_marc_by_vendor(marc_record, vendor_name):
-                logger.info(f"Excluding {vendor_name}")
-                continue
+    def marc_json_from_srs(self, instance_uuid: str) -> str:
+        srs_result = self.folio_client.folio_get(
+            f"/source-storage/records/{instance_uuid}/formatted?idType=INSTANCE"
+        )
 
-            self.write_marc(instance_file, instance_file.parent.parent, marc_record)
+        return srs_result["parsedRecord"]["content"]
 
-
-  def marc21(self, instance_uuid: str) -> pymarc.Record:
-    json_handler = pymarc.JSONHandler()
-
-    json_handler.elements(self.marc_json_from_srs(instance_uuid))
-
-    marc21 = json_handler.records[0]
-
-    return marc21
-
-
-  def marc_json_from_srs(self, instance_uuid: str) -> str:
-    srs_result = self.folio_client.folio_get(
-        f"/source-storage/records/{instance_uuid}/formatted?idType=INSTANCE"
-      )
-
-    return srs_result["parsedRecord"]["content"]
-
-
-  def write_marc(self,
-                 instance_file: pathlib.Path,
-                 marc_directory: pathlib.Path,
-                 marc_record: pymarc.Record
-                 ):
-      """
-      Writes marc record to file system
-      """
-      marc_file_name = instance_file.stem
-      directory = marc_directory / "marc-files"
-      directory.mkdir(parents=True, exist_ok=True)
-      marc_file = directory / f"{marc_file_name}.mrc"
-      marc_writer = pymarc.MARCWriter(marc_file.open("ab"))
-      marc_writer.write(marc_record)
-      marc_writer.close()
-      return str(marc_file.absolute())
+    def write_marc(
+        self,
+        instance_file: pathlib.Path,
+        marc_directory: pathlib.Path,
+        marc_record: pymarc.Record,
+    ):
+        """
+        Writes marc record to file system
+        """
+        marc_file_name = instance_file.stem
+        directory = marc_directory / "marc-files"
+        directory.mkdir(parents=True, exist_ok=True)
+        marc_file = directory / f"{marc_file_name}.mrc"
+        marc_writer = pymarc.MARCWriter(marc_file.open("ab"))
+        marc_writer.write(marc_record)
+        marc_writer.close()
+        return str(marc_file.absolute())

--- a/libsys_airflow/plugins/data_exports/marc/exporter.py
+++ b/libsys_airflow/plugins/data_exports/marc/exporter.py
@@ -1,0 +1,136 @@
+import csv
+import logging
+import pathlib
+import pymarc
+
+from libsys_airflow.plugins.folio_client import folio_client
+
+
+logger = logging.getLogger(__name__)
+
+
+class Exporter(object):
+  def __init__(self):
+    self.folio_client = folio_client()
+
+
+  def check_001(self, field001s: list) -> bool:
+    reject = False
+    for field in field001s:
+        if field.value() == "gls":
+            reject = True
+    return reject
+
+
+  def check_008(self, fields008: list) -> bool:
+      reject = False
+      for field in fields008:
+          lang_code = field.value()[35:37]
+          if lang_code not in ["eng", "fre"]:
+              reject = True
+      return reject
+
+
+  def check_590(self, field590s: list) -> bool:
+      reject = False
+      for field in field590s:
+          if "MARCit brief record" in field.get_subfields("a"):
+              reject = True
+      return reject
+
+
+  def check_915(self, fields915: list) -> bool:
+      reject = False
+      for field in fields915:
+          if "NO EXPORT" in field.get_subfields(
+              "a"
+          ) and "FOR SU ONLY" in field.get_subfields("b"):
+              reject = True
+      return reject
+
+
+  def exclude_marc_by_vendor(self, marc_record: pymarc.Record, vendor: str):
+      """
+      Filters MARC record by Vendor
+      """
+      exclude = False
+      match vendor:
+          case "gobi":
+              exclude = any(
+                  [
+                      self.check_001(marc_record.get_fields("001")),
+                      self.check_008(marc_record.get_fields("008")),
+                  ]
+              )
+
+          case "oclc" | "pod" | "sharevde":
+              exclude = any(
+                  [
+                      self.check_590(marc_record.get_fields("590")),
+                      self.check_915(marc_record.get_fields("915")),
+                  ]
+              )
+
+      return exclude
+
+
+  def retrieve_marc_for_instances(self, instance_file: pathlib.Path) -> None:
+    """
+    Writes and returns converted MARC from SRS
+    """
+    if not instance_file.exists():
+        raise ValueError("Instance file does not exist for retrieve_marc_for_instances")
+
+    vendor_name = instance_file.parent.parent.name
+
+    with instance_file.open() as fo:
+        instance_reader = csv.reader(fo)
+        for row in instance_reader:
+            uuid = row[0]
+            try:
+                marc_record = self.marc21(uuid)
+            except Exception as e:
+                logger.warning(e)
+                continue
+
+            if self.exclude_marc_by_vendor(marc_record, vendor_name):
+                logger.info(f"Excluding {vendor_name}")
+                continue
+
+            self.write_marc(instance_file, instance_file.parent.parent, marc_record)
+
+
+  def marc21(self, instance_uuid: str) -> pymarc.Record:
+    json_handler = pymarc.JSONHandler()
+
+    json_handler.elements(self.marc_json_from_srs(instance_uuid))
+
+    marc21 = json_handler.records[0]
+
+    return marc21
+
+
+  def marc_json_from_srs(self, instance_uuid: str) -> str:
+    srs_result = self.folio_client.folio_get(
+        f"/source-storage/records/{instance_uuid}/formatted?idType=INSTANCE"
+      )
+
+    return srs_result["parsedRecord"]["content"]
+
+
+  def write_marc(self,
+                 instance_file: pathlib.Path,
+                 marc_directory: pathlib.Path,
+                 marc_record: pymarc.Record
+                 ):
+      """
+      Writes marc record to file system
+      """
+      marc_file_name = instance_file.stem
+      directory = marc_directory / "marc-files"
+      directory.mkdir(parents=True, exist_ok=True)
+      marc_file = directory / f"{marc_file_name}.mrc"
+      marc_writer = pymarc.MARCWriter(marc_file.open("ab"))
+      marc_writer.write(marc_record)
+      marc_writer.close()
+      return str(marc_file.absolute())

--- a/libsys_airflow/plugins/data_exports/marc/exports.py
+++ b/libsys_airflow/plugins/data_exports/marc/exports.py
@@ -22,8 +22,7 @@ def marc_for_instances(**kwargs) -> list[str]:
     Retrieves the converted marc for each instance id file in vendor directory
     """
     instance_files = instance_files_dir(
-        airflow=kwargs.get("airflow", "/opt/airflow"),
-        vendor=kwargs.get("vendor", "")
+        airflow=kwargs.get("airflow", "/opt/airflow"), vendor=kwargs.get("vendor", "")
     )
 
     exporter = Exporter()

--- a/libsys_airflow/plugins/data_exports/marc/exports.py
+++ b/libsys_airflow/plugins/data_exports/marc/exports.py
@@ -1,108 +1,5 @@
-import csv
-import logging
 import pathlib
-
-import pymarc
-
-from airflow.models import Variable
-from folioclient import FolioClient
-
-logger = logging.getLogger(__name__)
-
-
-def _check_001(field001s: list) -> bool:
-    reject = False
-    for field in field001s:
-        if field.value() == "gls":
-            reject = True
-    return reject
-
-
-def _check_008(fields008: list) -> bool:
-    reject = False
-    for field in fields008:
-        lang_code = field.value()[35:37]
-        if lang_code not in ["eng", "fre"]:
-            reject = True
-    return reject
-
-
-def _check_590(field590s: list) -> bool:
-    reject = False
-    for field in field590s:
-        if "MARCit brief record" in field.get_subfields("a"):
-            reject = True
-    return reject
-
-
-def _check_915(fields915: list) -> bool:
-    reject = False
-    for field in fields915:
-        if "NO EXPORT" in field.get_subfields(
-            "a"
-        ) and "FOR SU ONLY" in field.get_subfields("b"):
-            reject = True
-    return reject
-
-
-def _exclude_marc_by_vendor(marc_record: pymarc.Record, vendor: str):
-    """
-    Filters MARC record by Vendor
-    """
-    exclude = False
-    match vendor:
-        case "gobi":
-            exclude = any(
-                [
-                    _check_001(marc_record.get_fields("001")),
-                    _check_008(marc_record.get_fields("008")),
-                ]
-            )
-
-        case "oclc" | "pod" | "sharevde":
-            exclude = any(
-                [
-                    _check_590(marc_record.get_fields("590")),
-                    _check_915(marc_record.get_fields("915")),
-                ]
-            )
-
-    return exclude
-
-
-def _folio_client(**kwargs):
-    _client = kwargs.get("client")
-
-    if _client is None:
-        _client = FolioClient(
-            Variable.get("OKAPI_URL"),
-            "sul",
-            Variable.get("FOLIO_USER"),
-            Variable.get("FOLIO_PASSWORD"),
-        )
-
-    return _client
-
-
-def _marc21_from_srs(instance_uuid: str, folio_client: FolioClient) -> pymarc.Record:
-    """
-    Retrieve MARC JSON from SRS based instance UUID, converts and returns
-    MARC21 record
-    """
-    srs_result = folio_client.folio_get(
-        #  f"/change-manager/parsedRecords?externalId={instance_uuid}"
-        f"/source-storage/records/{instance_uuid}/formatted?idType=INSTANCE"
-    )
-
-    marc_json_record = srs_result["parsedRecord"]["content"]
-
-    json_handler = pymarc.JSONHandler()
-
-    json_handler.elements(marc_json_record)
-
-    marc21 = json_handler.records[0]
-
-    return marc21
+from libsys_airflow.plugins.data_exports.marc.exporter import Exporter
 
 
 def instance_files_dir(**kwargs) -> list[pathlib.Path]:
@@ -125,62 +22,12 @@ def marc_for_instances(**kwargs) -> list[str]:
     Retrieves the converted marc for each instance id file in vendor directory
     """
     instance_files = instance_files_dir(
-        airflow=kwargs.get("airflow", "/opt/airflow"), vendor=kwargs.get("vendor")
+        airflow=kwargs.get("airflow", "/opt/airflow"),
+        vendor=kwargs.get("vendor", "")
     )
 
+    exporter = Exporter()
     for file_datename in instance_files:
-        retrieve_marc_for_instances(
-            instance_file=file_datename,
-            folio_client=_folio_client(client=kwargs.get("folio_client")),
-        )
+        exporter.retrieve_marc_for_instances(instance_file=file_datename)
 
     return [str(f) for f in instance_files]
-
-
-def retrieve_marc_for_instances(**kwargs) -> None:
-    """
-    Writes and returns converted MARC from SRS
-    """
-
-    instance_file = pathlib.Path(kwargs.get("instance_file", ""))
-    if not instance_file.exists():
-        raise ValueError("Instance file does not exist for retrieve_marc_for_instances")
-
-    vendor_name = instance_file.parent.parent.name
-
-    with instance_file.open() as fo:
-        instance_reader = csv.reader(fo)
-        for row in instance_reader:
-            uuid = row[0]
-            try:
-                marc_record = _marc21_from_srs(
-                    uuid, _folio_client(client=kwargs.get("folio_client"))
-                )
-            except Exception as e:
-                logger.warning(e)
-                continue
-
-            if _exclude_marc_by_vendor(marc_record, vendor_name):
-                logger.info(f"Excluding {vendor_name}")
-                continue
-
-            write_marc(
-                instance_file=instance_file,
-                marc_directory=instance_file.parent.parent,
-                marc_record=marc_record,
-            )
-
-
-def write_marc(**kwargs):
-    """
-    Writes marc record to file system
-    """
-    instance_file = kwargs.get("instance_file")
-    marc_file_name = instance_file.stem
-    marc_directory = kwargs.get("marc_directory") / "marc-files"
-    marc_directory.mkdir(parents=True, exist_ok=True)
-    marc_file = marc_directory / f"{marc_file_name}.mrc"
-    marc_writer = pymarc.MARCWriter(marc_file.open("ab"))
-    marc_writer.write(kwargs.get("marc_record"))
-    marc_writer.close()
-    return str(marc_file.absolute())

--- a/libsys_airflow/plugins/data_exports/marc/transformer.py
+++ b/libsys_airflow/plugins/data_exports/marc/transformer.py
@@ -7,130 +7,126 @@ from libsys_airflow.plugins.folio_client import folio_client
 
 logger = logging.getLogger(__name__)
 
+
 class Transformer(object):
-  def __init__(self):
-    self.folio_client = folio_client()
-    self.call_numbers = self.call_number_lookup()
-    self.holdings_type = self.holdings_type_lookup()
-    self.locations = self.locations_lookup()
+    def __init__(self):
+        self.folio_client = folio_client()
+        self.call_numbers = self.call_number_lookup()
+        self.holdings_type = self.holdings_type_lookup()
+        self.locations = self.locations_lookup()
 
+    def call_number_lookup(self) -> dict:
+        lookup = {}
+        for row in self.folio_client.call_number_types:
+            lookup[row['id']] = row['name']
+        return lookup
 
-  def call_number_lookup(self) -> dict:
-    lookup = {}
-    for row in self.folio_client.call_number_types:
-        lookup[row['id']] = row['name']
-    return lookup
+    def holdings_type_lookup(self) -> dict:
+        lookup = {}
+        for row in self.folio_client.holdings_types:
+            lookup[row['id']] = row['name']
+        return lookup
 
+    def locations_lookup(self) -> dict:
+        lookup = {}
+        for location in self.folio_client.locations:
+            lookup[location['id']] = location['code']
+        return lookup
 
-  def holdings_type_lookup(self) -> dict:
-    lookup = {}
-    for row in self.folio_client.holdings_types:
-        lookup[row['id']] = row['name']
-    return lookup
+    def add_holdings_items(self, marc_file: str):
+        """
+        Adds FOLIO Holdings and Items information to MARC records
+        """
 
+        marc_path = pathlib.Path(marc_file)
 
-  def locations_lookup(self) -> dict:
-    lookup = {}
-    for location in self.folio_client.locations:
-        lookup[location['id']] = location['code']
-    return lookup
+        marc_records = []
+        logger.info("Starting MARC processing")
+        with marc_path.open('rb') as fo:
+            for i, record in enumerate(pymarc.MARCReader(fo)):
+                subfields_i = record["999"].get_subfields("i")
+                new_999s = self.add_holdings_items_fields(subfields_i)
+                record.add_field(*new_999s)
+                marc_records.append(record)
+                if not i % 100:
+                    logger.info(f"{i:,} processed records")
 
-
-  def add_holdings_items(self, marc_file: str):
-    """
-    Adds FOLIO Holdings and Items information to MARC records
-    """
-
-    marc_path = pathlib.Path(marc_file)
-
-    marc_records = []
-    logger.info("Starting MARC processing")
-    with marc_path.open('rb') as fo:
-        for i, record in enumerate(pymarc.MARCReader(fo)):
-            subfields_i = record["999"].get_subfields("i")
-            new_999s = self.add_holdings_items_fields(subfields_i)
-            record.add_field(*new_999s)
-            marc_records.append(record)
-            if not i % 100:
-                logger.info(f"{i:,} processed records")
-
-    logger.info(f"Writing {len(marc_records):,} modified MARC records to {marc_path}")
-    with marc_path.open('wb+') as fo:
-        marc_writer = pymarc.MARCWriter(fo)
-        for record in marc_records:
-            marc_writer.write(record)
-
-
-  def add_holdings_items_fields(self, instance_subfields: list) -> list:
-    fields = []
-    for uuid in instance_subfields:
-        holdings_result = self.folio_client.folio_get(
-            f"/holdings-storage/holdings?query=(instanceId=={uuid})"
+        logger.info(
+            f"Writing {len(marc_records):,} modified MARC records to {marc_path}"
         )
-        for holding in holdings_result['holdingsRecords']:
-            field_999 = self.add_holdings_subfields(holding)
+        with marc_path.open('wb+') as fo:
+            marc_writer = pymarc.MARCWriter(fo)
+            for record in marc_records:
+                marc_writer.write(record)
 
-            items_result = self.folio_client.folio_get(
-                f"inventory/items?query=(holdingsRecordId=={holding['id']})"
+    def add_holdings_items_fields(self, instance_subfields: list) -> list:
+        fields = []
+        for uuid in instance_subfields:
+            holdings_result = self.folio_client.folio_get(
+                f"/holdings-storage/holdings?query=(instanceId=={uuid})"
             )
-            items = items_result['items']
-            match len(items):
-                case 0:
-                    if len(field_999.subfields) > 0:
-                        fields.append(field_999)
+            for holding in holdings_result['holdingsRecords']:
+                field_999 = self.add_holdings_subfields(holding)
 
-                case 1:
-                    self.add_item_subfields(field_999, items[0])
-                    if len(field_999.subfields) > 0:
-                        fields.append(field_999)
+                items_result = self.folio_client.folio_get(
+                    f"inventory/items?query=(holdingsRecordId=={holding['id']})"
+                )
+                items = items_result['items']
+                match len(items):
+                    case 0:
+                        if len(field_999.subfields) > 0:
+                            fields.append(field_999)
 
-                case _:
-                    org_999 = copy.deepcopy(field_999)
-                    self.add_item_subfields(field_999, items[0])
-                    if len(field_999.subfields) > 0:
-                        fields.append(field_999)
-                    for item in items[1:]:
-                        new_999 = copy.deepcopy(org_999)
-                        self.add_item_subfields(new_999, item)
-                        if len(new_999.subfields) > 0:
-                            fields.append(new_999)
-    return fields
+                    case 1:
+                        self.add_item_subfields(field_999, items[0])
+                        if len(field_999.subfields) > 0:
+                            fields.append(field_999)
 
+                    case _:
+                        org_999 = copy.deepcopy(field_999)
+                        self.add_item_subfields(field_999, items[0])
+                        if len(field_999.subfields) > 0:
+                            fields.append(field_999)
+                        for item in items[1:]:
+                            new_999 = copy.deepcopy(org_999)
+                            self.add_item_subfields(new_999, item)
+                            if len(new_999.subfields) > 0:
+                                fields.append(new_999)
+        return fields
 
-  def add_holdings_subfields(self, holdings: dict) -> pymarc.Field:
-    field_999 = pymarc.Field(tag="999", indicators=[' ', ' '])
-    if len(holdings["holdingsTypeId"]) > 0:
-        holdings_type_name = self.holdings_type.get(holdings["holdingsTypeId"])
-        if holdings_type_name:
-            field_999.add_subfield('h', holdings_type_name)
-    if len(holdings['permanentLocationId']) > 0:
-        permanent_location_code = self.locations.get(
-            holdings['permanentLocationId']
-        )
-        if permanent_location_code:
-            field_999.add_subfield('l', permanent_location_code)
-    if len(holdings['callNumberTypeId']) > 0:
-        call_number_type = self.call_numbers.get(holdings['callNumberTypeId'])
-        if call_number_type:
-            field_999.add_subfield('w', call_number_type)
-    if len(holdings['callNumber']) > 0:
-        field_999.add_subfield('a', holdings['callNumber'], 0)
-    return field_999
+    def add_holdings_subfields(self, holdings: dict) -> pymarc.Field:
+        field_999 = pymarc.Field(tag="999", indicators=[' ', ' '])
+        if len(holdings["holdingsTypeId"]) > 0:
+            holdings_type_name = self.holdings_type.get(holdings["holdingsTypeId"])
+            if holdings_type_name:
+                field_999.add_subfield('h', holdings_type_name)
+        if len(holdings['permanentLocationId']) > 0:
+            permanent_location_code = self.locations.get(
+                holdings['permanentLocationId']
+            )
+            if permanent_location_code:
+                field_999.add_subfield('l', permanent_location_code)
+        if len(holdings['callNumberTypeId']) > 0:
+            call_number_type = self.call_numbers.get(holdings['callNumberTypeId'])
+            if call_number_type:
+                field_999.add_subfield('w', call_number_type)
+        if len(holdings['callNumber']) > 0:
+            field_999.add_subfield('a', holdings['callNumber'], 0)
+        return field_999
 
+    def add_item_subfields(self, field_999: pymarc.Field, item: dict):
+        if 'materialType' in item:
+            field_999.add_subfield('t', item['materialType'].get('name'))
+        if 'effectiveLocation' in item:
+            location_code = self.locations.get(item['effectiveLocation'].get('id'))
+            if location_code:
+                field_999.add_subfield('e', location_code)
+        if len(item.get('numberOfPieces', '')) > 0:
+            field_999.add_subfield('j', item['numberOfPieces'])
 
-  def add_item_subfields(self, field_999: pymarc.Field, item: dict):
-    if 'materialType' in item:
-        field_999.add_subfield('t', item['materialType'].get('name'))
-    if 'effectiveLocation' in item:
-        location_code = self.locations.get(item['effectiveLocation'].get('id'))
-        if location_code:
-            field_999.add_subfield('e', location_code)
-    if len(item.get('numberOfPieces', '')) > 0:
-        field_999.add_subfield('j', item['numberOfPieces'])
-
-    if "enumeration" in item:
-        for subfield in field_999.subfields:
-            if subfield.code == 'a':
-                value = field_999.delete_subfield('a')
-                value = f"{value} {item['enumeration']}"
-                field_999.add_subfield('a', value, 0)
+        if "enumeration" in item:
+            for subfield in field_999.subfields:
+                if subfield.code == 'a':
+                    value = field_999.delete_subfield('a')
+                    value = f"{value} {item['enumeration']}"
+                    field_999.add_subfield('a', value, 0)

--- a/libsys_airflow/plugins/data_exports/marc/transformer.py
+++ b/libsys_airflow/plugins/data_exports/marc/transformer.py
@@ -1,0 +1,136 @@
+import copy
+import logging
+import pathlib
+import pymarc
+
+from libsys_airflow.plugins.folio_client import folio_client
+
+logger = logging.getLogger(__name__)
+
+class Transformer(object):
+  def __init__(self):
+    self.folio_client = folio_client()
+    self.call_numbers = self.call_number_lookup()
+    self.holdings_type = self.holdings_type_lookup()
+    self.locations = self.locations_lookup()
+
+
+  def call_number_lookup(self) -> dict:
+    lookup = {}
+    for row in self.folio_client.call_number_types:
+        lookup[row['id']] = row['name']
+    return lookup
+
+
+  def holdings_type_lookup(self) -> dict:
+    lookup = {}
+    for row in self.folio_client.holdings_types:
+        lookup[row['id']] = row['name']
+    return lookup
+
+
+  def locations_lookup(self) -> dict:
+    lookup = {}
+    for location in self.folio_client.locations:
+        lookup[location['id']] = location['code']
+    return lookup
+
+
+  def add_holdings_items(self, marc_file: str):
+    """
+    Adds FOLIO Holdings and Items information to MARC records
+    """
+
+    marc_path = pathlib.Path(marc_file)
+
+    marc_records = []
+    logger.info("Starting MARC processing")
+    with marc_path.open('rb') as fo:
+        for i, record in enumerate(pymarc.MARCReader(fo)):
+            subfields_i = record["999"].get_subfields("i")
+            new_999s = self.add_holdings_items_fields(subfields_i)
+            record.add_field(*new_999s)
+            marc_records.append(record)
+            if not i % 100:
+                logger.info(f"{i:,} processed records")
+
+    logger.info(f"Writing {len(marc_records):,} modified MARC records to {marc_path}")
+    with marc_path.open('wb+') as fo:
+        marc_writer = pymarc.MARCWriter(fo)
+        for record in marc_records:
+            marc_writer.write(record)
+
+
+  def add_holdings_items_fields(self, instance_subfields: list) -> list:
+    fields = []
+    for uuid in instance_subfields:
+        holdings_result = self.folio_client.folio_get(
+            f"/holdings-storage/holdings?query=(instanceId=={uuid})"
+        )
+        for holding in holdings_result['holdingsRecords']:
+            field_999 = self.add_holdings_subfields(holding)
+
+            items_result = self.folio_client.folio_get(
+                f"inventory/items?query=(holdingsRecordId=={holding['id']})"
+            )
+            items = items_result['items']
+            match len(items):
+                case 0:
+                    if len(field_999.subfields) > 0:
+                        fields.append(field_999)
+
+                case 1:
+                    self.add_item_subfields(field_999, items[0])
+                    if len(field_999.subfields) > 0:
+                        fields.append(field_999)
+
+                case _:
+                    org_999 = copy.deepcopy(field_999)
+                    self.add_item_subfields(field_999, items[0])
+                    if len(field_999.subfields) > 0:
+                        fields.append(field_999)
+                    for item in items[1:]:
+                        new_999 = copy.deepcopy(org_999)
+                        self.add_item_subfields(new_999, item)
+                        if len(new_999.subfields) > 0:
+                            fields.append(new_999)
+    return fields
+
+
+  def add_holdings_subfields(self, holdings: dict) -> pymarc.Field:
+    field_999 = pymarc.Field(tag="999", indicators=[' ', ' '])
+    if len(holdings["holdingsTypeId"]) > 0:
+        holdings_type_name = self.holdings_type.get(holdings["holdingsTypeId"])
+        if holdings_type_name:
+            field_999.add_subfield('h', holdings_type_name)
+    if len(holdings['permanentLocationId']) > 0:
+        permanent_location_code = self.locations.get(
+            holdings['permanentLocationId']
+        )
+        if permanent_location_code:
+            field_999.add_subfield('l', permanent_location_code)
+    if len(holdings['callNumberTypeId']) > 0:
+        call_number_type = self.call_numbers.get(holdings['callNumberTypeId'])
+        if call_number_type:
+            field_999.add_subfield('w', call_number_type)
+    if len(holdings['callNumber']) > 0:
+        field_999.add_subfield('a', holdings['callNumber'], 0)
+    return field_999
+
+
+  def add_item_subfields(self, field_999: pymarc.Field, item: dict):
+    if 'materialType' in item:
+        field_999.add_subfield('t', item['materialType'].get('name'))
+    if 'effectiveLocation' in item:
+        location_code = self.locations.get(item['effectiveLocation'].get('id'))
+        if location_code:
+            field_999.add_subfield('e', location_code)
+    if len(item.get('numberOfPieces', '')) > 0:
+        field_999.add_subfield('j', item['numberOfPieces'])
+
+    if "enumeration" in item:
+        for subfield in field_999.subfields:
+            if subfield.code == 'a':
+                value = field_999.delete_subfield('a')
+                value = f"{value} {item['enumeration']}"
+                field_999.add_subfield('a', value, 0)

--- a/libsys_airflow/plugins/data_exports/marc/transforms.py
+++ b/libsys_airflow/plugins/data_exports/marc/transforms.py
@@ -1,11 +1,9 @@
-import copy
 import logging
 import pathlib
 
 import pymarc
 
-from airflow.models import Variable
-from folioclient import FolioClient
+from libsys_airflow.plugins.data_exports.marc.transformer import Transformer
 
 logger = logging.getLogger(__name__)
 
@@ -87,140 +85,10 @@ excluded_tags = [
 ]
 
 
-def _add_holdings_items_fields(
-    instance_subfields: list, lookups: dict, folio_client: FolioClient
-) -> list:
-    fields = []
-    for uuid in instance_subfields:
-        holdings_result = folio_client.folio_get(
-            f"/holdings-storage/holdings?query=(instanceId=={uuid})"
-        )
-        for holding in holdings_result['holdingsRecords']:
-            field_999 = _add_holdings_subfields(holding, lookups)
-
-            items_result = folio_client.folio_get(
-                f"inventory/items?query=(holdingsRecordId=={holding['id']})"
-            )
-            items = items_result['items']
-            match len(items):
-                case 0:
-                    if len(field_999.subfields) > 0:
-                        fields.append(field_999)
-
-                case 1:
-                    _add_item_subfields(field_999, items[0], lookups)
-                    if len(field_999.subfields) > 0:
-                        fields.append(field_999)
-
-                case _:
-                    org_999 = copy.deepcopy(field_999)
-                    _add_item_subfields(field_999, items[0], lookups)
-                    if len(field_999.subfields) > 0:
-                        fields.append(field_999)
-                    for item in items[1:]:
-                        new_999 = copy.deepcopy(org_999)
-                        _add_item_subfields(new_999, item, lookups)
-                        if len(new_999.subfields) > 0:
-                            fields.append(new_999)
-    return fields
-
-
-def _add_holdings_subfields(holdings: dict, lookups: dict) -> pymarc.Field:
-    field_999 = pymarc.Field(tag="999", indicators=[' ', ' '])
-    if len(holdings["holdingsTypeId"]) > 0:
-        holdings_type_name = lookups["holdings_type"].get(holdings["holdingsTypeId"])
-        if holdings_type_name:
-            field_999.add_subfield('h', holdings_type_name)
-    if len(holdings['permanentLocationId']) > 0:
-        permanent_location_code = lookups['locations'].get(
-            holdings['permanentLocationId']
-        )
-        if permanent_location_code:
-            field_999.add_subfield('l', permanent_location_code)
-    if len(holdings['callNumberTypeId']) > 0:
-        call_number_type = lookups["call_number"].get(holdings['callNumberTypeId'])
-        if call_number_type:
-            field_999.add_subfield('w', call_number_type)
-    if len(holdings['callNumber']) > 0:
-        field_999.add_subfield('a', holdings['callNumber'], 0)
-    return field_999
-
-
-def _add_item_subfields(field_999: pymarc.Field, item: dict, lookups: dict):
-    if 'materialType' in item:
-        field_999.add_subfield('t', item['materialType'].get('name'))
-    if 'effectiveLocation' in item:
-        location_code = lookups['locations'].get(item['effectiveLocation'].get('id'))
-        if location_code:
-            field_999.add_subfield('e', location_code)
-    if len(item.get('numberOfPieces', '')) > 0:
-        field_999.add_subfield('j', item['numberOfPieces'])
-
-    if "enumeration" in item:
-        for subfield in field_999.subfields:
-            if subfield.code == 'a':
-                value = field_999.delete_subfield('a')
-                value = f"{value} {item['enumeration']}"
-                field_999.add_subfield('a', value, 0)
-
-
-def _call_number_lookup(folio_client: FolioClient) -> dict:
-    lookup = {}
-    for row in folio_client.call_number_types:
-        lookup[row['id']] = row['name']
-    return lookup
-
-
-def _holdings_type_lookup(folio_client: FolioClient) -> dict:
-    lookup = {}
-    for row in folio_client.holdings_types:
-        lookup[row['id']] = row['name']
-    return lookup
-
-
-def _locations_lookup(folio_client: FolioClient) -> dict:
-    lookup = {}
-    for location in folio_client.locations:
-        lookup[location['id']] = location['code']
-    return lookup
-
-
-def add_holdings_items(marc_file: str, folio_client: FolioClient = None):
-    """
-    Adds FOLIO Holdings and Items information to MARC records
-    """
-    if folio_client is None:
-        folio_client = FolioClient(
-            Variable.get("OKAPI_URL"),
-            "sul",
-            Variable.get("FOLIO_USER"),
-            Variable.get("FOLIO_PASSWORD"),
-        )
-
-    look_ups = {
-        "call_number": _call_number_lookup(folio_client),
-        "holdings_type": _holdings_type_lookup(folio_client),
-        "locations": _locations_lookup(folio_client),
-    }
-
-    marc_path = pathlib.Path(marc_file)
-
-    marc_records = []
-    logger.info("Starting MARC processing")
-    with marc_path.open('rb') as fo:
-        for i, record in enumerate(pymarc.MARCReader(fo)):
-            subfields_i = record["999"].get_subfields("i")
-            new_999s = _add_holdings_items_fields(subfields_i, look_ups, folio_client)
-            record.add_field(*new_999s)
-            marc_records.append(record)
-            if not i % 100:
-                logger.info(f"{i:,} processed records")
-
-    logger.info(f"Writing {len(marc_records):,} modified MARC records to {marc_path}")
-    with marc_path.open('wb+') as fo:
-        marc_writer = pymarc.MARCWriter(fo)
-        for record in marc_records:
-            marc_writer.write(record)
+def add_holdings_items_to_marc_files(marc_file_list: list):
+    transformer = Transformer()
+    for marc_file in marc_file_list:
+        transformer.add_holdings_items(marc_file=marc_file)
 
 
 def remove_marc_fields(marc_file: str):
@@ -243,3 +111,4 @@ def remove_marc_fields(marc_file: str):
         marc_writer = pymarc.MARCWriter(fo)
         for record in marc_records:
             marc_writer.write(record)
+

--- a/libsys_airflow/plugins/data_exports/marc/transforms.py
+++ b/libsys_airflow/plugins/data_exports/marc/transforms.py
@@ -111,4 +111,3 @@ def remove_marc_fields(marc_file: str):
         marc_writer = pymarc.MARCWriter(fo)
         for record in marc_records:
             marc_writer.write(record)
-

--- a/libsys_airflow/plugins/folio_client.py
+++ b/libsys_airflow/plugins/folio_client.py
@@ -1,0 +1,15 @@
+from airflow.models import Variable
+from folioclient import FolioClient
+
+def folio_client(**kwargs):
+    client = kwargs.get("client")
+
+    if client is None:
+        client = FolioClient(
+            Variable.get("OKAPI_URL", "http://example:9130"),
+            "sul",
+            Variable.get("FOLIO_USER", "nausername"),
+            Variable.get("FOLIO_PASSWORD", "napassword"),
+        )
+
+    return client

--- a/libsys_airflow/plugins/folio_client.py
+++ b/libsys_airflow/plugins/folio_client.py
@@ -1,6 +1,7 @@
 from airflow.models import Variable
 from folioclient import FolioClient
 
+
 def folio_client(**kwargs):
     client = kwargs.get("client")
 

--- a/tests/data_exports/test_marc_exports.py
+++ b/tests/data_exports/test_marc_exports.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock
 
 from libsys_airflow.plugins.data_exports.marc.exports import (
     marc_for_instances,
-    instance_files_dir
-    )
+    instance_files_dir,
+)
 
 from libsys_airflow.plugins.data_exports.marc.exporter import Exporter
 
@@ -129,8 +129,8 @@ def setup_test_file(tmp_path):
 def test_retrieve_marc_for_instances(mocker, mock_folio_client, tmp_path):
     mocker.patch(
         'libsys_airflow.plugins.data_exports.marc.exporter.folio_client',
-        return_value = mock_folio_client
-        )
+        return_value=mock_folio_client,
+    )
 
     instance_file = setup_test_file(tmp_path)
 
@@ -150,8 +150,8 @@ def test_retrieve_marc_for_instances(mocker, mock_folio_client, tmp_path):
 def test_retrieve_marc_for_instance_404(mocker, mock_folio_404, tmp_path, caplog):
     mocker.patch(
         'libsys_airflow.plugins.data_exports.marc.exporter.folio_client',
-        return_value = mock_folio_404
-        )
+        return_value=mock_folio_404,
+    )
 
     instance_file = setup_test_file(tmp_path)
 
@@ -173,8 +173,8 @@ def test_marc_for_instances(mocker, tmp_path, mock_folio_client):
 
     mocker.patch(
         'libsys_airflow.plugins.data_exports.marc.exporter.folio_client',
-        return_value = mock_folio_client
-        )
+        return_value=mock_folio_client,
+    )
 
     files = marc_for_instances(airflow=tmp_path, vendor="pod")
 

--- a/tests/data_exports/test_marc_exports.py
+++ b/tests/data_exports/test_marc_exports.py
@@ -4,11 +4,11 @@ import pytest
 from unittest.mock import MagicMock
 
 from libsys_airflow.plugins.data_exports.marc.exports import (
-    _exclude_marc_by_vendor,
-    retrieve_marc_for_instances,
-    instance_files_dir,
     marc_for_instances,
-)
+    instance_files_dir
+    )
+
+from libsys_airflow.plugins.data_exports.marc.exporter import Exporter
 
 
 @pytest.fixture
@@ -126,12 +126,16 @@ def setup_test_file(tmp_path):
     return instance_file
 
 
-def test_retrieve_marc_for_instances(tmp_path, mock_folio_client):
+def test_retrieve_marc_for_instances(mocker, mock_folio_client, tmp_path):
+    mocker.patch(
+        'libsys_airflow.plugins.data_exports.marc.exporter.folio_client',
+        return_value = mock_folio_client
+        )
+
     instance_file = setup_test_file(tmp_path)
 
-    retrieve_marc_for_instances(
-        instance_file=str(instance_file), folio_client=mock_folio_client
-    )
+    exporter = Exporter()
+    exporter.retrieve_marc_for_instances(instance_file)
 
     marc_file = instance_file.parent.parent / "marc-files/2024022711.mrc"
 
@@ -143,12 +147,16 @@ def test_retrieve_marc_for_instances(tmp_path, mock_folio_client):
     assert len(marc_records) == 1
 
 
-def test_retrieve_marc_for_instance_404(tmp_path, mock_folio_404, caplog):
+def test_retrieve_marc_for_instance_404(mocker, mock_folio_404, tmp_path, caplog):
+    mocker.patch(
+        'libsys_airflow.plugins.data_exports.marc.exporter.folio_client',
+        return_value = mock_folio_404
+        )
+
     instance_file = setup_test_file(tmp_path)
 
-    retrieve_marc_for_instances(
-        instance_file=str(instance_file), folio_client=mock_folio_404
-    )
+    exporter = Exporter()
+    exporter.retrieve_marc_for_instances(instance_file)
 
     assert "response code 404" in caplog.text
 
@@ -160,11 +168,15 @@ def test_fetch_marc_missing_instance_file(tmp_path):
         instance_files_dir(airflow=tmp_path, vendor="gobi")
 
 
-def test_marc_for_instances(tmp_path, mock_folio_client):
+def test_marc_for_instances(mocker, tmp_path, mock_folio_client):
     setup_test_file(tmp_path)
-    files = marc_for_instances(
-        airflow=tmp_path, vendor="pod", folio_client=mock_folio_client
-    )
+
+    mocker.patch(
+        'libsys_airflow.plugins.data_exports.marc.exporter.folio_client',
+        return_value = mock_folio_client
+        )
+
+    files = marc_for_instances(airflow=tmp_path, vendor="pod")
 
     assert files[0].endswith('2024022711.csv')
 
@@ -195,34 +207,42 @@ field_915_alt = pymarc.Field(
 )
 
 
-def test_exclude_marc_by_vendor_gobi():
+def test_exclude_marc_by_vendor_gobi(mocker):
+    mocker.patch('libsys_airflow.plugins.data_exports.marc.exporter.folio_client')
+    exporter = Exporter()
     marc_record = pymarc.Record()
     marc_record.add_field(field_001, field_008)
 
-    assert _exclude_marc_by_vendor(marc_record, 'gobi')
+    assert exporter.exclude_marc_by_vendor(marc_record, 'gobi')
 
     marc_record = pymarc.Record()
     marc_record.add_field(field_008)
 
-    assert _exclude_marc_by_vendor(marc_record, 'gobi')
+    assert exporter.exclude_marc_by_vendor(marc_record, 'gobi')
 
 
-def test_exclude_marc_by_vendor_oclc():
+def test_exclude_marc_by_vendor_oclc(mocker):
+    mocker.patch('libsys_airflow.plugins.data_exports.marc.exporter.folio_client')
+    exporter = Exporter()
     marc_record = pymarc.Record()
     marc_record.add_field(field_590, field_915)
 
-    assert _exclude_marc_by_vendor(marc_record, 'oclc')
+    assert exporter.exclude_marc_by_vendor(marc_record, 'oclc')
 
 
-def test_exclude_marc_by_vendor_pod():
+def test_exclude_marc_by_vendor_pod(mocker):
+    mocker.patch('libsys_airflow.plugins.data_exports.marc.exporter.folio_client')
+    exporter = Exporter()
     marc_record = pymarc.Record()
     marc_record.add_field(field_590, field_915)
 
-    assert _exclude_marc_by_vendor(marc_record, 'pod')
+    assert exporter.exclude_marc_by_vendor(marc_record, 'pod')
 
 
-def test_exclude_marc_by_vendor_sharevde():
+def test_exclude_marc_by_vendor_sharevde(mocker):
+    mocker.patch('libsys_airflow.plugins.data_exports.marc.exporter.folio_client')
+    exporter = Exporter()
     marc_record = pymarc.Record()
     marc_record.add_field(field_590, field_915)
 
-    assert _exclude_marc_by_vendor(marc_record, 'sharevde')
+    assert exporter.exclude_marc_by_vendor(marc_record, 'sharevde')

--- a/tests/data_exports/test_marc_transformations.py
+++ b/tests/data_exports/test_marc_transformations.py
@@ -162,7 +162,7 @@ def mock_folio_client():
 def test_add_holdings_items_single_999(mocker, tmp_path, mock_folio_client):
     mocker.patch(
         'libsys_airflow.plugins.data_exports.marc.transformer.folio_client',
-        return_value = mock_folio_client
+        return_value=mock_folio_client,
     )
     record = pymarc.Record()
     record.add_field(
@@ -200,7 +200,7 @@ def test_add_holdings_items_single_999(mocker, tmp_path, mock_folio_client):
 def test_add_holdings_items_multiple_999(mocker, tmp_path, mock_folio_client):
     mocker.patch(
         'libsys_airflow.plugins.data_exports.marc.transformer.folio_client',
-        return_value = mock_folio_client
+        return_value=mock_folio_client,
     )
     record = pymarc.Record()
     record.add_field(
@@ -238,7 +238,7 @@ def test_add_holdings_items_multiple_999(mocker, tmp_path, mock_folio_client):
 def test_add_holdings_items_no_items(mocker, tmp_path, mock_folio_client):
     mocker.patch(
         'libsys_airflow.plugins.data_exports.marc.transformer.folio_client',
-        return_value = mock_folio_client
+        return_value=mock_folio_client,
     )
     record = pymarc.Record()
 

--- a/tests/data_exports/test_marc_transformations.py
+++ b/tests/data_exports/test_marc_transformations.py
@@ -3,10 +3,10 @@ import pytest
 
 from unittest.mock import MagicMock
 
-from libsys_airflow.plugins.data_exports.marc.transforms import (
-    add_holdings_items,
-    remove_marc_fields,
-)
+from libsys_airflow.plugins.data_exports.marc.transforms import remove_marc_fields
+
+from libsys_airflow.plugins.data_exports.marc.transformer import Transformer
+
 
 holdings_multiple_items = {
     "holdingsRecords": [
@@ -159,7 +159,11 @@ def mock_folio_client():
     return mock_client
 
 
-def test_add_holdings_items_single_999(tmp_path, mock_folio_client):
+def test_add_holdings_items_single_999(mocker, tmp_path, mock_folio_client):
+    mocker.patch(
+        'libsys_airflow.plugins.data_exports.marc.transformer.folio_client',
+        return_value = mock_folio_client
+    )
     record = pymarc.Record()
     record.add_field(
         pymarc.Field(
@@ -175,7 +179,8 @@ def test_add_holdings_items_single_999(tmp_path, mock_folio_client):
         marc_writer = pymarc.MARCWriter(fo)
         marc_writer.write(record)
 
-    add_holdings_items(str(marc_file), mock_folio_client)
+    transformer = Transformer()
+    transformer.add_holdings_items(str(marc_file))
 
     with marc_file.open('rb') as fo:
         mod_marc_records = [r for r in pymarc.MARCReader(fo)]
@@ -192,7 +197,11 @@ def test_add_holdings_items_single_999(tmp_path, mock_folio_client):
     assert field_999s[1].get_subfields('w')[0].startswith("Library of Congress")
 
 
-def test_add_holdings_items_multiple_999(tmp_path, mock_folio_client):
+def test_add_holdings_items_multiple_999(mocker, tmp_path, mock_folio_client):
+    mocker.patch(
+        'libsys_airflow.plugins.data_exports.marc.transformer.folio_client',
+        return_value = mock_folio_client
+    )
     record = pymarc.Record()
     record.add_field(
         pymarc.Field(
@@ -209,7 +218,8 @@ def test_add_holdings_items_multiple_999(tmp_path, mock_folio_client):
         marc_writer = pymarc.MARCWriter(fo)
         marc_writer.write(record)
 
-    add_holdings_items(str(marc_file), mock_folio_client)
+    transformer = Transformer()
+    transformer.add_holdings_items(str(marc_file))
 
     with marc_file.open('rb') as fo:
         mod_marc_records = [r for r in pymarc.MARCReader(fo)]
@@ -225,7 +235,11 @@ def test_add_holdings_items_multiple_999(tmp_path, mock_folio_client):
     assert field_999s[1].get_subfields('l') == field_999s[2].get_subfields('l')
 
 
-def test_add_holdings_items_no_items(tmp_path, mock_folio_client):
+def test_add_holdings_items_no_items(mocker, tmp_path, mock_folio_client):
+    mocker.patch(
+        'libsys_airflow.plugins.data_exports.marc.transformer.folio_client',
+        return_value = mock_folio_client
+    )
     record = pymarc.Record()
 
     record.add_field(
@@ -243,7 +257,8 @@ def test_add_holdings_items_no_items(tmp_path, mock_folio_client):
         marc_writer = pymarc.MARCWriter(fo)
         marc_writer.write(record)
 
-    add_holdings_items(str(marc_file), mock_folio_client)
+    transformer = Transformer()
+    transformer.add_holdings_items(str(marc_file))
 
     with marc_file.open('rb') as fo:
         mod_marc_records = [r for r in pymarc.MARCReader(fo)]


### PR DESCRIPTION
@jermnelson worked with me to create `Transformer` and `Exporter` classes to allow for instantiation of the folio client and other class methods, and better mocking of folio client in the tests without having to pass the client around in messages to other functions.