### PR TITLE
Adds "Deletes" to OCLC API Wrapper

### DIFF
--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -156,7 +156,7 @@ class OCLCAPIWrapper(object):
             return output
 
         marc_records = self.__read_marc_files__(marc_files)
-        successful_files: set = set() 
+        successful_files: set = set()
         failed_files: set = set()
         with MetadataSession(authorization=self.oclc_token) as session:
             for record, file_name in marc_records:
@@ -195,6 +195,7 @@ class OCLCAPIWrapper(object):
             failures: set = kwargs["failures"]
 
             oclc_id = get_record_id(record)
+
             if len(oclc_id) != 1:
                 failures.add(file_name)
                 output['failures'].append(instance_uuid)
@@ -213,6 +214,7 @@ class OCLCAPIWrapper(object):
                 output['failures'].append(instance_uuid)
                 failures.add(file_name)
             else:
+                output['success'].append(instance_uuid)
                 successes.add(file_name)
 
         output = self.__oclc_operations__(

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -20,9 +20,6 @@ logger = logging.getLogger(__name__)
 class OCLCAPIWrapper(object):
     # Helper class for transmitting MARC records to OCLC Worldcat API
 
-    auth_url = "https://oauth.oclc.org/token?grant_type=client_credentials&scope=WorldCatMetadataAPI"
-    worldcat_metadata_url = "https://metadata.api.oclc.org/worldcat"
-
     def __init__(self, **kwargs):
         self.oclc_token = None
         client_id = kwargs["client_id"]

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -4,7 +4,7 @@ import pathlib
 import httpx
 import pymarc
 
-from typing import List, Union
+from typing import List, Union, Callable
 
 from bookops_worldcat import WorldcatAccessToken, MetadataSession
 from bookops_worldcat.errors import WorldcatRequestError
@@ -145,67 +145,35 @@ class OCLCAPIWrapper(object):
         record.add_ordered_field(new_035)
         return self.__put_folio_record__(srs_uuid, record)
 
-    def delete(self, marc_files: List[str]) -> dict:
+    def __oclc_operations__(self, **kwargs) -> dict:
+        marc_files: List[str] = kwargs['marc_files']
+        function: Callable = kwargs['function']
+        no_recs_message: str = kwargs.get("no_recs_message", "")
         output: dict = {"success": [], "failures": []}
+
         if len(marc_files) < 1:
-            logger.info("No marc records for deletes")
+            logger.info(no_recs_message)
             return output
+
         marc_records = self.__read_marc_files__(marc_files)
-
-        with MetadataSession(authorization=self.oclc_token) as session:
-            for record in marc_records:
-                instance_uuid, srs_uuid = self.__record_uuids__(record)
-                if srs_uuid is None:
-                    continue
-                oclc_id = get_record_id(record)
-                if len(oclc_id) != 1:
-                    match len(oclc_id):
-
-                        case 0:
-                            logger.error(f"{srs_uuid} missing OCLC number")
-                            output['failures'].append(instance_uuid)
-
-                        case _:
-                            logger.error(f"Multiple OCLC ids for {srs_uuid}")
-                            output['failures'].append(instance_uuid)
-
-                    continue
-                try:
-                    response = session.holdings_unset(oclcNumber=oclc_id[0])
-                    if response is None:
-                        output['failures'].append(instance_uuid)
-                        continue
-                except WorldcatRequestError as e:
-                    logger.error(f"Failed to unset record, error: {e}")
-                    output['failures'].append(instance_uuid)
-                    continue
-            return output
-
-    def new(self, marc_files: List[str]) -> dict:
-        output: dict = {"success": [], "failures": []}
-        if len(marc_files) < 1:
-            logger.info("No new marc records")
-            return output
-        marc_records = self.__read_marc_files__(marc_files)
-        successful_files, failed_files = set(), set()
+        successful_files: set = set() 
+        failed_files: set = set()
         with MetadataSession(authorization=self.oclc_token) as session:
             for record, file_name in marc_records:
                 instance_uuid, srs_uuid = self.__record_uuids__(record)
                 if srs_uuid is None:
                     continue
                 try:
-                    record.remove_fields(*oclc_excluded)
-                    marc21 = record.as_marc21()
-                    new_record = session.bib_create(
-                        record=marc21,
-                        recordFormat="application/marc",
+                    function(
+                        session=session,
+                        output=output,
+                        record=record,
+                        file_name=file_name,
+                        srs_uuid=srs_uuid,
+                        instance_uuid=instance_uuid,
+                        successes=successful_files,
+                        failures=failed_files,
                     )
-                    if self.__update_035__(new_record.text, srs_uuid):  # type: ignore
-                        output['success'].append(instance_uuid)
-                        successful_files.add(file_name)
-                    else:
-                        output['failures'].append(instance_uuid)
-                        failed_files.add(file_name)
                 except WorldcatRequestError as e:
                     logger.error(e)
                     output['failures'].append(instance_uuid)
@@ -214,54 +182,118 @@ class OCLCAPIWrapper(object):
         output["archive"] = list(successful_files.difference(failed_files))
         return output
 
-    def update(self, marc_files: List[str]):
-        output: dict = {"success": [], "failures": []}
-        if len(marc_files) < 1:
-            logger.info("No updated marc records")
-            return output
-        marc_records = self.__read_marc_files__(marc_files)
-        successful_files, failed_files = set(), set()
-        with MetadataSession(authorization=self.oclc_token) as session:
-            for record, file_name in marc_records:
-                instance_uuid, srs_uuid = self.__record_uuids__(record)
-                if srs_uuid is None:
-                    continue
-                oclc_id = get_record_id(record)
+    def delete(self, marc_files: List[str]) -> dict:
+
+        def __delete_oclc__(**kwargs):
+            session: MetadataSession = kwargs["session"]
+            output: dict = kwargs["output"]
+            record: pymarc.Record = kwargs["record"]
+            instance_uuid: str = kwargs["instance_uuid"]
+            srs_uuid: str = kwargs["srs_uuid"]
+            file_name: str = kwargs["file_name"]
+            successes: set = kwargs["successes"]
+            failures: set = kwargs["failures"]
+
+            oclc_id = get_record_id(record)
+            if len(oclc_id) != 1:
+                failures.add(file_name)
+                output['failures'].append(instance_uuid)
                 match len(oclc_id):
 
                     case 0:
                         logger.error(f"{srs_uuid} missing OCLC number")
-                        output['failures'].append(instance_uuid)
-                        failed_files.add(file_name)
-                        continue
-
-                    case 1:
-                        pass
 
                     case _:
                         logger.error(f"Multiple OCLC ids for {srs_uuid}")
-                        output['failures'].append(instance_uuid)
-                        failed_files.add(file_name)
-                        continue
 
-                try:
-                    response = session.holdings_set(oclcNumber=oclc_id[0])
-                    if response is None:
-                        output['failures'].append(instance_uuid)
-                        failed_files.add(file_name)
-                        continue
-                    if self.__update_oclc_number__(
-                        response.json()['controlNumber'], srs_uuid
-                    ):
-                        output['success'].append(instance_uuid)
-                        successful_files.add(file_name)
-                    else:
-                        output['failures'].append(instance_uuid)
-                        failed_files.add(file_name)
-                except WorldcatRequestError as e:
-                    logger.error(f"Failed to update record, error: {e}")
-                    output['failures'].append(instance_uuid)
-                    failed_files.add(file_name)
-                    continue
-        output["archive"] = list(successful_files.difference(failed_files))
+                return
+
+            response = session.holdings_unset(oclcNumber=oclc_id[0])
+            if response is None:
+                output['failures'].append(instance_uuid)
+                failures.add(file_name)
+            else:
+                successes.add(file_name)
+
+        output = self.__oclc_operations__(
+            marc_files=marc_files,
+            function=__delete_oclc__,
+            no_recs_message="No marc records for deletes",
+        )
+        return output
+
+    def new(self, marc_files: List[str]) -> dict:
+
+        def __new_oclc__(**kwargs):
+            session: MetadataSession = kwargs["session"]
+            output: dict = kwargs["output"]
+            record: pymarc.Record = kwargs["record"]
+            instance_uuid: str = kwargs["instance_uuid"]
+            srs_uuid: str = kwargs["srs_uuid"]
+            file_name: str = kwargs["file_name"]
+            successes: set = kwargs["successes"]
+            failures: set = kwargs["failures"]
+
+            record.remove_fields(*oclc_excluded)
+            marc21 = record.as_marc21()
+            new_record = session.bib_create(
+                record=marc21,
+                recordFormat="application/marc",
+            )
+            if self.__update_035__(new_record.text, srs_uuid):  # type: ignore
+                output['success'].append(instance_uuid)
+                successes.add(file_name)
+            else:
+                output['failures'].append(instance_uuid)
+                failures.add(file_name)
+
+        output = self.__oclc_operations__(
+            marc_files=marc_files,
+            function=__new_oclc__,
+            no_recs_message="No new marc records",
+        )
+        return output
+
+    def update(self, marc_files: List[str]):
+        def __update_oclc__(**kwargs):
+            session: MetadataSession = kwargs["session"]
+            output: dict = kwargs["output"]
+            record: pymarc.Record = kwargs["record"]
+            instance_uuid: str = kwargs["instance_uuid"]
+            srs_uuid: str = kwargs["srs_uuid"]
+            file_name: str = kwargs["file_name"]
+            successes: set = kwargs["successes"]
+            failures: set = kwargs["failures"]
+
+            oclc_id = get_record_id(record)
+            if len(oclc_id) != 1:
+                output['failures'].append(instance_uuid)
+                failures.add(file_name)
+
+                match len(oclc_id):
+
+                    case 0:
+                        logger.error(f"{srs_uuid} missing OCLC number")
+
+                    case _:
+                        logger.error(f"Multiple OCLC ids for {srs_uuid}")
+
+                return
+            response = session.holdings_set(oclcNumber=oclc_id[0])
+            if response is None:
+                output['failures'].append(instance_uuid)
+                failures.add(file_name)
+                return
+            if self.__update_oclc_number__(response.json()['controlNumber'], srs_uuid):
+                output['success'].append(instance_uuid)
+                successes.add(file_name)
+            else:
+                output['failures'].append(instance_uuid)
+                failures.add(file_name)
+
+        output = self.__oclc_operations__(
+            marc_files=marc_files,
+            function=__update_oclc__,
+            no_recs_message="No updated marc records",
+        )
         return output

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -161,7 +161,7 @@ def transmit_data_ftp_task(conn_id, gather_files) -> dict:
 @task
 def transmit_data_oclc_api_task(connection_details, libraries) -> dict:
     success: dict = {}
-    failures: dict = {} 
+    failures: dict = {}
     archive: list = []
 
     connection_lookup = oclc_connections(connection_details)

--- a/tests/data_exports/test_oclc_api.py
+++ b/tests/data_exports/test_oclc_api.py
@@ -415,7 +415,7 @@ def test_bad_holdings_set_call(tmp_path, mock_oclc_api, caplog):
         'f8fa3682-fef8-4810-b8da-8f51b73785ac',
     ]
 
-    assert "Failed to update record" in caplog.text
+    assert "Failed to update FOLIO for Instance" in caplog.text
 
 
 def test_already_exists_control_number(tmp_path, mock_oclc_api):

--- a/tests/data_exports/test_oclc_api.py
+++ b/tests/data_exports/test_oclc_api.py
@@ -516,3 +516,14 @@ def test_missing_or_multiple_oclc_numbers(mock_oclc_api, caplog, tmp_path):
         "958835d2-39cc-4ab3-9c56-53bf7940421b",
         "f19fd2fc-586c-45df-9b0c-127af97aef34",
     ]
