### PR TITLE
Fix queries for materialzed view

### DIFF
--- a/libsys_airflow/plugins/data_exports/full_dump_marc.py
+++ b/libsys_airflow/plugins/data_exports/full_dump_marc.py
@@ -55,7 +55,7 @@ def refresh_view(**kwargs) -> None:
     refresh = params.get("refresh_view", True)
 
     if refresh:
-        query = "refresh materialized view data_export_marc_ids"
+        query = "refresh materialized view data_export_marc"
 
         result = SQLExecuteQueryOperator(
             task_id="postgres_full_count_query",


### PR DESCRIPTION
To get unique records_lb  rows I found out about the sql `select distinct on`. From https://www.postgresql.org/docs/current/sql-select.html:

`SELECT DISTINCT ON ( expression [, ...] ) keeps only the first row of each set of rows where the given expressions evaluate to equal. The DISTINCT ON expressions are interpreted using the same rules as for ORDER BY... Note that the “first row” of each set is unpredictable unless ORDER BY is used to ensure that the desired row appears first.` 

I updated the query [on the folio-k8s wiki](https://github.com/sul-dlss/folio-k8s/wiki/Custom-Database-Indexes).