### PR TITLE
Patch log config

### DIFF
--- a/log_config.py
+++ b/log_config.py
@@ -6,11 +6,6 @@ LOGGING_CONFIG = deep_update(
     deepcopy(DEFAULT_LOGGING_CONFIG),
     {
         "loggers": {
-            "airflow.providers.common.sql.hooks.sql": {
-                "handlers": ["task"],
-                "level": "WARN",
-                "propagate": True,
-            },
             "airflow.hooks.base": {
                 "handlers": ["task"],
                 "level": "WARN",

--- a/log_config.py
+++ b/log_config.py
@@ -6,7 +6,12 @@ LOGGING_CONFIG = deep_update(
     deepcopy(DEFAULT_LOGGING_CONFIG),
     {
         "loggers": {
-            "airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator": {
+            "airflow.providers.common.sql.hooks.sql": {
+                "handlers": ["task"],
+                "level": "WARN",
+                "propagate": True,
+            },
+            "airflow.hooks.base": {
                 "handlers": ["task"],
                 "level": "WARN",
                 "propagate": True,


### PR DESCRIPTION
Other airflow classes use `self.log` and not the logger class for logging, and do not seem to be overridable.