### PR TITLE
Filters out remote path if found in Filename

### DIFF
--- a/tests/vendor/test_download.py
+++ b/tests/vendor/test_download.py
@@ -7,6 +7,7 @@ from pytest_mock_resources import create_sqlite_fixture, Rows
 from libsys_airflow.plugins.vendor.download import (
     download,
     FTPAdapter,
+    _filter_remote_path,
     _regex_filter_strategy,
     _gobi_order_filter_strategy,
 )
@@ -102,7 +103,7 @@ def test_ftp_download(ftp_hook, download_path, pg_hook):
         ftp_hook,
         "oclc",
         download_path,
-        _regex_filter_strategy(r".+\.mrc"),
+        _regex_filter_strategy(r".+\.mrc", ""),
         "65d30c15-a560-4064-be92-f90e38eeb351",
         datetime.fromisoformat("2020-01-01T00:05:23"),
     )
@@ -187,7 +188,7 @@ def test_sftp_download(sftp_hook, download_path, pg_hook):
         sftp_hook,
         "oclc",
         download_path,
-        _regex_filter_strategy(r".+\.mrc"),
+        _regex_filter_strategy(r".+\.mrc", ""),
         "65d30c15-a560-4064-be92-f90e38eeb351",
         datetime.fromisoformat("2020-01-01T00:05:23"),
     )
@@ -219,7 +220,7 @@ def test_download_error(ftp_hook, download_path, pg_hook):
             ftp_hook,
             "oclc",
             download_path,
-            _regex_filter_strategy(r".+\.mrc"),
+            _regex_filter_strategy(r".+\.mrc", ""),
             "65d30c15-a560-4064-be92-f90e38eeb351",
             datetime.fromisoformat("2020-01-01T00:05:23"),
         )
@@ -263,3 +264,9 @@ def test_download_gobi_order(ftp_hook, download_path, pg_hook):
     assert ftp_hook.retrieve_file.called_with(
         "3820230411.ord", f"{download_path}/3820230411.ord"
     )
+
+
+def test_filter_remote_path():
+    filename = "Stanford/ST26673.mrc"
+    filtered_filename = _filter_remote_path(filename, "Stanford")
+    assert filtered_filename == "ST26673.mrc"


### PR DESCRIPTION
Better Fixes #944 

Unlike PR #948, does not required any changes to the Interface's File Pattern and address @ahafele concern in [comment](https://github.com/sul-dlss/libsys-airflow/pull/948#issuecomment-2090976782) about previously fetched files be fetched again if the Remote path is part of the filename. 

@ahafele, I just deployed this branch libsys-stage for testing and changed the regex for interface https://sul-libsys-airflow-stage.stanford.edu/vendor_management/interfaces/139 back to it's original one for you to test next week.