+    oclc_api_instance.update([str(marc_file)])
+
+
+def test_no_delete_records(mock_oclc_api, caplog):
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+        client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
+        secret="c867b1dd75e6490f99d1cd1c9252ef22",
+    )
+    oclc_api_instance.delete([])
+
+    assert "No marc records for deletes" in caplog.text

--- a/tests/data_exports/test_oclc_api.py
+++ b/tests/data_exports/test_oclc_api.py
@@ -58,6 +58,107 @@ def sample_marc_records():
     return sample
 
 
+def bad_records():
+    sample = []
+    marc_record = pymarc.Record()
+    marc_record.add_field(
+        pymarc.Field(tag='001', data='4566'),
+        pymarc.Field(
+            tag='035',
+            indicators=['', ''],
+            subfields=[pymarc.Subfield(code='a', value='(OCoLC)ocn456907809')],
+        ),
+        pymarc.Field(
+            tag='999',
+            indicators=['f', 'f'],
+            subfields=[
+                pymarc.Subfield(code='i', value='8c9447fa-0556-47cc-98af-c8d5e0d763fb'),
+                pymarc.Subfield(code='s', value='ea5b38dc-8f96-45de-8306-a2dd673716d5'),
+            ],
+        ),
+    )
+    sample.append(marc_record)
+    bad_srs_record = pymarc.Record()
+    bad_srs_record.add_field(
+        pymarc.Field(
+            tag='035',
+            indicators=['', ''],
+            subfields=[pymarc.Subfield(code='a', value='(OCoLC)7789932')],
+        ),
+        pymarc.Field(
+            tag='999',
+            indicators=['f', 'f'],
+            subfields=[
+                pymarc.Subfield(code='i', value='00b492cb-704d-41f4-bd12-74cfe643aea9'),
+                pymarc.Subfield(code='s', value='d63085c0-cab6-4bdd-95e8-d53696919ac1'),
+            ],
+        ),
+    )
+    sample.append(bad_srs_record)
+    no_response_record = pymarc.Record()
+    no_response_record.add_field(
+        pymarc.Field(
+            tag='035',
+            indicators=['', ''],
+            subfields=[pymarc.Subfield(code='a', value='(OCoLC)2369001')],
+        ),
+        pymarc.Field(
+            tag='999',
+            indicators=['f', 'f'],
+            subfields=[
+                pymarc.Subfield(code='i', value='f8fa3682-fef8-4810-b8da-8f51b73785ac'),
+                pymarc.Subfield(code='s', value='6325e8fd-101a-4972-8da7-298cd01d1a9d'),
+            ],
+        ),
+    )
+    sample.append(no_response_record)
+    return sample
+
+
+def missing_or_multiple_oclc_records():
+    sample = []
+    missing_oclc_record = pymarc.Record()
+    missing_oclc_record.add_field(
+        pymarc.Field(
+            tag="245",
+            indicators=[" ", " "],
+            subfields=[pymarc.Subfield(code="a", value="Various Stuff")],
+        ),
+        pymarc.Field(
+            tag='999',
+            indicators=['f', 'f'],
+            subfields=[
+                pymarc.Subfield(code='i', value="958835d2-39cc-4ab3-9c56-53bf7940421b"),
+                pymarc.Subfield(code='s', value='08ca5a68-241a-4a5f-89b9-5af5603981ad'),
+            ],
+        ),
+    )
+    sample.append(missing_oclc_record)
+    multiple_oclc_record = pymarc.Record()
+    multiple_oclc_record.add_field(
+        pymarc.Field(
+            tag='035',
+            indicators=[" ", " "],
+            subfields=[pymarc.Subfield(code='a', value='(OCoLC)2369001')],
+        ),
+        pymarc.Field(
+            tag='035',
+            indicators=[" ", " "],
+            subfields=[pymarc.Subfield(code='a', value='(OCoLC)456789')],
+        ),
+        pymarc.Field(
+            tag='999',
+            indicators=['f', 'f'],
+            subfields=[
+                pymarc.Subfield(code='i', value='f19fd2fc-586c-45df-9b0c-127af97aef34'),
+                pymarc.Subfield(code='s', value='d63085c0-cab6-4bdd-95e8-d53696919ac1'),
+            ],
+        ),
+    )
+    sample.append(multiple_oclc_record)
+    return sample
+
+
 def mock_metadata_session(authorization=None):
     mock_response = MagicMock()
 
