### PR TITLE
Retry transmission for send_all_records DAG

### DIFF
--- a/libsys_airflow/dags/data_exports/full_dump_transmission.py
+++ b/libsys_airflow/dags/data_exports/full_dump_transmission.py
@@ -58,13 +58,26 @@ def send_all_records():
         files_params="upload[files][]",
     )
 
-    retry_files = retry_failed_files_task(vendor="full-dump", files=transmit_data["failures"])
+    retry_files = retry_failed_files_task(
+        vendor="full-dump", files=transmit_data["failures"]
+    )
 
-    retry_transmission = transmit_data_http_task(retry_files, files_params="upload[files][]",)
+    retry_transmission = transmit_data_http_task(
+        retry_files,
+        files_params="upload[files][]",
+    )
 
     email_failures = failed_transmission_email(retry_transmission["failures"])
 
-    start >> gather_files >> transmit_data >> retry_files >> retry_transmission >> email_failures >> end
+    (
+        start
+        >> gather_files
+        >> transmit_data
+        >> retry_files
+        >> retry_transmission
+        >> email_failures
+        >> end
+    )
 
 
 send_all_records()

--- a/libsys_airflow/dags/data_exports/pod_transmission.py
+++ b/libsys_airflow/dags/data_exports/pod_transmission.py
@@ -45,7 +45,6 @@ def send_pod_records():
         gather_files,
         params={"vendor": "pod"},
         files_params="upload[files][]",
-        url_params={"stream": "Test"},
     )
 
     archive_data = archive_transmitted_data_task(transmit_data["success"])

--- a/libsys_airflow/plugins/data_exports/email.py
+++ b/libsys_airflow/plugins/data_exports/email.py
@@ -3,8 +3,6 @@ import logging
 from jinja2 import Template
 
 from airflow.decorators import task
-from airflow.models.taskinstance import TaskInstance
-from airflow.models.dagrun import DagRun
 from airflow.models import Variable
 from airflow.utils.email import send_email
 

--- a/libsys_airflow/plugins/data_exports/email.py
+++ b/libsys_airflow/plugins/data_exports/email.py
@@ -2,6 +2,9 @@ import logging
 
 from jinja2 import Template
 
+from airflow.decorators import task
+from airflow.models.taskinstance import TaskInstance
+from airflow.models.dagrun import DagRun
 from airflow.models import Variable
 from airflow.utils.email import send_email
 
@@ -52,5 +55,67 @@ def generate_multiple_oclc_identifiers_email(multiple_codes: list):
             devs_to_email_addr,
         ],
         subject="Review Instances with Multiple OCLC Indentifiers",
+        html_content=html_content,
+    )
+
+
+def _failed_transmission_email_body(
+    files: list, vendor: str, base_url: str, dag_id: str, dag_run_id: str
+):
+    template = Template(
+        """
+        {% if vendor|length > 0 %}
+        <h2>Failed to Transmit Files for {{ dag_id }} {{ vendor }}</h2>
+        {% else %}
+        <h2>Failed to Transmit Files for {{ dag_id }}</h2>
+        {% endif %}
+        <p><a href="https://{{ base_url }}/dags/{{ dag_id }}/grid?dag_run_id={{ dag_run_id }}">{{ dag_run_id }}</a>
+        <p>These files failed to transmit</p>
+        <ol>
+        {% for row in files %}
+        <li>
+          {{ row }}
+        </li>
+        {% endfor %}
+        </ol>
+    """
+    )
+
+    return template.render(
+        files=files,
+        vendor=vendor,
+        base_url=base_url,
+        dag_id=dag_id,
+        dag_run_id=dag_run_id,
+    )
+
+
+@task
+def failed_transmission_email(files: list, **kwargs):
+    """
+    Generates an email listing files that failed to transmit
+    Sends to libsys devs to troubleshoot
+    """
+    dag = kwargs["dag_run"]
+    dag_id = dag.id
+    dag_run_id = dag.run_id
+    params = kwargs.get("params", {})
+    full_dump_vendor = params.get("vendor", {})
+    if len(files) == 0:
+        logger.info("No failed files to send in email")
+        return
+    logger.info("Generating email of failed to transmit files")
+    devs_to_email_addr = Variable.get("EMAIL_DEVS")
+    base_url = Variable.get("AIRFLOW__WEBSERVER__BASE_URL")
+
+    html_content = _failed_transmission_email_body(
+        files, full_dump_vendor, base_url, dag_id, dag_run_id
+    )
+
+    send_email(
+        to=[
+            devs_to_email_addr,
+        ],
+        subject=f"Failed File Transmission for {dag_id} {dag_run_id}",
         html_content=html_content,
     )

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -43,6 +43,26 @@ def gather_files_task(**kwargs) -> dict:
         "s3": bool(bucket),
     }
 
