### PR TITLE
Move Airflow Logs to Shared directories

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -17,7 +17,7 @@ set :deploy_to, "/home/libsys/#{fetch(:application)}"
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w[]
-set :linked_dirs, %w[.aws config vendor-data vendor-keys data-export-files orafin-files]
+set :linked_dirs, %w[.aws config vendor-data vendor-keys data-export-files orafin-files logs]
 
 # Default value for keep_releases is 5
 set :keep_releases, 2

--- a/libsys_airflow/dags/data_exports/oclc_selections.py
+++ b/libsys_airflow/dags/data_exports/oclc_selections.py
@@ -130,9 +130,9 @@ with DAG(
     @task
     def remove_original_marc_files(**kwargs):
         marc_file_list = kwargs["marc_file_list"]
-        remove_marc_files(str(marc_file_list['new']))
-        remove_marc_files(str(marc_file_list['updates']))
-        remove_marc_files(str(marc_file_list['deletes']))
+        remove_marc_files(marc_file_list['new'])
+        remove_marc_files(marc_file_list['updates'])
+        remove_marc_files(marc_file_list['deletes'])
 
     fetch_marc_records = retrieve_marc_records()
 


### PR DESCRIPTION
Would allow Airflow logs to persist between Capistrano deploys and would prevent issues like #1071. 

Also, when testing this PR on airflow-dev, discovered that I missed one place in the code where lists were being re-cast as a strings that is no longer needed because of PR #1074.