@@ -97,12 +198,30 @@ def mock_metadata_session(authorization=None):
         }
         return mock_response
 
+    def mock_holdings_unset(**kwargs):
+        if kwargs["oclcNumber"] == "456907809":
+            raise WorldcatRequestError(b"400 Client Error")
+        if kwargs["oclcNumber"] == "2369001":
+            return
+        mock_response.json = lambda: {
+            'controlNumber': '1125353',
+            'requestedControlNumber': '1125353',
+            'institutionCode': '158223',
+            'institutionSymbol': 'STF',
+            'firstTimeUse': False,
+            'success': True,
+            'message': 'Unset Holdings Succeeded.',
+            'action': 'Unset Holdings',
+        }
+        return mock_response
+
     mock_session = MagicMock()
     # Supports mocking context manager
     mock_session.__enter__ = mock__enter__
     mock_session.__exit__ = mock__exit__
     mock_session.bib_create = mock_bib_create
     mock_session.holdings_set = mock_holdings_set
+    mock_session.holdings_unset = mock_holdings_unset
 
     return mock_session
 
@@ -343,62 +462,13 @@ def test_no_update_records(mock_oclc_api, caplog):
 
 
 def test_bad_holdings_set_call(tmp_path, mock_oclc_api, caplog):
-    marc_record = pymarc.Record()
-    marc_record.add_field(
-        pymarc.Field(tag='001', data='4566'),
-        pymarc.Field(
-            tag='035',
-            indicators=['', ''],
-            subfields=[pymarc.Subfield(code='a', value='(OCoLC)ocn456907809')],
-        ),
-        pymarc.Field(
-            tag='999',
-            indicators=['f', 'f'],
-            subfields=[
-                pymarc.Subfield(code='i', value='8c9447fa-0556-47cc-98af-c8d5e0d763fb'),
-                pymarc.Subfield(code='s', value='ea5b38dc-8f96-45de-8306-a2dd673716d5'),
-            ],
-        ),
-    )
+    error_records = bad_records()
 
