### PR TITLE
Adds send_all_records DAG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 log*
 !log_config.py
+.aws
 .env
 __pycache__/
 .coveralls.yml

--- a/README.md
+++ b/README.md
@@ -57,11 +57,19 @@ Based on the documentation, [Running Airflow in Docker](https://airflow.apache.o
 
   **NOTE** In order to connect to the OKAPI_URL you must be connected to the VPN or the on-campus network.
 
-6. Run `docker compose build` to build the customized Airflow image. (Note: the `usermod` command may take a while to complete when running the build.)
-7. Run `docker compose up airflow-init` to initialize the Airflow database and create a user the first time you deploy Airflow.
-8. Bring up Airflow, `docker compose up` to run the containers in the foreground. Use `docker compose up -d` to run as a daemon.
-9. Access Airflow locally at http://localhost:8080. The default username and password are both `airflow`.
-10. Log into the worker container using `docker exec -it libsys-airflow-airflow-worker-1 /bin/bash` to view the raw work files.
+6. Add a `.aws` directory with the config and credentials for the S3 bucket your want to use.
+  Example credentials
+  ```
+  [default]
+  aws_access_key_id = myaccess
+  aws_secret_access_key = mysecret
+  ```
+
+7. Run `docker compose build` to build the customized Airflow image. (Note: the `usermod` command may take a while to complete when running the build.)
+8. Run `docker compose up airflow-init` to initialize the Airflow database and create a user the first time you deploy Airflow.
+9. Bring up Airflow, `docker compose up` to run the containers in the foreground. Use `docker compose up -d` to run as a daemon.
+10. Access Airflow locally at http://localhost:8080. The default username and password are both `airflow`.
+11. Log into the worker container using `docker exec -it libsys-airflow-airflow-worker-1 /bin/bash` to view the raw work files.
 
 ### For FOLIO migration loads
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -100,7 +100,7 @@ x-airflow-common:
     - ${AIRFLOW_PROJ_DIR:-.}/vendor-keys:/opt/airflow/vendor-keys
     - ${AIRFLOW_PROJ_DIR:-.}/data-export-files:/opt/airflow/data-export-files
     - ${AIRFLOW_PROJ_DIR:-.}/orafin-files:/opt/airflow/orafin-files
-    - ${AIRFLOW_PROJ_DIR:-.}/.aws:/opt/airflow/.aws
+    - ${AIRFLOW_PROJ_DIR:-.}/.aws:/home/airflow/.aws
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:
     &airflow-common-depends-on

--- a/libsys_airflow/dags/data_exports/full_dump_transmission.py
+++ b/libsys_airflow/dags/data_exports/full_dump_transmission.py
@@ -1,0 +1,59 @@
+import logging
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag
+from airflow.models.param import Param
+from airflow.models import Variable
+from airflow.operators.empty import EmptyOperator
+
+from libsys_airflow.plugins.data_exports.transmission_tasks import (
+    gather_files_task,
+    transmit_data_http_task,
+)
+
+logger = logging.getLogger(__name__)
+
+default_args = {
+    "owner": "libsys",
+    "depends_on_past": False,
+    "email_on_failure": True,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+}
+
+
+@dag(
+    default_args=default_args,
+    schedule=None,
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    tags=["data export"],
+    params={
+        "vendor": Param(
+            "pod",
+            type="string",
+            description="Send all records to this vendor.",
+            enum=["pod", "sharevde"],
+        ),
+        "bucket": Param(
+            Variable.get("FOLIO_AWS_BUCKET", "folio-data-export-prod"), type="string"
+        ),
+    },
+)
+def send_all_records():
+    start = EmptyOperator(task_id="start")
+
+    end = EmptyOperator(task_id="end")
+
+    gather_files = gather_files_task(vendor="full-dump")
+
+    transmit_data = transmit_data_http_task(
+        gather_files,
+        files_params="upload[files][]",
+    )
+
+    start >> gather_files >> transmit_data >> end
+
+
+send_all_records()

--- a/libsys_airflow/dags/data_exports/pod_transmission.py
+++ b/libsys_airflow/dags/data_exports/pod_transmission.py
@@ -38,8 +38,8 @@ def send_pod_records():
     gather_files = gather_files_task(vendor="pod")
 
     transmit_data = transmit_data_http_task(
-        "pod",
         gather_files,
+        params={"vendor": "pod"},
         files_params="upload[files][]",
     )
 

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -27,8 +27,14 @@ def gather_files_task(**kwargs) -> dict:
     else:
         marc_filepath = Path(airflow) / f"data-export-files/{vendor}/marc-files/"
 
+    marc_filelist = []
+    for f in marc_filepath.glob("*.mrc"):
+        if f.stat().st_size == 0:
+            continue
+        marc_filelist.append(str(f))
+
     return {
-        "file_list": [str(p) for p in marc_filepath.glob("*.mrc")],
+        "file_list": marc_filelist,
         "s3": bool(bucket),
     }
 

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -37,9 +37,11 @@ def mock_marc_files(mock_file_system):
         "marc_files": ["2024022914.mrc", "2024030114.mrc", "2024030214.mrc"]
     }
     marc_files = []
-    for x in setup_marc_files['marc_files']:
+    for i, x in enumerate(setup_marc_files['marc_files']):
         marc_file = pathlib.Path(f"{marc_file_dir}/{x}")
         marc_file.touch()
+        if i == 0:
+            marc_file.write_text("hello world")
         marc_files.append(str(marc_file))
 
     return {"file_list": marc_files, "s3": False}
