### PR TITLE
Do not write empty csv instanceid file when sql query returns zero rows

### DIFF
--- a/libsys_airflow/plugins/data_exports/instance_ids.py
+++ b/libsys_airflow/plugins/data_exports/instance_ids.py
@@ -70,7 +70,7 @@ def save_ids(**kwargs) -> str:
     kind = kwargs.get("kind")
 
     if not data:
-        return
+        return ""
 
     data_path = (
         Path(airflow) / f"data-export-files/{vendor}/instanceids/{kind}/{filestamp}.csv"

--- a/libsys_airflow/plugins/data_exports/instance_ids.py
+++ b/libsys_airflow/plugins/data_exports/instance_ids.py
@@ -70,7 +70,7 @@ def save_ids(**kwargs) -> str:
     kind = kwargs.get("kind")
 
     if not data:
-        return ""
+        return  # type: ignore
 
     data_path = (
         Path(airflow) / f"data-export-files/{vendor}/instanceids/{kind}/{filestamp}.csv"

--- a/libsys_airflow/plugins/data_exports/instance_ids.py
+++ b/libsys_airflow/plugins/data_exports/instance_ids.py
@@ -66,8 +66,11 @@ def save_ids(**kwargs) -> str:
     filestamp = kwargs.get("timestamp", datetime.now().strftime('%Y%m%d%H%M'))
     airflow = kwargs.get("airflow", "/opt/airflow")
     vendor = kwargs.get("vendor")
-    data = kwargs.get("data", "")
+    data = kwargs.get("data")
     kind = kwargs.get("kind")
+
+    if not data:
+        return
 
     data_path = (
         Path(airflow) / f"data-export-files/{vendor}/instanceids/{kind}/{filestamp}.csv"


### PR DESCRIPTION
Opening posix path for write with no data still creates an empty file. Adding guard clause to return early if no data is present.