### PR TITLE
Lookup campuses, check before adding to gobi export list

### DIFF
--- a/libsys_airflow/plugins/data_exports/marc/gobi.py
+++ b/libsys_airflow/plugins/data_exports/marc/gobi.py
@@ -74,10 +74,10 @@ class GobiTransformer(Transformer):
                     for holding in holdings_result['holdingsRecords']:
                         ebook = False
 
-                        library = self.campus_lookup.get(
+                        campus = self.campus_lookup.get(
                             holding.get('permanentLocationId')
                         )
-                        if not library == 'SUL':
+                        if not campus == 'SUL':
                             continue
 
                         if len(holding.get("holdingsTypeId", "")) > 0:

--- a/libsys_airflow/plugins/data_exports/marc/gobi.py
+++ b/libsys_airflow/plugins/data_exports/marc/gobi.py
@@ -74,6 +74,12 @@ class GobiTransformer(Transformer):
                     for holding in holdings_result['holdingsRecords']:
                         ebook = False
 
+                        library = self.campus_lookup.get(
+                            holding.get('permanentLocationId')
+                        )
+                        if not library == 'SUL':
+                            continue
+
                         if len(holding.get("holdingsTypeId", "")) > 0:
                             if (
                                 self.holdings_type.get(holding["holdingsTypeId"])

--- a/libsys_airflow/plugins/data_exports/marc/transformer.py
+++ b/libsys_airflow/plugins/data_exports/marc/transformer.py
@@ -19,7 +19,8 @@ class Transformer(object):
         self.holdings_type = self.holdings_type_lookup()
         self.locations = self.locations_lookup()
         self.materialtypes = self.materialtype_lookup()
-        self.library_lookup = self.locations_by_library_lookup()
+        self.library_lookup = self.library_by_locations_lookup()
+        self.campus_lookup = self.campus_by_locations_lookup()
 
     def call_number_lookup(self) -> dict:
         lookup = {}
@@ -48,7 +49,17 @@ class Transformer(object):
             lookup[m['id']] = m['name']
         return lookup
 
-    def locations_by_library_lookup(self) -> dict:
+    def campus_by_locations_lookup(self) -> dict:
+        lookup = {}
+        campus_result = self.folio_client.folio_get("/location-units/campuses")
+        campus_lookup = {}
+        for campus in campus_result.get("loccamps"):
+            campus_lookup[campus['id']] = campus["code"]
+        for location in self.folio_client.locations:
+            lookup[location['id']] = campus_lookup.get(location['campusId'])
+        return lookup
+
+    def library_by_locations_lookup(self) -> dict:
         lookup = {}
         libraries_result = self.folio_client.folio_get(
             "/location-units/libraries?limit=1000"

--- a/tests/data_exports/test_marc_transformations.py
+++ b/tests/data_exports/test_marc_transformations.py
@@ -152,18 +152,21 @@ def mock_folio_client():
             'id': 'bffa197c-a6db-446c-96f7-e1fd37a8842e',
             'name': 'Business Newspaper Stacks',
             'code': 'BUS-NEWS-STKS',
+            "campusId": "b89563c5-cb66-4de7-b63c-ca4d82e9d856",
             'libraryId': 'f5c58187-3db6-4bda-b1bf-e5f0717e2149',
         },
         {
             'id': 'a8676073-7520-4f26-8573-55976301ab5d',
             'name': 'Green Flat Folios',
             'code': 'GRE-FOLIO-FLAT',
+            "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
             'libraryId': 'f6b5519e-88d9-413e-924d-9ed96255f72e',
         },
         {
             'id': 'b0a1a8c3-cc9a-487c-a2ed-308fc3a49a91',
             'name': 'SUL Electronic',
             'code': 'SUL-ELECTRONIC',
+            "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
             'libraryId': 'c1a86906-ced0-46cb-8f5b-8cef542bdd00',
         },
     ]
@@ -179,6 +182,9 @@ def mock_folio_client():
             {"id": "5b2c8449-eed6-4bd3-bcef-af1e5a225400", "code": "LANE"},
             {"id": "7e4c05e3-1ce6-427d-b9ce-03464245cd78", "code": "LAW"},
             {"id": 'c1a86906-ced0-46cb-8f5b-8cef542bdd00', "code": 'SUL'},
+        ],
+        "loccamps": [
+            {"id": "c365047a-51f2-45ce-8601-e421ca3615c5", "code": "SUL"},
         ],
     }
 