-    bad_srs_record = pymarc.Record()
-    bad_srs_record.add_field(
-        pymarc.Field(
-            tag='035',
-            indicators=['', ''],
-            subfields=[pymarc.Subfield(code='a', value='(OCoLC)7789932')],
-        ),
-        pymarc.Field(
-            tag='999',
-            indicators=['f', 'f'],
-            subfields=[
-                pymarc.Subfield(code='i', value='00b492cb-704d-41f4-bd12-74cfe643aea9'),
-                pymarc.Subfield(code='s', value='d63085c0-cab6-4bdd-95e8-d53696919ac1'),
-            ],
-        ),
-    )
-
-    no_response_record = pymarc.Record()
-    no_response_record.add_field(
-        pymarc.Field(
-            tag='035',
-            indicators=['', ''],
-            subfields=[pymarc.Subfield(code='a', value='(OCoLC)2369001')],
-        ),
-        pymarc.Field(
-            tag='999',
-            indicators=['f', 'f'],
-            subfields=[
-                pymarc.Subfield(code='i', value='f8fa3682-fef8-4810-b8da-8f51b73785ac'),
-                pymarc.Subfield(code='s', value='6325e8fd-101a-4972-8da7-298cd01d1a9d'),
-            ],
-        ),
-    )
     marc_file = tmp_path / "202403273-STF.mrc"
 
     with marc_file.open('wb+') as fo:
         marc_writer = pymarc.MARCWriter(fo)
