### PR TITLE
Adds job_summary_task as dependency for file_loaded_email_task

### DIFF
--- a/libsys_airflow/dags/vendor/default_data_processor.py
+++ b/libsys_airflow/dags/vendor/default_data_processor.py
@@ -164,6 +164,7 @@ with DAG(
         processed_params=processed_params,
         params=params,
         job_execution_id=data_import["job_execution_id"],
+        job_summary=job_summary,
     )
 
     file_not_loaded_email = file_not_loaded_email_task(

--- a/libsys_airflow/plugins/vendor/emails.py
+++ b/libsys_airflow/plugins/vendor/emails.py
@@ -80,7 +80,8 @@ def file_loaded_email_task(**kwargs):
     processed_params = kwargs["processed_params"]
     params = kwargs["params"]
     job_execution_id = kwargs["job_execution_id"]
-    kwargs = {**processed_params, **params}
+    job_summary = kwargs["job_summary"]
+    kwargs = {**processed_params, **params, **job_summary}
     kwargs["job_execution_id"] = job_execution_id
     send_file_loaded_email(**kwargs)
 


### PR DESCRIPTION
Otherwise `file_loaded_email_task` errors out because instance and srs stats are not available until `job_summary_task` is completed.