### PR TITLE
New Options for scp to AP server

### DIFF
--- a/libsys_airflow/dags/orafin/payments_to_orafin.py
+++ b/libsys_airflow/dags/orafin/payments_to_orafin.py
@@ -62,4 +62,5 @@ with DAG(
         generate_file
         >> upload_status
         >> invoices_pending_payment_task(filtered_invoices["feed"])
+        >> email_summary_invoices
     )

--- a/libsys_airflow/plugins/orafin/payments.py
+++ b/libsys_airflow/plugins/orafin/payments.py
@@ -138,6 +138,8 @@ def transfer_to_orafin(feeder_file: str):
         "-i /opt/airflow/vendor-keys/apdrop.key",
         "-o KexAlgorithms=diffie-hellman-group14-sha1",
         "-o StrictHostKeyChecking=no",
+        "-o HostKeyAlgorithms=+ssh-rsa",
+        "-o PubkeyAcceptedAlgorithms=+ssh-rsa",
         str(feeder_file),
         "of_aplib@extxfer.stanford.edu:/home/of_aplib/OF1_PRD/inbound/data/xxdl_ap_lib.dat",
     ]

--- a/libsys_airflow/plugins/orafin/reports.py
+++ b/libsys_airflow/plugins/orafin/reports.py
@@ -22,6 +22,8 @@ ap_server_options = [
     "-i /opt/airflow/vendor-keys/apdrop.key",
     "-o KexAlgorithms=diffie-hellman-group14-sha1",
     "-o StrictHostKeyChecking=no",
+    "-o HostKeyAlgorithms=+ssh-rsa",
+    "-o PubkeyAcceptedAlgorithms=+ssh-rsa",
 ]
 
 


### PR DESCRIPTION
With last week's Airflow upgrade, the image's version of OpenSSH upgraded to 9.2p1 which caused our current scp configuration to fail. This PR adds additional flags to support the very old version of OpenSSH on the AP server. Also, added the `invoices_pending_payment_task` as an upstream dependency for the `email_summary_report` so email will only be generate and sent if everything is successful.