### PR TITLE
Updated record SQL does not need to look at columns: generation or ACTUAL 

### DIFF
--- a/libsys_airflow/plugins/data_exports/sql/updates/marc_instance_updated.sql
+++ b/libsys_airflow/plugins/data_exports/sql/updates/marc_instance_updated.sql
@@ -4,7 +4,6 @@ where id in (
   select external_id
   from sul_mod_source_record_storage.records_lb
   where record_type = 'MARC_BIB'
-  and generation > 0
   and state = 'ACTUAL'
 )
 and (jsonb->>'statusId')::uuid in (
@@ -14,4 +13,4 @@ and (jsonb->>'statusId')::uuid in (
 )
 and jsonb->'metadata'->>'updatedDate' between %(from_date)s and %(to_date)s
 and jsonb->>'catalogedDate' similar to '\d{4}-\d{2}-\d{2}'
-and (jsonb->>'discoverySuppress')::boolean is false)  
+and (jsonb->>'discoverySuppress')::boolean is false)

--- a/libsys_airflow/plugins/data_exports/sql/updates/marc_instance_updated.sql
+++ b/libsys_airflow/plugins/data_exports/sql/updates/marc_instance_updated.sql
@@ -1,10 +1,9 @@
 (select id
 from sul_mod_inventory_storage.instance
 where id in (
-  select external_id
+  select distinct(external_id)
   from sul_mod_source_record_storage.records_lb
   where record_type = 'MARC_BIB'
-  and state = 'ACTUAL'
 )
 and (jsonb->>'statusId')::uuid in (
   select id


### PR DESCRIPTION
the SQL was still not correct after the last change of looking for the updatedDate from the instance record. We needed to stop looking for a "marc generation of greater then 0" because in these cases the marc record was not updated at all.