### PR TITLE
Adds ftp and http hooks to transmission tasks

### DIFF
--- a/libsys_airflow/dags/data_exports/gobi_transmission.py
+++ b/libsys_airflow/dags/data_exports/gobi_transmission.py
@@ -6,9 +6,8 @@ from airflow.models import Variable
 from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
-    connection_details_task,
     gather_files_task,
-    transmit_data_task,
+    transmit_data_ftp_task,
     archive_transmitted_data_task,
 )
 
@@ -38,9 +37,7 @@ def send_gobi_records():
 
     gather_files = gather_files_task(vendor="gobi")
 
-    connection_details = connection_details_task()
-
-    transmit_data = transmit_data_task(connection_details)
+    transmit_data = transmit_data_ftp_task("ftp-ftp.ybp.com-stanford", gather_files)
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 

--- a/libsys_airflow/dags/data_exports/google_transmission.py
+++ b/libsys_airflow/dags/data_exports/google_transmission.py
@@ -6,9 +6,8 @@ from airflow.models import Variable
 from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
-    connection_details_task,
     gather_files_task,
-    transmit_data_task,
+    transmit_data_ftp_task,
     archive_transmitted_data_task,
 )
 
@@ -38,9 +37,7 @@ def send_google_records():
 
     gather_files = gather_files_task(vendor="google")
 
-    connection_details = connection_details_task()
-
-    transmit_data = transmit_data_task(connection_details)
+    transmit_data = transmit_data_ftp_task("google", gather_files)
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 

--- a/libsys_airflow/dags/data_exports/hathi_transmission.py
+++ b/libsys_airflow/dags/data_exports/hathi_transmission.py
@@ -6,9 +6,8 @@ from airflow.models import Variable
 from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
-    connection_details_task,
     gather_files_task,
-    transmit_data_task,
+    transmit_data_ftp_task,
     archive_transmitted_data_task,
 )
 
@@ -38,9 +37,7 @@ def send_hathi_records():
 
     gather_files = gather_files_task(vendor="hathi")
 
-    connection_details = connection_details_task()
-
-    transmit_data = transmit_data_task(connection_details)
+    transmit_data = transmit_data_ftp_task("hathi", gather_files)
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 

--- a/libsys_airflow/dags/data_exports/nielsen_transmission.py
+++ b/libsys_airflow/dags/data_exports/nielsen_transmission.py
@@ -6,9 +6,8 @@ from airflow.models import Variable
 from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
-    connection_details_task,
     gather_files_task,
-    transmit_data_task,
+    transmit_data_ftp_task,
     archive_transmitted_data_task,
 )
 
@@ -38,9 +37,7 @@ def send_nielsen_records():
 
     gather_files = gather_files_task(vendor="nielsen")
 
-    connection_details = connection_details_task()
-
-    transmit_data = transmit_data_task(connection_details)
+    transmit_data = transmit_data_ftp_task("nielsen", gather_files)
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 

--- a/libsys_airflow/dags/data_exports/oclc_transmission.py
+++ b/libsys_airflow/dags/data_exports/oclc_transmission.py
@@ -6,9 +6,8 @@ from airflow.models import Variable
 from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
-    connection_details_task,
     gather_files_task,
-    transmit_data_task,
+    transmit_data_ftp_task,
     archive_transmitted_data_task,
 )
 
@@ -38,9 +37,7 @@ def send_oclc_records():
 
     gather_files = gather_files_task(vendor="oclc")
 
-    connection_details = connection_details_task()
-
-    transmit_data = transmit_data_task(connection_details)
+    transmit_data = transmit_data_ftp_task("google", gather_files)
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 

--- a/libsys_airflow/dags/data_exports/pod_transmission.py
+++ b/libsys_airflow/dags/data_exports/pod_transmission.py
@@ -6,9 +6,8 @@ from airflow.models import Variable
 from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
-    connection_details_task,
     gather_files_task,
-    transmit_data_task,
+    transmit_data_http_task,
     archive_transmitted_data_task,
 )
 
@@ -38,9 +37,7 @@ def send_pod_records():
 
     gather_files = gather_files_task(vendor="pod")
 
-    connection_details = connection_details_task()
-
-    transmit_data = transmit_data_task(connection_details)
+    transmit_data = transmit_data_http_task("pod", gather_files)
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 

--- a/libsys_airflow/dags/data_exports/pod_transmission.py
+++ b/libsys_airflow/dags/data_exports/pod_transmission.py
@@ -37,7 +37,12 @@ def send_pod_records():
 
     gather_files = gather_files_task(vendor="pod")
 
-    transmit_data = transmit_data_http_task("pod", gather_files)
+    transmit_data = transmit_data_http_task(
+        "pod",
+        gather_files,
+        files_params="upload[files][]",
+        url_params={"stream": "Test"},
+    )
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 

--- a/libsys_airflow/dags/data_exports/sharevde_transmission.py
+++ b/libsys_airflow/dags/data_exports/sharevde_transmission.py
@@ -6,9 +6,8 @@ from airflow.models import Variable
 from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
-    connection_details_task,
     gather_files_task,
-    transmit_data_task,
+    transmit_data_ftp_task,
     archive_transmitted_data_task,
 )
 
@@ -38,9 +37,7 @@ def send_sharevde_records():
 
     gather_files = gather_files_task(vendor="sharevde")
 
-    connection_details = connection_details_task()
-
-    transmit_data = transmit_data_task(connection_details)
+    transmit_data = transmit_data_ftp_task("sharevde", gather_files)
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 

--- a/libsys_airflow/dags/data_exports/west_transmission.py
+++ b/libsys_airflow/dags/data_exports/west_transmission.py
@@ -6,9 +6,8 @@ from airflow.models import Variable
 from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
-    connection_details_task,
     gather_files_task,
-    transmit_data_task,
+    transmit_data_ftp_task,
     archive_transmitted_data_task,
 )
 
@@ -38,9 +37,7 @@ def send_west_records():
 
     gather_files = gather_files_task(vendor="west")
 
-    connection_details = connection_details_task()
-
-    transmit_data = transmit_data_task(connection_details)
+    transmit_data = transmit_data_ftp_task("west", gather_files)
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 


### PR DESCRIPTION
Closes #889

Http hook not working. Per mypy:
```
libsys_airflow/plugins/data_exports/transmission_tasks.py:43: error: Argument "data" to "run" of "HttpHook" has incompatible type
"bytes"; expected "dict[str, Any] | str | None"  [arg-type]
                hook.run(headers=connection.extra_dejson, data=marc_data)
```
