### PR TITLE
Use Active SRS record ID for Updating SRS with Change Manager Endpoint

### DIFF
--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -185,8 +185,10 @@ class OCLCAPIWrapper(object):
             return output
 
         marc_records = self.__read_marc_files__(marc_files)
+
         successful_files: set = set()
         failed_files: set = set()
+
         with MetadataSession(authorization=self.oclc_token) as session:
             for record, file_name in marc_records:
                 instance_uuid = self.__instance_uuid__(record)
@@ -268,6 +270,7 @@ class OCLCAPIWrapper(object):
                 record=marc21,
                 recordFormat="application/marc",
             )
+
             control_number = self.__extract_control_number_035__(new_record.text)
 
             if control_number is None:
@@ -276,11 +279,6 @@ class OCLCAPIWrapper(object):
                 return
 
             modified_marc_record = self.__update_oclc_number__(control_number, record)
-
-            if modified_marc_record is None:
-                output['failures'].append(instance_uuid)
-                failures.add(file_name)
-                return
 
             if self.__put_folio_record__(instance_uuid, modified_marc_record):
                 output['success'].append(instance_uuid)

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -153,11 +153,14 @@ class OCLCAPIWrapper(object):
                     if matched_oclc:
                         suffix, oclc_number = matched_oclc.groups()
                         # Test if control number already exists
-                        if suffix is None and oclc_number == control_number:
-                            # Change prefix to include -M
-                            new_prefix = subfield.value.replace("(OCoLC)", "(OCoLC-M)")
-                            field.subfields.pop(i)
-                            field.add_subfield(code="a", value=new_prefix, pos=i)
+                        if oclc_number == control_number:
+                            if suffix is None:
+                                # Change prefix to include -M
+                                new_prefix = subfield.value.replace(
+                                    "(OCoLC)", "(OCoLC-M)"
+                                )
+                                field.subfields.pop(i)
+                                field.add_subfield(code="a", value=new_prefix, pos=i)
                             needs_new_035 = False
                             break
         if needs_new_035:

--- a/tests/data_exports/test_oclc_api.py
+++ b/tests/data_exports/test_oclc_api.py
@@ -266,7 +266,7 @@ def mock_folio_client(mocker):
                             "recordId": "e941404e-2dab-4a34-8aa5-3dcaef62736b",
                             "parsedRecord": {
                                 "content": json.loads(sample_marc[0].as_json())
-                            }
+                            },
                         }
                     ]
                 }
@@ -277,7 +277,7 @@ def mock_folio_client(mocker):
                             "recordId": "d63085c0-cab6-4bdd-95e8-d53696919ac1",
                             "parsedRecord": {
                                 "content": json.loads(sample_marc[2].as_json())
-                            }
+                            },
                         }
                     ]
                 }
@@ -288,14 +288,12 @@ def mock_folio_client(mocker):
                             "recordId": "4c2d955a-b024-448f-9f7a-6fc1f51416d8",
                             "parsedRecord": {
                                 "content": json.loads(sample_marc[1].as_json())
-                            }
+                            },
                         }
                     ]
                 }
             if args[0].endswith("6aabb9cd-64cc-4673-b63b-d35fa015b91c"):
-                output = {
-                    "sourceRecords": []
-                }
+                output = {"sourceRecords": []}
         if args[0].startswith("/inventory/instances/"):
             for instance_uuid in [
                 "f19fd2fc-586c-45df-9b0c-127af97aef34",
@@ -305,7 +303,7 @@ def mock_folio_client(mocker):
             ]:
                 if args[0].endswith(instance_uuid):
                     output = {"_version": "2", "hrid": "a345691"}
-        
+
         return output
 
     mock = mocker
@@ -554,11 +552,15 @@ def test_missing_srs_record_id(mock_oclc_api, caplog):
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
 
-    srs_record_id = oclc_api_instance.__get_srs_record_id__("6aabb9cd-64cc-4673-b63b-d35fa015b91c")
+    srs_record_id = oclc_api_instance.__get_srs_record_id__(
+        "6aabb9cd-64cc-4673-b63b-d35fa015b91c"
+    )
 
     assert srs_record_id is None
-    assert "No Active SRS record found for 6aabb9cd-64cc-4673-b63b-d35fa015b91c" in caplog.text
-
+    assert (
+        "No Active SRS record found for 6aabb9cd-64cc-4673-b63b-d35fa015b91c"
+        in caplog.text
+    )
 
 
 def test_missing_or_multiple_oclc_numbers(mock_oclc_api, caplog, tmp_path):
@@ -591,13 +593,11 @@ def test_failed_folio_put(mock_oclc_api, caplog):
     )
 
     put_result = oclc_api_instance.__put_folio_record__(
-        "38a7bb66-cd11-4af6-a339-c13f5855b36f",
-        pymarc.Record()
+        "38a7bb66-cd11-4af6-a339-c13f5855b36f", pymarc.Record()
     )
 
     assert put_result is False
 
-    
 
 def test_no_delete_records(mock_oclc_api, caplog):
     oclc_api_instance = oclc_api.OCLCAPIWrapper(


### PR DESCRIPTION
Discovered while testing that the SRS UUID in the 999 field subfield s is not necessarily the correct UUID to use for the Okapi change-manager API. This refactoring retrieves the Active SRS UUID by using the Instance UUID to update the SRS record.