### PR TITLE
Fix for MARC 999 field, refactors method to module function 

### DIFF
--- a/libsys_airflow/plugins/data_exports/marc/oclc.py
+++ b/libsys_airflow/plugins/data_exports/marc/oclc.py
@@ -8,6 +8,32 @@ from libsys_airflow.plugins.data_exports.marc.transformer import Transformer
 logger = logging.getLogger(__name__)
 
 
+def get_record_id(record: pymarc.Record) -> list:
+    """
+    Extracts OCLC control number from 035 field
+    """
+    oclc_ids = set()
+    for field in record.get_fields("035"):
+        subfields_a = field.get_subfields("a")
+        for subfield in subfields_a:
+            # Skip Legacy OCLC Number
+            if subfield.startswith("(OCoLC-I)"):
+                continue
+            # Matches (OCoLC) and (OCoLC-M)
+            if subfield.startswith("(OCoLC"):
+                raw_oclc_number = subfield.split(")")[-1].strip()
+                if raw_oclc_number.startswith("ocm") or raw_oclc_number.startswith(
+                    "ocn"
+                ):
+                    oclc_number = raw_oclc_number[3:]
+                elif raw_oclc_number.startswith("on"):
+                    oclc_number = raw_oclc_number[2:]
+                else:
+                    oclc_number = raw_oclc_number
+                oclc_ids.add(oclc_number)
+    return list(oclc_ids)
+
+
 class OCLCTransformer(Transformer):
     def __init__(self):
         super().__init__()
@@ -18,7 +44,9 @@ class OCLCTransformer(Transformer):
         self.staff_notices = []
 
     def determine_campus_code(self, record: pymarc.Record):
-        instance_uuid = record["999"].get_subfields("i")[0]
+        fields999 = record.get_fields("999")
+        # FOLIO adds the 999 as the last field in the record
+        instance_uuid = fields999[-1].get_subfields("i")[0]
         holdings_result = self.folio_client.folio_get(
             f"/holdings-storage/holdings?query=(instanceId=={instance_uuid})"
         )
@@ -61,7 +89,7 @@ class OCLCTransformer(Transformer):
             if not i % 100:
                 logger.info(f"{i:,} records processed")
 
-            record_ids = self.get_record_id(record)
+            record_ids = get_record_id(record)
             campus_codes = self.determine_campus_code(record)
             for code in campus_codes:
                 match len(record_ids):

--- a/tests/data_exports/test_oclc.py
+++ b/tests/data_exports/test_oclc.py
@@ -3,7 +3,7 @@ import pytest
 
 from unittest.mock import MagicMock
 
-from libsys_airflow.plugins.data_exports.marc.oclc import OCLCTransformer
+from libsys_airflow.plugins.data_exports.marc.oclc import OCLCTransformer, get_record_id
 
 
 @pytest.fixture
@@ -359,8 +359,6 @@ def test_get_record_id(mocker, mock_folio_client):
         return_value=mock_folio_client,
     )
 
-    oclc_transformer = OCLCTransformer()
-
     record_oclc_i = pymarc.Record()
     record_oclc_i.add_field(
         pymarc.Field(
@@ -375,7 +373,7 @@ def test_get_record_id(mocker, mock_folio_client):
         ),
     )
 
-    oclc_no_i_ids = oclc_transformer.get_record_id(record_oclc_i)
+    oclc_no_i_ids = get_record_id(record_oclc_i)
     assert oclc_no_i_ids == ["38180605"]
 
     record_dup_and_prefixes = pymarc.Record()
@@ -397,6 +395,6 @@ def test_get_record_id(mocker, mock_folio_client):
         ),
     )
 
-    oclc_ids = oclc_transformer.get_record_id(record_dup_and_prefixes)
+    oclc_ids = get_record_id(record_dup_and_prefixes)
 
     assert oclc_ids == ["1427207959"]


### PR DESCRIPTION
The current MARC 999 field selection fails if there are more than one 999, for FOLIO MARC records we should use the last 999 field in the record. Also moves the `get_record_id` from a class method to a module function in order to use this function in PR #912.