+@task
+def retry_failed_files_task(**kwargs) -> dict:
+    """
+    Returns a list of files and s3 boolean
+    Uses the list of failed files from xcom
+    """
+    marc_filelist = []
+    params = kwargs.get("params", {})
+    bucket = params.get("bucket", {})
+    if len(kwargs["files"]) == 0:
+        logger.info("No failures to retry")
+    else:
+        logger.info("Retry failed files")
+        marc_filelist = kwargs["files"]
+
+    return {
+        "file_list": marc_filelist,
+        "s3": bool(bucket),
+    }
+
 
 @task(multiple_outputs=True)
 def gather_oclc_files_task(**kwargs) -> dict:

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -71,7 +71,7 @@ def gather_oclc_files_task(**kwargs) -> dict:
     return libraries
 
 
-@task(multiple_outputs=True)
+@task
 def transmit_data_http_task(gather_files, **kwargs) -> dict:
     if not is_production():
         return return_success_test_instance(gather_files)
@@ -110,7 +110,7 @@ def transmit_data_http_task(gather_files, **kwargs) -> dict:
     return {"success": success, "failures": failures}
 
 
-@task(multiple_outputs=True)
+@task
 def transmit_data_ftp_task(conn_id, gather_files) -> dict:
     if not is_production():
         return return_success_test_instance(gather_files)

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -43,6 +43,7 @@ def gather_files_task(**kwargs) -> dict:
         "s3": bool(bucket),
     }
 
