### PR TITLE
Fixes bug for archiving of GOBI files

### DIFF
--- a/libsys_airflow/plugins/data_exports/marc/gobi.py
+++ b/libsys_airflow/plugins/data_exports/marc/gobi.py
@@ -26,8 +26,8 @@ class GobiTransformer(Transformer):
         # marc_path is data-export-files/gobi/marc-files/updates/YYYYMMDD.mrc
         marc_path = pathlib.Path(marc_file)
         gobi_list_name = marc_path.stem
-        # gobi_path is data-export-files/gobi/marc-files/updates/stf.YYYMMDD.txt
-        gobi_path = pathlib.Path(marc_path.parent) / f"stf.{gobi_list_name}.txt"
+        # gobi_path is data-export-files/gobi/marc-files/updates/YYYMMDD.txt
+        gobi_path = pathlib.Path(marc_path.parent) / f"{gobi_list_name}.txt"
 
         with marc_path.open('rb') as fo:
             marc_records = [record for record in pymarc.MARCReader(fo)]

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -208,10 +208,12 @@ def archive_transmitted_data_task(files):
         kind = Path(x).parent.name
         # original_transmitted_file_path = data-export-files/{vendor}/marc-files/new|updates|deletes/*.mrc|*.txt
         original_transmitted_file_path = Path(x)
+
         # archive_path = data-export-files/{vendor}/transmitted/new|updates|deletes
         archive_path = archive_dir / kind
         archive_path.mkdir(exist_ok=True)
         archive_path = archive_path / original_transmitted_file_path.name
+
         # instance_path = data-export-files/{vendor}/instanceids/new|updates|deletes/*.csv
         instance_path = (
             original_transmitted_file_path.parent.parent.parent
@@ -225,7 +227,7 @@ def archive_transmitted_data_task(files):
         )
         marc_archive_path = archive_dir / kind / marc_path.name
 
-        # move transmitted files
+        # move transmitted files (for GOBI this will be *.txt files)
         logger.info(
             f"Moving transmitted file {original_transmitted_file_path} to {archive_path}"
         )

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -145,7 +145,8 @@ def transmit_data_ftp_task(conn_id, gather_files) -> dict:
     success = []
     failures = []
     for f in gather_files["file_list"]:
-        remote_file_path = f"{remote_path}/{Path(f).name}"
+        remote_file_name = vendor_filename_spec(conn_id, f)
+        remote_file_path = f"{remote_path}/{remote_file_name}"
         try:
             logger.info(f"Start transmission of file {f}")
             hook.store_file(remote_file_path, f)
@@ -241,6 +242,19 @@ def archive_transmitted_data_task(files):
         if marc_path.exists():
             logger.info(f"Moving related marc file {marc_path} to {marc_archive_path}")
             marc_path.replace(marc_archive_path)
+
+
+def vendor_filename_spec(conn_id, filename):
+    """
+    Returns a filename per the vendor's filenaming convention
+    """
+    if conn_id == "gobi":
+        # gobi should have "stf" prepended
+        return "stf" + Path(filename).name
+    elif conn_id == "sharevde":
+        return "tbd"
+    else:
+        Path(filename).name
 
 
 def is_production():

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -216,6 +216,8 @@ def archive_transmitted_data_task(files):
             original_transmitted_file_path.parent.parent.parent
             / f"instanceids/{kind}/{original_transmitted_file_path.stem}.csv"
         )