--- a/tests/data_exports/test_oclc.py
+++ b/tests/data_exports/test_oclc.py
@@ -87,12 +87,36 @@ def mock_folio_client():
         if args[0].startswith("/location-units/libraries"):
             return {
                 "loclibs": [
-                    {"id": 'f5c58187-3db6-4bda-b1bf-e5f0717e2149', "code": 'BUSINESS'},
-                    {"id": "f6b5519e-88d9-413e-924d-9ed96255f72e", "code": "GREEN"},
-                    {"id": "ffe6ea8e-1e14-482f-b3e9-66e05efb04dd", "code": "HILA"},
-                    {"id": "5b2c8449-eed6-4bd3-bcef-af1e5a225400", "code": "LANE"},
-                    {"id": "7e4c05e3-1ce6-427d-b9ce-03464245cd78", "code": "LAW"},
-                    {"id": 'c1a86906-ced0-46cb-8f5b-8cef542bdd00', "code": 'SUL'},
+                    {
+                        "id": 'f5c58187-3db6-4bda-b1bf-e5f0717e2149',
+                        "campusId": "b89563c5-cb66-4de7-b63c-ca4d82e9d856",
+                        "code": 'BUSINESS',
+                    },
+                    {
+                        "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+                        "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                        "code": "GREEN",
+                    },
+                    {
+                        "id": "ffe6ea8e-1e14-482f-b3e9-66e05efb04dd",
+                        "campusId": "be6468b8-ed88-4876-93fe-5bdac764959c",
+                        "code": "HILA",
+                    },
+                    {
+                        "id": "5b2c8449-eed6-4bd3-bcef-af1e5a225400",
+                        "campusId": "40b76104-95ea-4360-a2be-5fd887222e2d",
+                        "code": "LANE",
+                    },
+                    {
+                        "id": "7e4c05e3-1ce6-427d-b9ce-03464245cd78",
+                        "campusId": "7003123d-ef65-45f6-b469-d2b9839e1bb3",
+                        "code": "LAW",
+                    },
+                    {
+                        "id": 'c1a86906-ced0-46cb-8f5b-8cef542bdd00',
+                        "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                        "code": 'SUL',
+                    },
                 ]
             }
         # Material types
@@ -106,42 +130,55 @@ def mock_folio_client():
                     {"id": "1a54b431-2e4f-452d-9cae-9cee66c9a892", "name": "book"},
                 ]
             }
+        # Campuses
+        if args[0].startswith("/location-units/campuses"):
+            return {
+                "loccamps": [
+                    {"id": "c365047a-51f2-45ce-8601-e421ca3615c5", "code": "SUL"},
+                ],
+            }
 
     mock_locations = [
         {
             'id': 'bffa197c-a6db-446c-96f7-e1fd37a8842e',
             'name': 'Business Newspaper Stacks',
             'code': 'BUS-NEWS-STKS',
+            "campusId": "b89563c5-cb66-4de7-b63c-ca4d82e9d856",
             'libraryId': 'f5c58187-3db6-4bda-b1bf-e5f0717e2149',
         },
         {
             'id': 'a8676073-7520-4f26-8573-55976301ab5d',
             'name': 'Green Flat Folios',
             'code': 'GRE-FOLIO-FLAT',
+            "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
             'libraryId': 'f6b5519e-88d9-413e-924d-9ed96255f72e',
         },
         {
             'id': 'c9cef3c6-5874-4bae-b90b-2e1d1f4674db',
             'name': 'HILA Stacks',
             'code': 'HILA-STACKS',
+            "campusId": "be6468b8-ed88-4876-93fe-5bdac764959c",
             'libraryId': 'ffe6ea8e-1e14-482f-b3e9-66e05efb04dd',
         },
         {
             'id': '5ffcbe91-775f-484e-91a2-e5473ff6c915',
             'name': 'Lane New Books',
             'code': 'LANE-NEWB',
+            "campusId": "40b76104-95ea-4360-a2be-5fd887222e2d",
             'libraryId': '5b2c8449-eed6-4bd3-bcef-af1e5a225400',
         },
         {
             'id': '9f015af5-208c-49b3-9a43-4f079fb4f699',
             'name': 'Law Shadow Order',
             'code': 'LAW-SHADOW-ORD',
+            "campusId": "7003123d-ef65-45f6-b469-d2b9839e1bb3",
             'libraryId': '7e4c05e3-1ce6-427d-b9ce-03464245cd78',
         },
         {
             'id': 'b0a1a8c3-cc9a-487c-a2ed-308fc3a49a91',
             'name': 'SUL Electronic',
             'code': 'SUL-ELECTRONIC',
+            "campusId": "c365047a-51f2-45ce-8601-e421ca3615c5",
             'libraryId': 'c1a86906-ced0-46cb-8f5b-8cef542bdd00',
         },
     ]


### PR DESCRIPTION
Fixes #997 

- Adds a lookup for campus id based on library location.
- Adds mocks to all tests that subclass Transformer to include mock `loccamps`