-        for record in [marc_record, bad_srs_record, no_response_record]:
+        for record in error_records:
             marc_writer.write(record)
 
     oclc_api_instance = oclc_api.OCLCAPIWrapper(
@@ -459,50 +529,12 @@ def test_missing_marc_json(mock_oclc_api, caplog):
 
 
 def test_missing_or_multiple_oclc_numbers(mock_oclc_api, caplog, tmp_path):
-    missing_oclc_record = pymarc.Record()
-    missing_oclc_record.add_field(
-        pymarc.Field(
-            tag="245",
-            indicators=[" ", " "],
-            subfields=[pymarc.Subfield(code="a", value="Various Stuff")],
-        ),
-        pymarc.Field(
-            tag='999',
-            indicators=['f', 'f'],
-            subfields=[
-                pymarc.Subfield(code='i', value="958835d2-39cc-4ab3-9c56-53bf7940421b"),
-                pymarc.Subfield(code='s', value='08ca5a68-241a-4a5f-89b9-5af5603981ad'),
-            ],
-        ),
-    )
-    multiple_oclc_record = pymarc.Record()
-
-    multiple_oclc_record.add_field(
-        pymarc.Field(
-            tag='035',
-            indicators=[" ", " "],
-            subfields=[pymarc.Subfield(code='a', value='(OCoLC)2369001')],
-        ),
-        pymarc.Field(
-            tag='035',
-            indicators=[" ", " "],
-            subfields=[pymarc.Subfield(code='a', value='(OCoLC)456789')],
-        ),
-        pymarc.Field(
-            tag='999',
-            indicators=['f', 'f'],
-            subfields=[
-                pymarc.Subfield(code='i', value='f19fd2fc-586c-45df-9b0c-127af97aef34'),
-                pymarc.Subfield(code='s', value='d63085c0-cab6-4bdd-95e8-d53696919ac1'),
-            ],
-        ),
-    )
 
     marc_file = tmp_path / "2024042413-STF.mrc"
 
     with marc_file.open('wb+') as fo:
         marc_writer = pymarc.MARCWriter(fo)
-        for record in [missing_oclc_record, multiple_oclc_record]:
+        for record in missing_or_multiple_oclc_records():
             marc_writer.write(record)
 
     oclc_api_instance = oclc_api.OCLCAPIWrapper(
@@ -516,7 +548,6 @@ def test_missing_or_multiple_oclc_numbers(mock_oclc_api, caplog, tmp_path):
         "958835d2-39cc-4ab3-9c56-53bf7940421b",
         "f19fd2fc-586c-45df-9b0c-127af97aef34",
     ]
-    oclc_api_instance.update([str(marc_file)])
 
 
 def test_no_delete_records(mock_oclc_api, caplog):
@@ -527,3 +558,83 @@ def test_no_delete_records(mock_oclc_api, caplog):
     oclc_api_instance.delete([])
 
     assert "No marc records for deletes" in caplog.text
+
+
+def test_delete_records_success(mock_oclc_api, tmp_path):
+    marc_record = pymarc.Record()
+    marc_record.add_field(
+        pymarc.Field(
+            tag='035',
+            indicators=[" ", " "],
+            subfields=[pymarc.Subfield(code='a', value='(OCoLC)1125353')],
+        ),
+        pymarc.Field(
+            tag='999',
+            indicators=['f', 'f'],
+            subfields=[
+                pymarc.Subfield(code='i', value='f19fd2fc-586c-45df-9b0c-127af97aef34'),
+                pymarc.Subfield(code='s', value='d63085c0-cab6-4bdd-95e8-d53696919ac1'),
+            ],
+        ),
+    )
+
+    marc_file = tmp_path / "202406061104-STF.mrc"
+
+    with marc_file.open('wb+') as fo:
+        marc_writer = pymarc.MARCWriter(fo)
+        marc_writer.write(marc_record)
+
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+        client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
+        secret="c867b1dd75e6490f99d1cd1c9252ef22",
+    )
+
+    result = oclc_api_instance.delete([str(marc_file)])
+
+    assert result["success"] == ['f19fd2fc-586c-45df-9b0c-127af97aef34']
+    assert result['archive'] == [str(marc_file)]
+
+
+def test_delete_errors(mock_oclc_api, caplog, tmp_path):
+
+    marc_file = tmp_path / "2024060611-STF.mrc"
+
+    with marc_file.open('wb+') as fo:
+        marc_writer = pymarc.MARCWriter(fo)
+        for record in bad_records():
+            marc_writer.write(record)
+
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+        client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
+        secret="c867b1dd75e6490f99d1cd1c9252ef22",
+    )
+
+    result = oclc_api_instance.delete([str(marc_file)])
+
+    assert result['success'] == ['00b492cb-704d-41f4-bd12-74cfe643aea9']
+    assert sorted(result['failures']) == [
+        '8c9447fa-0556-47cc-98af-c8d5e0d763fb',
+        'f8fa3682-fef8-4810-b8da-8f51b73785ac',
+    ]
+    assert result['archive'] == []
+
+
+def test_delete_missing_or_multiple_oclc_numbers(mock_oclc_api, tmp_path):
+    marc_file = tmp_path / "2024060612-STF.mrc"
+
+    with marc_file.open('wb+') as fo:
+        marc_writer = pymarc.MARCWriter(fo)
+        for record in missing_or_multiple_oclc_records():
+            marc_writer.write(record)
+
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+        client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
+        secret="c867b1dd75e6490f99d1cd1c9252ef22",
+    )
+
+    results = oclc_api_instance.delete([str(marc_file)])
+
+    assert sorted(results["failures"]) == [
+        "958835d2-39cc-4ab3-9c56-53bf7940421b",
+        "f19fd2fc-586c-45df-9b0c-127af97aef34",
+    ]


### PR DESCRIPTION
Fixes #968 

Calls BookOps `holdings_unset` for MARC record deletes from FOLIO.