+
 @task
 def retry_failed_files_task(**kwargs) -> dict:
     """

--- a/tests/data_exports/test_data_exports_emails.py
+++ b/tests/data_exports/test_data_exports_emails.py
@@ -13,7 +13,7 @@ def test_multiple_oclc_email(mocker):
     )
 
     mocker.patch(
-        "libsys_airflow.plugins.orafin.emails.Variable.get",
+        "libsys_airflow.plugins.data_exports.email.Variable.get",
         return_value="test@stanford.edu",
     )
 
@@ -60,7 +60,7 @@ def test_no_multiple_oclc_code_email(mocker, caplog):
     mocker.patch("libsys_airflow.plugins.data_exports.email.send_email")
 
     mocker.patch(
-        "libsys_airflow.plugins.orafin.emails.Variable.get",
+        "libsys_airflow.plugins.data_exports.email.Variable.get",
         return_value="test@stanford.edu",
     )
 

--- a/tests/data_exports/test_data_exports_emails.py
+++ b/tests/data_exports/test_data_exports_emails.py
@@ -1,10 +1,39 @@
 import pytest  # noqa
 
 from bs4 import BeautifulSoup
+from airflow.models import Variable
 
 from libsys_airflow.plugins.data_exports.email import (
     generate_multiple_oclc_identifiers_email,
+    failed_transmission_email,
 )
+
+
+@pytest.fixture
+def mock_folio_variables(monkeypatch):
+    def mock_get(key):
+        value = None
+        match key:
+            case "AIRFLOW__WEBSERVER__BASE_URL":
+                value = "example.com"
+
+            case "EMAIL_DEVS":
+                value = "test@stanford.edu"
+
+            case _:
+                raise ValueError("")
+        return value
+
+    monkeypatch.setattr(Variable, "get", mock_get)
+
+
+@pytest.fixture
+def mock_dag_run(mocker):
+    dag_run = mocker.stub(name="dag_run")
+    dag_run.run_id = "manual_2022-03-05"
+    dag_run.id = "send_vendor_records"
+
+    return dag_run
 
 
 def test_multiple_oclc_email(mocker):
@@ -67,3 +96,96 @@ def test_no_multiple_oclc_code_email(mocker, caplog):
     generate_multiple_oclc_identifiers_email([])
 
     assert "No multiple OCLC Identifiers" in caplog.text
+
+
+def test_no_failed_transmission_email(mock_dag_run, caplog):
+    files = []
+    failed_transmission_email.function(files, dag_run=mock_dag_run)
+    assert "No failed files to send in email" in caplog.text
+
+
+def test_failed_transmission_email(mocker, mock_dag_run, mock_folio_variables, caplog):
+    mock_send_email = mocker.patch(
+        "libsys_airflow.plugins.data_exports.email.send_email"
+    )
+
+    files = [
+        "data-export-files/some-vendor/marc-files/updates/1234.mrc",
+        "data-export-files/some-vendor/marc-files/updates/5678.mrc",
+    ]
+
+    failed_transmission_email.function(files, dag_run=mock_dag_run)
+
+    assert "Generating email of failed to transmit files" in caplog.text
+
+    assert mock_send_email.called
+
+    assert (
+        mock_send_email.call_args[1]["subject"]
+        == "Failed File Transmission for send_vendor_records manual_2022-03-05"
+    )
+
+    html_body = BeautifulSoup(
+        mock_send_email.call_args[1]["html_content"], "html.parser"
+    )
+
+    assert (
+        html_body.find("h2").text == "Failed to Transmit Files for send_vendor_records"
+    )
+    assert html_body.find("a").text == "manual_2022-03-05"
+
+    assert (
+        html_body.find("a").attrs["href"]
+        == "https://example.com/dags/send_vendor_records/grid?dag_run_id=manual_2022-03-05"
+    )
+
+    list_items = html_body.findAll("li")
+
+    assert (
+        list_items[0].text.strip()
+        == "data-export-files/some-vendor/marc-files/updates/1234.mrc"
+    )
+    assert (
+        list_items[1].text.strip()
+        == "data-export-files/some-vendor/marc-files/updates/5678.mrc"
+    )
+
+
+def test_failed_full_dump_transmission_email(
+    mocker, mock_dag_run, mock_folio_variables
+):
+    mock_dag_run.id = "send_all_records"
+
+    mock_send_email = mocker.patch(
+        "libsys_airflow.plugins.data_exports.email.send_email"
+    )
+
+    files = [
+        "data-export-files/some-vendor/marc-files/updates/1234.mrc",
+        "data-export-files/some-vendor/marc-files/updates/5678.mrc",
+    ]
+
+    failed_transmission_email.function(
+        files, params={"vendor": "pod"}, dag_run=mock_dag_run
+    )
+
+    assert mock_send_email.called
+
+    assert (
+        mock_send_email.call_args[1]["subject"]
+        == "Failed File Transmission for send_all_records manual_2022-03-05"
+    )
+
+    html_body = BeautifulSoup(
+        mock_send_email.call_args[1]["html_content"], "html.parser"
+    )
+
+    assert (
+        html_body.find("h2").text == "Failed to Transmit Files for send_all_records pod"
+    )
+    assert html_body.find("a").text == "manual_2022-03-05"
+
+    assert (
+        html_body.find("a").attrs["href"]
+        == "https://example.com/dags/send_all_records/grid?dag_run_id=manual_2022-03-05"
+    )

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -10,6 +10,7 @@ import libsys_airflow.plugins.data_exports.transmission_tasks as transmission_ta
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
     gather_files_task,
+    retry_failed_files_task,
     transmit_data_http_task,
     transmit_data_ftp_task,
     archive_transmitted_data_task,
@@ -137,6 +138,13 @@ def test_gather_gobi_files(tmp_path, mock_vendor_marc_files):
     marc_files = gather_files_task.function(airflow=airflow, vendor="gobi")
     assert marc_files["file_list"][0] == mock_vendor_marc_files["file_list"][-1]
     assert len(marc_files["file_list"]) == 1
+
+
+def test_retry_failed_files_task(mock_marc_files, caplog):
+    retry_failed_files_task.function(files=mock_marc_files["file_list"])
+    assert "Retry failed files" in caplog.text
+    retry_failed_files_task.function(files=[])
+    assert "No failures to retry" in caplog.text
 
 
 def test_transmit_data_ftp_task(


### PR DESCRIPTION
Fixes #899 

I'm not sure how we want to handle failures in the regular transmission DAGs. I did [this](https://github.com/sul-dlss/libsys-airflow/commit/0b8fc482a77ff9f1e71a28ff8127d9f49615182d) for pod but the transmission task, I feel, is sort of an airflow anti-pattern, where we are not raising an error for a failure (and thus having airflow do a retry) but instead appending the file that failed to a list to be added to the xcom. I played with the idea of raising an error if the dag id is not send_all_records so that airflow would retry the transmission. What do you think of that approach? Otherwise, on a day-to-day basis, the `send_<vendor>_records` DAGs would simply forgo archiving the file that failed and would retry sending it the next day when the DAG runs on schedule. Is that good enough? 