+        instance_archive_path = archive_dir / kind / instance_path.name
+
         marc_path = (
             original_transmitted_file_path.parent
             / f"{original_transmitted_file_path.stem}.mrc"
@@ -223,14 +225,21 @@ def archive_transmitted_data_task(files):
         marc_archive_path = archive_dir / kind / marc_path.name
 
         # move transmitted files
+        logger.info(
+            f"Moving transmitted file {original_transmitted_file_path} to {archive_path}"
+        )
         original_transmitted_file_path.replace(archive_path)
 
         # move instance id files with same stem as transmitted filename
         if instance_path.exists():
-            instance_path.replace(archive_dir / kind / instance_path.name)
+            logger.info(
+                f"Moving related instanceid file {instance_path} to {instance_archive_path}"
+            )
+            instance_path.replace(instance_archive_path)
 
         # move marc files with same stem as transmitted filename (when transmitted file is not *.mrc)
         if marc_path.exists():
+            logger.info(f"Moving related marc file {marc_path} to {marc_archive_path}")
             marc_path.replace(marc_archive_path)
 
 

--- a/tests/data_exports/test_gobi_exports_list.py
+++ b/tests/data_exports/test_gobi_exports_list.py
@@ -113,7 +113,7 @@ def test_with_ebook_and_print(tmp_path, mocker, mock_folio_client):  # noqa
     transformer = gobi_transformer.GobiTransformer()
     transformer.generate_list(marc_file)
 
-    gobi_file = pathlib.Path(marc_file.parent / f"stf.{file_date}.txt")
+    gobi_file = pathlib.Path(marc_file.parent / f"{file_date}.txt")
 
     with gobi_file.open('r+') as fo:
         assert fo.readline() == "1234567890123|print|325099\n"
@@ -163,7 +163,7 @@ def test_with_ebook_only(tmp_path, mocker, mock_folio_client):  # noqa
     transformer = gobi_transformer.GobiTransformer()
     transformer.generate_list(marc_file)
 
-    gobi_file = pathlib.Path(marc_file.parent / f"stf.{file_date}.txt")
+    gobi_file = pathlib.Path(marc_file.parent / f"{file_date}.txt")
 
     with gobi_file.open('r+') as fo:
         assert fo.readline() == "1234567890123|ebook|325099\n"
@@ -221,7 +221,7 @@ def test_with_no_isbn(tmp_path, mocker, mock_folio_client):  # noqa
     transformer = gobi_transformer.GobiTransformer()
     transformer.generate_list(marc_file)
 
-    gobi_file = pathlib.Path(marc_file.parent / f"stf.{file_date}.txt")
+    gobi_file = pathlib.Path(marc_file.parent / f"{file_date}.txt")
 
     with gobi_file.open('r+') as fo:
         assert fo.readline() == ""
@@ -272,7 +272,7 @@ def test_with_modified_isbn(tmp_path, mocker, mock_folio_client):  # noqa
     transformer = gobi_transformer.GobiTransformer()
     transformer.generate_list(marc_file)
 
-    gobi_file = pathlib.Path(marc_file.parent / f"stf.{file_date}.txt")
+    gobi_file = pathlib.Path(marc_file.parent / f"{file_date}.txt")
 
     with gobi_file.open('r+') as fo:
         assert fo.readline() == "1234567890|print|325099\n"
@@ -322,7 +322,7 @@ def test_with_print_no_electronic_holding(tmp_path, mocker, mock_folio_client): 
     transformer = gobi_transformer.GobiTransformer()
     transformer.generate_list(marc_file)
 
-    gobi_file = pathlib.Path(marc_file.parent / f"stf.{file_date}.txt")
+    gobi_file = pathlib.Path(marc_file.parent / f"{file_date}.txt")
 
     with gobi_file.open('r+') as fo:
         assert fo.readline() == "1234567890123|print|325099\n"
@@ -374,7 +374,7 @@ def test_with_skipped_by_856(tmp_path, mocker, mock_folio_client):  # noqa
     transformer = gobi_transformer.GobiTransformer()
     transformer.generate_list(marc_file)
 
-    gobi_file = pathlib.Path(marc_file.parent / f"stf.{file_date}.txt")
+    gobi_file = pathlib.Path(marc_file.parent / f"{file_date}.txt")
 
     with gobi_file.open('r+') as fo:
         assert fo.readline() == "1234567890123|print|325099\n"
@@ -425,7 +425,7 @@ def test_with_skipped_by_956(tmp_path, mocker, mock_folio_client):  # noqa
     transformer = gobi_transformer.GobiTransformer()
     transformer.generate_list(marc_file)
 
-    gobi_file = pathlib.Path(marc_file.parent / f"stf.{file_date}.txt")
+    gobi_file = pathlib.Path(marc_file.parent / f"{file_date}.txt")
 
     with gobi_file.open('r+') as fo:
         assert fo.readline() == "1234567890123|print|325099\n"
@@ -477,7 +477,7 @@ def test_with_non_sul_holding(tmp_path, mocker, mock_folio_client):  # noqa
     transformer = gobi_transformer.GobiTransformer()
     transformer.generate_list(marc_file)
 
-    gobi_file = pathlib.Path(marc_file.parent / f"stf.{file_date}.txt")
+    gobi_file = pathlib.Path(marc_file.parent / f"{file_date}.txt")
 
     with gobi_file.open('r+') as fo:
         assert fo.readline() == ''


### PR DESCRIPTION
Fixes #1047 

I found myself jumping through hoops trying to address this issue on the `archive_transmitted_data_task` side. The prefix "stf." was part of the filename being looked for in the instanceids directory and related marc files to archive after the gobi ".txt" file is transmitted. I figured it would be easier if the "stf." was prepended when the file is uploaded to the GOBI ftp site since that is their spec for filenaming. We will have to do something similar for SHAREVDE anyways...

After re-writing the tests I then realized that maybe the vendor's filenaming convention should be in the extra field of the airflow Connection, like the remote_path is. If we want to go that route instead, I can make more changes.