### PR TITLE
Deduplicate uuids fetched from sql and handle absent uuids in 999

### DIFF
--- a/libsys_airflow/plugins/data_exports/instance_ids.py
+++ b/libsys_airflow/plugins/data_exports/instance_ids.py
@@ -1,5 +1,5 @@
-import csv
 import logging
+import numpy as np
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Union
@@ -39,6 +39,8 @@ def fetch_record_ids(**kwargs) -> dict:
                     },
                 ).execute(context)
             )
+
+        results[kind] = list(np.unique(results[kind]))
 
     return results
 
@@ -83,9 +85,7 @@ def save_ids(**kwargs) -> Union[str, None]:
     data_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(data_path, 'w') as f:
-        writer = csv.writer(f, lineterminator='\n')
         for id in data:
-            if id:
-                writer.writerow(id)
+            f.write(f"{id}\n")
 
     return str(data_path)

--- a/tests/data_exports/test_save_instance_ids.py
+++ b/tests/data_exports/test_save_instance_ids.py
@@ -1,4 +1,3 @@
-import csv
 import pandas as pd
 import pathlib
 import pytest
@@ -23,20 +22,12 @@ def mock_task_instance():
 def mock_xcom_pull(**kwargs):
     return {
         "updates": [
-            [],
-            [
-                ['4e66ce0d-4a1d-41dc-8b35-0914df20c7fb'],
-                ['fe2e581f-9767-442a-ae3c-a421ac655fe2'],
-            ],
-            [],
+            '4e66ce0d-4a1d-41dc-8b35-0914df20c7fb',
+            'fe2e581f-9767-442a-ae3c-a421ac655fe2',
         ],
         "deletes": [
-            [],
-            [
-                ['336971cd-2ea1-4ad2-af86-22ae7c0a95ae'],
-                ['4e66ce0d-4a1d-41dc-8b35-0914df20c7fb'],
-            ],
-            [],
+            '336971cd-2ea1-4ad2-af86-22ae7c0a95ae',
+            '4e66ce0d-4a1d-41dc-8b35-0914df20c7fb',
         ],
     }
 
@@ -46,14 +37,20 @@ def test_save_ids_to_fs(tmp_path, mock_task_instance):
         airflow=tmp_path, task_instance=mock_task_instance, vendor="oclc"
     )
 
+    file_list = []
     for i, path in enumerate(save_path):
         file = pathlib.Path(path)
         assert file.exists()
-
         with file.open('r') as fo:
-            id_list = list(row for row in csv.reader(fo))
+            for row in fo:
+                file_list.append(row)
 
-        assert id_list[0][i] == "['4e66ce0d-4a1d-41dc-8b35-0914df20c7fb']"
+    assert file_list == [
+        '4e66ce0d-4a1d-41dc-8b35-0914df20c7fb\n',
+        'fe2e581f-9767-442a-ae3c-a421ac655fe2\n',
+        '336971cd-2ea1-4ad2-af86-22ae7c0a95ae\n',
+        '4e66ce0d-4a1d-41dc-8b35-0914df20c7fb\n',
+    ]
 
 
 def test_upload_data_export_file_ids_one_column():


### PR DESCRIPTION
We discovered that some records already had 999 fields without subfield I, and the code was just looking for the first 999 field and silently skipping the block when no subfield I was present. This change checks all of the 999 fields for uuids and raises an excepted exception if none are found.

Also de-duplicate any uuids fetched via SQL for updates and deletes.