### PR TITLE
Fix bugs with transformer not getting correct file lists

### DIFF
--- a/libsys_airflow/plugins/data_exports/marc/transformer.py
+++ b/libsys_airflow/plugins/data_exports/marc/transformer.py
@@ -128,9 +128,9 @@ class Transformer(object):
 
                 for holding_tuple in holdings_result:
                     holding = holding_tuple[0]
-                    if len(holding.get("discoverySuppress", "")) > 0:
-                        if bool(holding["discoverySuppress"]):
-                            continue
+
+                    if holding.get("discoverySuppress", False):
+                        continue
 
                     field_999 = self.add_holdings_subfields(holding)
 
@@ -145,10 +145,7 @@ class Transformer(object):
 
                     active_items = []
                     for _item in items_result:
-                        try:
-                            if not bool(_item[0]["discoverySuppress"]):
-                                active_items.append(_item)
-                        except KeyError:
+                        if not _item[0].get("discoverySuppress", False):
                             active_items.append(_item)
 
                     match len(active_items):

--- a/libsys_airflow/plugins/data_exports/marc/transforms.py
+++ b/libsys_airflow/plugins/data_exports/marc/transforms.py
@@ -126,7 +126,8 @@ oclc_excluded = [
 def add_holdings_items_to_marc_files(marc_file_list: str, full_dump: bool):
     transformer = Transformer()
     marc_list = ast.literal_eval(marc_file_list)
-    for marc_file in marc_list['updates']:
+    new_and_updates = marc_list['new'] + marc_list['updates']
+    for marc_file in new_and_updates:
         transformer.add_holdings_items(marc_file=marc_file, full_dump=full_dump)
 
 


### PR DESCRIPTION
The transformer class methods were not getting the `new` file list, so the base marc records were just getting passed along without modification.

@ahafele ☝️ 

Also simplifies the testing for `discoverySuppress` so that there are not any nested exception catches, which makes debugging more difficult.