### PR TITLE
Changes OCLC Control Number Extract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage.xml
 refresh_vendors.log
 seed_vendors.log
 circ/
+data-export-files/
 dist/
 .python-version
 orafin-files/


### PR DESCRIPTION
Based on testing of OCLC API with sample records, we need to parse the OCLC number by ignoring the `(OCLC-I)` and removing the `ocm, ocn, and on` prefixes. This PR also removes any duplicate OCLC numbers.

(Also adds the `data-export-files` director to .gitignore)