### PR TITLE
Removes triggering transmission DAGs at end of selection DAGs.

### DIFF
--- a/libsys_airflow/dags/data_exports/google_selections.py
+++ b/libsys_airflow/dags/data_exports/google_selections.py
@@ -5,7 +5,6 @@ from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.models import Variable
 from airflow.operators.python import PythonOperator
-from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 from libsys_airflow.plugins.data_exports.instance_ids import (
     fetch_record_ids,
@@ -82,12 +81,6 @@ with DAG(
         },
     )
 
-    send_to_vendor = TriggerDagRunOperator(
-        task_id="send_google_records",
-        trigger_dag_id="send_google_records",
-        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
-    )
-
     finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
@@ -95,4 +88,4 @@ with DAG(
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
 fetch_marc_records >> transform_marc_record >> transform_marc_fields
-transform_marc_fields >> send_to_vendor >> finish_processing_marc
+transform_marc_fields >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/hathi_selections.py
+++ b/libsys_airflow/dags/data_exports/hathi_selections.py
@@ -5,7 +5,6 @@ from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.models import Variable
 from airflow.operators.python import PythonOperator
-from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 from libsys_airflow.plugins.data_exports.instance_ids import (
     fetch_record_ids,
@@ -82,12 +81,6 @@ with DAG(
         },
     )
 
-    send_to_vendor = TriggerDagRunOperator(
-        task_id="send_hathi_records",
-        trigger_dag_id="send_hathi_records",
-        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
-    )
-
     finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
@@ -95,4 +88,4 @@ with DAG(
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
 fetch_marc_records >> transform_marc_record >> transform_marc_fields
-transform_marc_fields >> send_to_vendor >> finish_processing_marc
+transform_marc_fields >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/nielsen_selections.py
+++ b/libsys_airflow/dags/data_exports/nielsen_selections.py
@@ -5,7 +5,6 @@ from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.models import Variable
 from airflow.operators.python import PythonOperator
-from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 from libsys_airflow.plugins.data_exports.instance_ids import (
     fetch_record_ids,
@@ -82,12 +81,6 @@ with DAG(
         },
     )
 
-    send_to_vendor = TriggerDagRunOperator(
-        task_id="send_nielson_records",
-        trigger_dag_id="send_nielson_records",
-        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
-    )
-
     finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
@@ -95,4 +88,4 @@ with DAG(
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
 fetch_marc_records >> transform_marc_record >> transform_marc_fields
-transform_marc_fields >> send_to_vendor >> finish_processing_marc
+transform_marc_fields >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/pod_selections.py
+++ b/libsys_airflow/dags/data_exports/pod_selections.py
@@ -5,7 +5,6 @@ from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.models import Variable
 from airflow.operators.python import PythonOperator
-from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 from libsys_airflow.plugins.data_exports.instance_ids import (
     fetch_record_ids,
@@ -84,12 +83,6 @@ with DAG(
         },
     )
 
-    send_to_vendor = TriggerDagRunOperator(
-        task_id="send_pod_records",
-        trigger_dag_id="send_pod_records",
-        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
-    )
-
     finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
@@ -97,4 +90,4 @@ with DAG(
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
 fetch_marc_records >> transform_marc_record >> transform_marc_fields
-transform_marc_fields >> send_to_vendor >> finish_processing_marc
+transform_marc_fields >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/sharevde_selections.py
+++ b/libsys_airflow/dags/data_exports/sharevde_selections.py
@@ -5,7 +5,6 @@ from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.models import Variable
 from airflow.operators.python import PythonOperator
-from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 from libsys_airflow.plugins.data_exports.instance_ids import (
     fetch_record_ids,
@@ -82,12 +81,6 @@ with DAG(
         },
     )
 
-    send_to_vendor = TriggerDagRunOperator(
-        task_id="send_sharevde_records",
-        trigger_dag_id="send_sharevde_records",
-        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
-    )
-
     finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
@@ -95,4 +88,4 @@ with DAG(
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
 fetch_marc_records >> transform_marc_record >> transform_marc_fields
-transform_marc_fields >> send_to_vendor >> finish_processing_marc
+transform_marc_fields >> finish_processing_marc

--- a/libsys_airflow/dags/data_exports/west_selections.py
+++ b/libsys_airflow/dags/data_exports/west_selections.py
@@ -5,7 +5,6 @@ from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.models import Variable
 from airflow.operators.python import PythonOperator
-from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 from libsys_airflow.plugins.data_exports.instance_ids import (
     fetch_record_ids,
@@ -82,12 +81,6 @@ with DAG(
         },
     )
 
-    send_to_vendor = TriggerDagRunOperator(
-        task_id="send_west_records",
-        trigger_dag_id="send_west_records",
-        conf={"marc_file_list": "{{ ti.xcom_pull('tbd') }}"},
-    )
-
     finish_processing_marc = EmptyOperator(
         task_id="finish_marc",
     )
@@ -95,4 +88,4 @@ with DAG(
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
 fetch_marc_records >> transform_marc_record >> transform_marc_fields
-transform_marc_fields >> send_to_vendor >> finish_processing_marc
+transform_marc_fields >> finish_processing_marc


### PR DESCRIPTION
I think we want to keep transmission and selection separated so we have control over running the selections but not sending the files. The transmission DAGs will use any files in the marc-files directories for each vendor and do not use xcom to get a list of files created by the selection DAGs.

I didn't update the OCLC and gobi selections DAGs since those are undergoing changes in other branches.