@@ -75,7 +77,7 @@ def mock_httpx_failure():
 def test_gather_files_task(mock_file_system, mock_marc_files):
     airflow = mock_file_system[0]
     marc_files = gather_files_task.function(airflow=airflow, vendor="oclc")
-    assert marc_files["file_list"].sort() == mock_marc_files["file_list"].sort()
+    assert marc_files["file_list"][0] == mock_marc_files["file_list"][0]
 
 
 def test_gather_full_dump_files(mocker):

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -6,6 +6,8 @@ from http import HTTPStatus
 
 from airflow.models import Connection
 
+import libsys_airflow.plugins.data_exports.transmission_tasks as transmission_tasks
+
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
     gather_files_task,
     transmit_data_http_task,
@@ -29,18 +31,18 @@ def mock_file_system(tmp_path):
 
 # Mock xcom messages dict
 @pytest.fixture
-def mock_marc_file_list(mock_file_system):
+def mock_marc_files(mock_file_system):
     marc_file_dir = mock_file_system[1]
     setup_marc_files = {
-        "marc_file_list": ["2024022914.mrc", "2024030114.mrc", "2024030214.mrc"]
+        "marc_files": ["2024022914.mrc", "2024030114.mrc", "2024030214.mrc"]
     }
-    marc_file_list = []
-    for x in setup_marc_files['marc_file_list']:
+    marc_files = []
+    for x in setup_marc_files['marc_files']:
         marc_file = pathlib.Path(f"{marc_file_dir}/{x}")
         marc_file.touch()
-        marc_file_list.append(str(marc_file))
+        marc_files.append(str(marc_file))
 
-    return marc_file_list
+    return {"file_list": marc_files, "s3": False}
 
 
 @pytest.fixture
@@ -70,14 +72,22 @@ def mock_httpx_failure():
     )
 
 
-def test_gather_files_task(mock_file_system, mock_marc_file_list):
+def test_gather_files_task(mock_file_system, mock_marc_files):
     airflow = mock_file_system[0]
-    marc_file_list = gather_files_task.function(airflow=airflow, vendor="oclc")
-    assert marc_file_list.sort() == mock_marc_file_list.sort()
+    marc_files = gather_files_task.function(airflow=airflow, vendor="oclc")
+    assert marc_files["file_list"].sort() == mock_marc_files["file_list"].sort()
+
+
+def test_gather_full_dump_files(mocker):
+    mocker.patch.object(transmission_tasks, "S3Path", pathlib.Path)
+    marc_files = gather_files_task.function(
+        vendor="full-dump", params={"bucket": "data-export-test"}
+    )
+    assert marc_files["s3"]
 
 
 def test_transmit_data_task(
-    mocker, mock_httpx_connection, mock_httpx_success, mock_marc_file_list
+    mocker, mock_httpx_connection, mock_httpx_success, mock_marc_files, caplog
 ):
     mocker.patch(
         "libsys_airflow.plugins.data_exports.transmission_tasks.httpx.Client",
@@ -88,15 +98,35 @@ def test_transmit_data_task(
         return_value=mock_httpx_connection,
     )
     transmit_data = transmit_data_http_task.function(
-        "vendor",
-        mock_marc_file_list,
-        files_params="upload[files][]",
+        mock_marc_files, files_params="upload[files][]", params={"vendor": "pod"}
     )
     assert len(transmit_data["success"]) == 3
+    assert "Transmit data to pod" in caplog.text
+
+
+def test_transmit_data_from_s3_task(
+    mocker, mock_httpx_connection, mock_httpx_success, mock_marc_files, caplog
+):
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.transmission_tasks.httpx.Client",
+        return_value=mock_httpx_success,
+    )
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.transmission_tasks.Connection.get_connection_from_secrets",
+        return_value=mock_httpx_connection,
+    )
+    mocker.patch.object(transmission_tasks, "S3Path", pathlib.Path)
+    mock_marc_files["s3"] = True
+    transmit_data_from_s3 = transmit_data_http_task.function(
+        mock_marc_files,
+        files_params="upload[files][]",
+        params={"vendor": "pod", "bucket": "data-export-test"},
+    )
+    assert len(transmit_data_from_s3["success"]) == 3
 
 
 def test_transmit_data_failed(
-    mocker, mock_httpx_connection, mock_httpx_failure, mock_marc_file_list
+    mocker, mock_httpx_connection, mock_httpx_failure, mock_marc_files, caplog
 ):
     mocker.patch(
         "libsys_airflow.plugins.data_exports.transmission_tasks.httpx.Client",
@@ -107,16 +137,18 @@ def test_transmit_data_failed(
         return_value=mock_httpx_connection,
     )
     transmit_data = transmit_data_http_task.function(
-        "vendor",
-        mock_marc_file_list,
+        mock_marc_files,
+        params={"vendor": "pod"},
     )
     assert len(transmit_data["failures"]) == 3
+    assert "Transmit data to pod" in caplog.text
 
 
-def test_archive_transmitted_data_task(mock_file_system, mock_marc_file_list):
+def test_archive_transmitted_data_task(mock_file_system, mock_marc_files):
     instance_id_dir = mock_file_system[2]
     instance_id_file1 = instance_id_dir / "2024022914.csv"
     instance_id_file1.touch()
+    mock_marc_file_list = mock_marc_files["file_list"]
     archive_transmitted_data_task.function(mock_marc_file_list)
     assert not instance_id_file1.exists()
     transmitted_dir = mock_file_system[-1]


### PR DESCRIPTION
Closes #898 

Refactors transmission tasks to use either S3 or filesystem.
Adds new DAG to send_all_records (full dump), getting files from S3.
Updates pod DAG to call transmission task with params.
Ensures 0 byte files are not transmitted.