### PR TITLE
Query instance id in gobi transformer instead of isbn

### DIFF
--- a/libsys_airflow/dags/data_exports/gobi_selections.py
+++ b/libsys_airflow/dags/data_exports/gobi_selections.py
@@ -15,10 +15,6 @@ from libsys_airflow.plugins.data_exports.instance_ids import (
 from libsys_airflow.plugins.data_exports.marc.gobi import gobi_list_from_marc_files
 
 from libsys_airflow.plugins.data_exports.marc.exports import marc_for_instances
-from libsys_airflow.plugins.data_exports.marc.transforms import (
-    add_holdings_items_to_marc_files,
-    remove_fields_from_marc_files,
-)
 
 default_args = {
     "owner": "libsys",

--- a/libsys_airflow/dags/data_exports/gobi_selections.py
+++ b/libsys_airflow/dags/data_exports/gobi_selections.py
@@ -71,23 +71,6 @@ with DAG(
         op_kwargs={"vendor": "gobi"},
     )
 
-    transform_marc_record = PythonOperator(
-        task_id="transform_folio_marc_record",
-        python_callable=add_holdings_items_to_marc_files,
-        op_kwargs={
-            "marc_file_list": "{{ ti.xcom_pull('fetch_marc_records_from_folio') }}",
-            "full_dump": False,
-        },
-    )
-
-    transform_marc_fields = PythonOperator(
-        task_id="transform_folio_remove_marc_fields",
-        python_callable=remove_fields_from_marc_files,
-        op_kwargs={
-            "marc_file_list": "{{ ti.xcom_pull('fetch_marc_records_from_folio') }}"
-        },
-    )
-
     generate_isbn_list = PythonOperator(
         task_id="generate_isbn_lists",
         python_callable=gobi_list_from_marc_files,
@@ -102,5 +85,4 @@ with DAG(
 
 
 fetch_folio_record_ids >> save_ids_to_file >> fetch_marc_records
-fetch_marc_records >> transform_marc_record >> transform_marc_fields
-transform_marc_fields >> generate_isbn_list >> finish_processing_marc
+fetch_marc_records >> generate_isbn_list >> finish_processing_marc

--- a/libsys_airflow/plugins/data_exports/marc/gobi.py
+++ b/libsys_airflow/plugins/data_exports/marc/gobi.py
@@ -43,7 +43,6 @@ class GobiTransformer(Transformer):
                 if not i % 100:
                     logger.info(f"{i:,} records processed")
 
-                fields035 = record.get_fields("035")
                 field856 = record.get_fields("856")
                 field856x = [s.get_subfields("x") for s in field856]
                 fields856x = list(itertools.chain.from_iterable(field856x))
@@ -96,10 +95,6 @@ class GobiTransformer(Transformer):
                                 set([s.lower() for s in fields856x + fields956x])
                             ):
                                 ebook = False
-
-                    for field035 in fields035:
-                        if re.search("^gls[0-9]+", field035.get_subfields("a")[0]):
-                            ebook = False
 
                     if ebook:
                         ebook_list.extend(stdnums)

--- a/libsys_airflow/plugins/data_exports/marc/gobi.py
+++ b/libsys_airflow/plugins/data_exports/marc/gobi.py
@@ -105,7 +105,7 @@ class GobiTransformer(Transformer):
                         ebook_list.extend(stdnums)
 
                     items_result = self.folio_client.folio_get(
-                        f"item-storage/items?query=(holdingsRecordId=={holding['id']})"
+                        f"/item-storage/items?query=(holdingsRecordId=={holding['id']})"
                     )
 
                     if len(items_result['items']):

--- a/libsys_airflow/plugins/data_exports/marc/gobi.py
+++ b/libsys_airflow/plugins/data_exports/marc/gobi.py
@@ -21,7 +21,7 @@ def gobi_list_from_marc_files(marc_file_list: str):
 
 
 class GobiTransformer(Transformer):
-    def generate_list(self, marc_file) -> None:
+    def generate_list(self, marc_file):
 
         # marc_path is data-export-files/gobi/marc-files/updates/YYYYMMDD.mrc
         marc_path = pathlib.Path(marc_file)
@@ -117,5 +117,3 @@ class GobiTransformer(Transformer):
 
             for e_isbn in ebook_list:
                 fo.write(f"{e_isbn}|ebook|325099\n")
-
-        return None

--- a/libsys_airflow/plugins/data_exports/marc/gobi.py
+++ b/libsys_airflow/plugins/data_exports/marc/gobi.py
@@ -21,7 +21,7 @@ def gobi_list_from_marc_files(marc_file_list: str):
 
 
 class GobiTransformer(Transformer):
-    def generate_list(self, marc_file) -> pathlib.Path:
+    def generate_list(self, marc_file) -> None:
 
         # marc_path is data-export-files/gobi/marc-files/updates/YYYYMMDD.mrc
         marc_path = pathlib.Path(marc_file)
@@ -118,4 +118,4 @@ class GobiTransformer(Transformer):
             for e_isbn in ebook_list:
                 fo.write(f"{e_isbn}|ebook|325099\n")
 
-        return gobi_path
+        return None

--- a/libsys_airflow/plugins/data_exports/marc/gobi.py
+++ b/libsys_airflow/plugins/data_exports/marc/gobi.py
@@ -105,7 +105,7 @@ class GobiTransformer(Transformer):
                         ebook_list.extend(stdnums)
 
                     items_result = self.folio_client.folio_get(
-                        f"inventory/items?query=(holdingsRecordId=={holding['id']})"
+                        f"item-storage/items?query=(holdingsRecordId=={holding['id']})"
                     )
 
                     if len(items_result['items']):

--- a/libsys_airflow/plugins/data_exports/marc/transformer.py
+++ b/libsys_airflow/plugins/data_exports/marc/transformer.py
@@ -143,9 +143,9 @@ class Transformer(object):
 
                 for holding_tuple in holdings_result:
                     holding = holding_tuple[0]
-                    if len(holding.get("discoverySuppress", "")) > 0:
-                        if bool(holding["discoverySuppress"]):
-                            continue
+
+                    if holding.get("discoverySuppress", False):
+                        continue
 
                     field_999 = self.add_holdings_subfields(holding)
 
@@ -160,10 +160,7 @@ class Transformer(object):
 
                     active_items = []
                     for _item in items_result:
-                        try:
-                            if not bool(_item[0]["discoverySuppress"]):
-                                active_items.append(_item)
-                        except KeyError:
+                        if not _item[0].get("discoverySuppress", False):
                             active_items.append(_item)
 
                     match len(active_items):

--- a/libsys_airflow/plugins/data_exports/marc/transforms.py
+++ b/libsys_airflow/plugins/data_exports/marc/transforms.py
@@ -126,7 +126,8 @@ oclc_excluded = [
 def add_holdings_items_to_marc_files(marc_file_list: str, full_dump: bool):
     transformer = Transformer()
     marc_list = ast.literal_eval(marc_file_list)
-    for marc_file in marc_list['updates']:
+    new_and_updates = marc_list['new'] + marc_list['updates']
+    for marc_file in new_and_updates:
         transformer.add_holdings_items(marc_file=marc_file, full_dump=full_dump)
 
 

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -31,7 +31,7 @@ def gather_files_task(**kwargs) -> dict:
     if vendor == "full-dump":
         marc_filepath = S3Path(f"/{bucket}/data-export-files/{vendor}/marc-files/")
     if vendor == "gobi":
-        file_glob_pattern = "**/*.txt"
+        file_glob_pattern = r"**/*.[mt][rx][ct]"
     marc_filelist = []
     for f in marc_filepath.glob(file_glob_pattern):
         if f.stat().st_size == 0:

--- a/tests/data_exports/test_gobi_exports_list.py
+++ b/tests/data_exports/test_gobi_exports_list.py
@@ -48,6 +48,15 @@ def record(**kwargs):
             )
         )
 
+    record.add_field(
+        pymarc.Field(
+            tag='999',
+            indicators=[' ', ' '],
+            subfields=[
+                pymarc.Subfield(code='i', value='5db0204e-0c10-40d7-8d11-26b94177b170')
+            ],
+        )
+    )
     return record
 
 

--- a/tests/data_exports/test_gobi_exports_list.py
+++ b/tests/data_exports/test_gobi_exports_list.py
@@ -7,7 +7,6 @@ from tests.data_exports.test_marc_transformations import mock_folio_client  # no
 
 def record(**kwargs):
     isbns = kwargs.get("isbns")
-    fields035 = kwargs.get("fields035")
     fields856 = kwargs.get("fields856")
     fields956 = kwargs.get("fields956")
 
@@ -16,15 +15,6 @@ def record(**kwargs):
         record.add_field(
             pymarc.Field(
                 tag='020',
-                indicators=[' ', ' '],
-                subfields=[pymarc.Subfield(code='a', value=field)],
-            )
-        )
-
-    for field in fields035:
-        record.add_field(
-            pymarc.Field(
-                tag='035',
                 indicators=[' ', ' '],
                 subfields=[pymarc.Subfield(code='a', value=field)],
             )
@@ -115,7 +105,6 @@ def test_with_ebook_and_print(tmp_path, mocker, mock_folio_client):  # noqa
         marc_writer.write(
             record(
                 isbns=["1234567890123", "9876543212345"],
-                fields035=["notgls12345", "other1value"],
                 fields856=["notgobi", "other"],
                 fields956=["notsubscribed", "other"],
             )
@@ -166,7 +155,6 @@ def test_with_ebook_only(tmp_path, mocker, mock_folio_client):  # noqa
         marc_writer.write(
             record(
                 isbns=["1234567890123"],
-                fields035=["notgls12345"],
                 fields856=["notgobi"],
                 fields956=["notsubscribed"],
             )
@@ -218,7 +206,6 @@ def test_with_no_isbn(tmp_path, mocker, mock_folio_client):  # noqa
         marc_writer.write(
             record(
                 isbns=["42"],  # <-- Not a valid ISBN
-                fields035=["notgls12345"],
                 fields856=["notgobi"],
                 fields956=["notsubscribed"],
             )
@@ -226,7 +213,6 @@ def test_with_no_isbn(tmp_path, mocker, mock_folio_client):  # noqa
         marc_writer.write(
             record(
                 isbns=[],  # <-- No ISBNs
-                fields035=["notgls12345"],
                 fields856=["notgobi"],
                 fields956=["notsubscribed"],
             )
@@ -278,7 +264,6 @@ def test_with_modified_isbn(tmp_path, mocker, mock_folio_client):  # noqa
         marc_writer.write(
             record(
                 isbns=["1234567890 some text", "9-876543212345"],
-                fields035=["notgls12345", "other1value"],
                 fields856=["notgobi", "other"],
                 fields956=["notsubscribed", "other"],
             )
@@ -329,62 +314,6 @@ def test_with_print_no_electronic_holding(tmp_path, mocker, mock_folio_client): 
         marc_writer.write(
             record(
                 isbns=["1234567890123"],
-                fields035=["notgls12345"],
-                fields856=["notgobi"],
-                fields956=["notsubscribed"],
-            )
-        )
-
-    transformer = gobi_transformer.GobiTransformer()
-    transformer.generate_list(marc_file)
-
-    gobi_file = pathlib.Path(marc_file.parent / f"stf.{file_date}.txt")
-
-    with gobi_file.open('r+') as fo:
-        assert fo.readline() == "1234567890123|print|325099\n"
-        assert fo.readline() == ""
-
-
-def test_with_skipped_by_035(tmp_path, mocker, mock_folio_client):  # noqa
-    file_date = "20240105"
-
-    holdings = [
-        {
-            'id': '3bb4a439-842e-5c8d-b86c-eaad46b6a316',
-            'holdingsTypeId': '996f93e2-5b5e-4cf2-9168-33ced1f95eed',
-            'permanentLocationId': 'a8676073-7520-4f26-8573-55976301ab5d',
-        }
-    ]
-
-    items = [
-        {
-            'id': '3251f045-f80c-5c0d-8774-a75af8a6f01c',
-        }
-    ]
-
-    def mock_folio_get(*args):
-        result = folio_result
-        result["holdingsRecords"] = holdings
-        result["items"] = items
-        return result
-
-    mock_folio_client.folio_get = mock_folio_get
-
-    mocker.patch(
-        'libsys_airflow.plugins.data_exports.marc.transformer.folio_client',
-        return_value=mock_folio_client,
-    )
-
-    marc_file = tmp_path / f"{file_date}.mrc"
-
-    with marc_file.open("wb+") as fo:
-        marc_writer = pymarc.MARCWriter(fo)
-        marc_writer.write(
-            record(
-                isbns=["1234567890123"],
-                fields035=[
-                    "gls12345"
-                ],  # <-- indicates an existing Gobi record, so no added line for "ebook"
                 fields856=["notgobi"],
                 fields956=["notsubscribed"],
             )
@@ -485,7 +414,6 @@ def test_with_skipped_by_956(tmp_path, mocker, mock_folio_client):  # noqa
         marc_writer.write(
             record(
                 isbns=["1234567890123"],
-                fields035=["notgls12345"],
                 fields856=["notgobi"],
                 fields956=[
                     "subscribed",
@@ -541,7 +469,6 @@ def test_with_non_sul_holding(tmp_path, mocker, mock_folio_client):  # noqa
         marc_writer.write(
             record(
                 isbns=["1234567890123", "9876543212345"],
-                fields035=["notgls12345", "other1value"],
                 fields856=["notgobi", "other"],
                 fields956=["notsubscribed", "other"],
             )

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -136,8 +136,8 @@ def test_gather_full_dump_files(mocker):
 def test_gather_gobi_files(tmp_path, mock_vendor_marc_files):
     airflow = tmp_path / "airflow"
     marc_files = gather_files_task.function(airflow=airflow, vendor="gobi")
-    assert marc_files["file_list"][0] == mock_vendor_marc_files["file_list"][-1]
-    assert len(marc_files["file_list"]) == 1
+    assert marc_files["file_list"][1] == mock_vendor_marc_files["file_list"][-1]
+    assert len(marc_files["file_list"]) == 2
 
 
 def test_retry_failed_files_task(mock_marc_files, caplog):


### PR DESCRIPTION
The gobi transformer was incorrectly querying isbn. Now queries instance id. Also refactors the loops so that it only queries for holdings once per marc record and items once per holding.