### PR TITLE
Logging and Timeout for OCLC API

### DIFF
--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -205,7 +205,7 @@ class OCLCAPIWrapper(object):
                         failures=failed_files,
                     )
                 except WorldcatRequestError as e:
-                    logger.error(e)
+                    logger.error(f"Instance UUID {instance_uuid} Error: {e}")
                     output['failures'].append(instance_uuid)
                     failed_files.add(file_name)
                     continue
@@ -271,7 +271,8 @@ class OCLCAPIWrapper(object):
                 recordFormat="application/marc",
             )
 
-            control_number = self.__extract_control_number_035__(new_record.text)
+            logging.info(f"Instance UUID {instance_uuid} MARC record added to OCLC {new_record}")
+            control_number = self.__extract_control_number_035__(new_record.content)
 
             if control_number is None:
                 output['failures'].append(instance_uuid)

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -189,7 +189,7 @@ class OCLCAPIWrapper(object):
         successful_files: set = set()
         failed_files: set = set()
 
-        with MetadataSession(authorization=self.oclc_token) as session:
+        with MetadataSession(authorization=self.oclc_token, timeout=30) as session:
             for record, file_name in marc_records:
                 instance_uuid = self.__instance_uuid__(record)
                 if instance_uuid is None:

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -271,7 +271,6 @@ class OCLCAPIWrapper(object):
                 recordFormat="application/marc",
             )
 
-            logging.info(f"Instance UUID {instance_uuid} MARC record added to OCLC {new_record}")
             control_number = self.__extract_control_number_035__(new_record.content)
 
             if control_number is None:

--- a/tests/data_exports/test_oclc_api.py
+++ b/tests/data_exports/test_oclc_api.py
@@ -159,7 +159,7 @@ def missing_or_multiple_oclc_records():
     return sample
 
 
-def mock_metadata_session(authorization=None):
+def mock_metadata_session(authorization=None, timeout=None):
     mock_response = MagicMock()
 
     def mock__enter__(*args):
@@ -189,7 +189,7 @@ def mock_metadata_session(authorization=None):
                     subfields=[pymarc.Subfield(code='a', value='(OCoLC)345678')],
                 )
             )
-        mock_response.text = record.as_marc21()
+        mock_response.content = record.as_marc21()
         return mock_response
 
     def mock_holdings_set(**kwargs):


### PR DESCRIPTION
New logging statement and adds instance UUID to error logging to OCLC API wrapper class. Also, new 30 second timeout for OCLC API HTTP calls. 