### PR TITLE
Use correct type checking and log warning instead of raising error

### DIFF
--- a/libsys_airflow/plugins/data_exports/apps/data_export_upload_view.py
+++ b/libsys_airflow/plugins/data_exports/apps/data_export_upload_view.py
@@ -5,6 +5,7 @@ import re
 
 from flask import flash, request
 from flask_appbuilder import expose, BaseView as AppBuilderBaseView
+from typing import Union
 
 from libsys_airflow.plugins.data_exports.instance_ids import save_ids
 
@@ -14,7 +15,7 @@ vendor_file = open(parent / "vendors.json")
 vendors = json.load(vendor_file)
 
 
-def upload_data_export_ids(ids_df: pd.DataFrame, vendor: str, kind: str) -> str:
+def upload_data_export_ids(ids_df: pd.DataFrame, vendor: str, kind: str) -> Union[str, None]:
     if len(ids_df.columns) > 1:
         raise ValueError("ID file has more than one column.")
     tuples = list(ids_df.itertuples(index=False, name=None))

--- a/libsys_airflow/plugins/data_exports/apps/data_export_upload_view.py
+++ b/libsys_airflow/plugins/data_exports/apps/data_export_upload_view.py
@@ -15,7 +15,9 @@ vendor_file = open(parent / "vendors.json")
 vendors = json.load(vendor_file)
 
 
-def upload_data_export_ids(ids_df: pd.DataFrame, vendor: str, kind: str) -> Union[str, None]:
+def upload_data_export_ids(
+    ids_df: pd.DataFrame, vendor: str, kind: str
+) -> Union[str, None]:
     if len(ids_df.columns) > 1:
         raise ValueError("ID file has more than one column.")
     tuples = list(ids_df.itertuples(index=False, name=None))

--- a/libsys_airflow/plugins/data_exports/instance_ids.py
+++ b/libsys_airflow/plugins/data_exports/instance_ids.py
@@ -1,6 +1,7 @@
 import csv
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Union
 
 from airflow.operators.python import get_current_context
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
@@ -48,7 +49,7 @@ def sql_files(**kwargs) -> list:
     return list(sql_path.glob("*.sql"))
 
 
-def save_ids_to_fs(**kwargs) -> list[str]:
+def save_ids_to_fs(**kwargs) -> list[Union[str, None]]:
     ids_path = []
     airflow = kwargs.get("airflow", "/opt/airflow")
     task_instance = kwargs["task_instance"]
@@ -62,7 +63,7 @@ def save_ids_to_fs(**kwargs) -> list[str]:
     return ids_path
 
 
-def save_ids(**kwargs) -> str:
+def save_ids(**kwargs) -> Union[str, None]:
     filestamp = kwargs.get("timestamp", datetime.now().strftime('%Y%m%d%H%M'))
     airflow = kwargs.get("airflow", "/opt/airflow")
     vendor = kwargs.get("vendor")
@@ -70,7 +71,7 @@ def save_ids(**kwargs) -> str:
     kind = kwargs.get("kind")
 
     if not data:
-        return  # type: ignore
+        return None
 
     data_path = (
         Path(airflow) / f"data-export-files/{vendor}/instanceids/{kind}/{filestamp}.csv"

--- a/libsys_airflow/plugins/data_exports/marc/exports.py
+++ b/libsys_airflow/plugins/data_exports/marc/exports.py
@@ -1,5 +1,8 @@
+import logging
 import pathlib
 from libsys_airflow.plugins.data_exports.marc.exporter import Exporter
+
+logger = logging.getLogger(__name__)
 
 
 def instance_files_dir(**kwargs) -> list[pathlib.Path]:
@@ -15,7 +18,7 @@ def instance_files_dir(**kwargs) -> list[pathlib.Path]:
     instance_files = list(instance_dir.glob("*.csv"))
 
     if not instance_files:
-        raise ValueError("Vendor instance files do not exist")
+        logger.warning(f"Vendor instance files do not exist for {kind}")
 
     return instance_files
 

--- a/tests/data_exports/test_marc_exports.py
+++ b/tests/data_exports/test_marc_exports.py
@@ -185,11 +185,12 @@ def test_retrieve_marc_for_instance_404(mocker, mock_folio_404, tmp_path, caplog
     assert "response code 404" in caplog.text
 
 
-def test_fetch_marc_missing_instance_file(tmp_path):
+def test_fetch_marc_missing_instance_file(tmp_path, caplog):
     setup_test_file_updates(tmp_path)
 
-    with pytest.raises(ValueError, match="Vendor instance files do not exist"):
-        instance_files_dir(airflow=tmp_path, vendor="gobi")
+    instance_files_dir(airflow=tmp_path, vendor="gobi")
+
+    assert "Vendor instance files do not exist" in caplog.text
 
 
 def test_marc_for_instances(mocker, tmp_path, mock_folio_client):


### PR DESCRIPTION
When there are no updates and deletes, do not raise exception, just log a warning.