### PR TITLE
Handles inclusion of Remote Path in FTP filename

### DIFF
--- a/libsys_airflow/plugins/vendor/archive.py
+++ b/libsys_airflow/plugins/vendor/archive.py
@@ -1,5 +1,5 @@
 import logging
-import os
+import pathlib
 import shutil
 from datetime import date
 
@@ -60,7 +60,6 @@ def archive_file(
     )
     archive_filepath = _filepath(archive_path, vendor_file.vendor_filename)
     print(f"Archive path: {archive_filepath}")
-    os.makedirs(archive_path, exist_ok=True)
     shutil.copyfile(download_filepath, archive_filepath)
     vendor_file.archive_date = date.today()
     session.commit()
@@ -68,4 +67,7 @@ def archive_file(
 
 
 def _filepath(path: str, filename: str) -> str:
-    return os.path.join(path, filename)
+    full_filepath = pathlib.Path(path) / filename
+    if not full_filepath.parent.exists():
+        full_filepath.parent.mkdir(parents=True, exist_ok=True)
+    return str(full_filepath)

--- a/libsys_airflow/plugins/vendor/download.py
+++ b/libsys_airflow/plugins/vendor/download.py
@@ -195,7 +195,10 @@ def download(
 
 
 def _download_filepath(download_path: str, filename: str) -> str:
-    return str(pathlib.Path(download_path) / filename)
+    full_path = pathlib.Path(download_path) / filename
+    if not full_path.parent.exists():
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+    return str(full_path)
 
 
 def _record_vendor_file(

--- a/tests/vendor/test_download.py
+++ b/tests/vendor/test_download.py
@@ -7,6 +7,7 @@ from pytest_mock_resources import create_sqlite_fixture, Rows
 from libsys_airflow.plugins.vendor.download import (
     download,
     FTPAdapter,
+    _download_filepath,
     _regex_filter_strategy,
     _gobi_order_filter_strategy,
 )
@@ -263,3 +264,13 @@ def test_download_gobi_order(ftp_hook, download_path, pg_hook):
     assert ftp_hook.retrieve_file.called_with(
         "3820230411.ord", f"{download_path}/3820230411.ord"
     )
+
+
+def test_missing_parent_directories(tmp_path):
+    download_filepath = tmp_path / "Stanford/test.mrc"
+
+    assert not download_filepath.parent.exists()
+
+    _download_filepath(tmp_path, "Stanford/test.mrc")
+
+    assert download_filepath.parent.exists()


### PR DESCRIPTION
Fixes error in #944's [comment](https://github.com/sul-dlss/libsys-airflow/issues/944#issuecomment-2083488048).

Will want @ahafele to maybe test in either dev or stage first before merging and deploying to production just in case there are additional issues in other parts of either the VMA or data-export.