### PR TITLE
OCLC Transmission DAG with match support

### DIFF
--- a/libsys_airflow/dags/data_exports/oclc_transmission.py
+++ b/libsys_airflow/dags/data_exports/oclc_transmission.py
@@ -11,7 +11,7 @@ from libsys_airflow.plugins.data_exports.transmission_tasks import (
     delete_from_oclc_task,
     match_oclc_task,
     new_to_oclc_task,
-    update_oclc_task,
+    set_holdings_oclc_task,
     gather_oclc_files_task,
 )
 
@@ -56,7 +56,7 @@ def send_oclc_records():
         connection_details=connections, delete_records=gather_files["deletes"]
     )
 
-    updated_records = update_oclc_task(
+    set_holdings_for_records = set_holdings_oclc_task(
         connection_details=connections, update_records=gather_files["updates"]
     )
 
@@ -72,7 +72,7 @@ def send_oclc_records():
         deleted_records["archive"],
         new_records["archive"],
         matched_records["archive"],
-        updated_records["archive"],
+        set_holdings_for_records["archive"],
     )
 
     archive_data = archive_transmitted_data_task(archive_files)

--- a/libsys_airflow/dags/data_exports/oclc_transmission.py
+++ b/libsys_airflow/dags/data_exports/oclc_transmission.py
@@ -7,7 +7,7 @@ from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
     archive_transmitted_data_task,
-    consolidate_oclc_success_files,
+    consolidate_oclc_archive_files,
     delete_from_oclc_task,
     match_oclc_task,
     new_to_oclc_task,
@@ -68,14 +68,14 @@ def send_oclc_records():
         connection_details=connections, new_records=matched_records["failures"]
     )
 
-    success_files = consolidate_oclc_success_files(
-        deleted_records["success"],
-        new_records["success"],
-        matched_records["success"],
-        updated_records["success"],
+    archive_files = consolidate_oclc_archive_files(
+        deleted_records["archive"],
+        new_records["archive"],
+        matched_records["archive"],
+        updated_records["archive"],
     )
 
-    archive_data = archive_transmitted_data_task(success_files)
+    archive_data = archive_transmitted_data_task(archive_files)
 
     start >> gather_files
     archive_data >> end

--- a/libsys_airflow/dags/data_exports/oclc_transmission.py
+++ b/libsys_airflow/dags/data_exports/oclc_transmission.py
@@ -7,8 +7,12 @@ from airflow.operators.empty import EmptyOperator
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
     archive_transmitted_data_task,
+    consolidate_oclc_success_files,
+    delete_from_oclc_task,
+    match_oclc_task,
+    new_to_oclc_task,
+    update_oclc_task,
     gather_oclc_files_task,
-    transmit_data_oclc_api_task,
 )
 
 logger = logging.getLogger(__name__)
@@ -21,6 +25,14 @@ default_args = {
     "retries": 1,
     "retry_delay": timedelta(minutes=1),
 }
+
+connections = [
+    "http-web.oclc-Business",
+    "http-web.oclc-Hoover",
+    "http-web.oclc-Lane",
+    "http-web.oclc-Law",
+    "http-web.oclc-SUL",
+]
 
 
 @dag(
@@ -40,20 +52,33 @@ def send_oclc_records():
 
     gather_files = gather_oclc_files_task()
 
-    transmit_data = transmit_data_oclc_api_task(
-        [
-            "http-web.oclc-Business",
-            "http-web.oclc-Hoover",
-            "http-web.oclc-Lane",
-            "http-web.oclc-Law",
-            "http-web.oclc-SUL",
-        ],
-        gather_files,
+    deleted_records = delete_from_oclc_task(
+        connection_details=connections, delete_records=gather_files["deletes"]
     )
 
-    archive_data = archive_transmitted_data_task(transmit_data['archive'])
+    updated_records = update_oclc_task(
+        connection_details=connections, update_records=gather_files["updates"]
+    )
 
-    start >> gather_files >> transmit_data >> archive_data >> end
+    matched_records = match_oclc_task(
+        connection_details=connections, new_records=gather_files["new"]
+    )
+
+    new_records = new_to_oclc_task(
+        connection_details=connections, new_records=matched_records["failures"]
+    )
+
+    success_files = consolidate_oclc_success_files(
+        deleted_records["success"],
+        new_records["success"],
+        matched_records["success"],
+        updated_records["success"],
+    )
+
+    archive_data = archive_transmitted_data_task(success_files)
+
+    start >> gather_files
+    archive_data >> end
 
 
 send_oclc_records()

--- a/libsys_airflow/plugins/data_exports/marc/oclc.py
+++ b/libsys_airflow/plugins/data_exports/marc/oclc.py
@@ -1,6 +1,7 @@
 import logging
 import pathlib
 
+import httpx
 import pymarc
 
 from libsys_airflow.plugins.data_exports.marc.transformer import Transformer
@@ -68,11 +69,15 @@ class OCLCTransformer(Transformer):
 
     def determine_campus_code(self, record: pymarc.Record):
         instance_uuid = self.__filter_999__(record)
+        codes: list = []
+        try:
+            holdings_result = self.folio_client.folio_get(
+                f"/holdings-storage/holdings?query=(instanceId=={instance_uuid})"
+            )
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to retrieve holdings; error {e}")
+            return codes
 
-        holdings_result = self.folio_client.folio_get(
-            f"/holdings-storage/holdings?query=(instanceId=={instance_uuid})"
-        )
-        codes = []
         for holding in holdings_result['holdingsRecords']:
             campus = self.campus_lookup.get(holding.get('permanentLocationId'))
             if campus is None:
@@ -113,6 +118,9 @@ class OCLCTransformer(Transformer):
 
             record_ids = get_record_id(record)
             campus_codes = self.determine_campus_code(record)
+
+            if len(campus_codes) < 1:
+                continue
 
             file_path = str(marc_path)
             for code in campus_codes:

--- a/libsys_airflow/plugins/data_exports/marc/oclc.py
+++ b/libsys_airflow/plugins/data_exports/marc/oclc.py
@@ -141,8 +141,12 @@ class OCLCTransformer(Transformer):
                         self.multiple_codes(record, code, record_ids)
 
     def multiple_codes(self, record: pymarc.Record, code: str, record_ids: list):
-        instance_id = record['999']['i']
-        self.staff_notices.append((instance_id, code, record_ids))
+        fields999 = record.get_fields('999')
+        for field in fields999:
+            if field.indicators == ['f', 'f']:
+                instance_id = field['i']
+                self.staff_notices.append((instance_id, code, record_ids))
+                break
 
     def save(self):
         """

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -45,18 +45,19 @@ def oclc_records_operation(**kwargs) -> dict:
 
         success[library] = []
         failures[library] = []
-
+        archive_files = []
         if len(records) > 0:
             oclc_result = oclc_api_function(records)
             success[library].extend(oclc_result['success'])
             failures[library].extend(oclc_result['failures'])
+            archive_files.extend(oclc_result['archive'])
             logger.info(
                 f"Processed {function_name} for {library} successful {len(success[library])} failures {len(failures[library])}"
             )
         else:
             logger.info(f"No {function_name} records for {library}")
 
-    return {"success": success, "failures": failures}
+    return {"success": success, "failures": failures, "archive": archive_files}
 
 
 class OCLCAPIWrapper(object):

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import pathlib
 import re
@@ -301,8 +302,9 @@ class OCLCAPIWrapper(object):
             failures: set = kwargs["failures"]
             successes: set = kwargs["successes"]
 
-            record.remove_fields(*oclc_excluded)
-            marc21 = record.as_marc21()
+            export_record = copy.deepcopy(record)
+            export_record.remove_fields(*oclc_excluded)
+            marc21 = export_record.as_marc21()
 
             matched_record_result = session.bib_match(
                 record=marc21,
@@ -356,8 +358,10 @@ class OCLCAPIWrapper(object):
             successes: set = kwargs["successes"]
             failures: set = kwargs["failures"]
 
-            record.remove_fields(*oclc_excluded)
-            marc21 = record.as_marc21()
+            export_record = copy.deepcopy(record)
+            export_record.remove_fields(*oclc_excluded)
+
+            marc21 = export_record.as_marc21()
             new_record = session.bib_create(
                 record=marc21,
                 recordFormat="application/marc",

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -23,6 +23,29 @@ logger = logging.getLogger(__name__)
 OCLC_REGEX = re.compile(r"\(OCoLC(-[M])?\)(\w+)")
 
 
+def oclc_record_operation(**kwargs):
+    oclc_api_function: Callable = kwargs["oclc_function"]
+    library: str = kwargs["library"]
+    type_of: str = kwargs["type_of"]
+    type_of_records: list = kwargs["records"]
+    success: dict = kwargs.get("success", {})
+    failures: dict = kwargs.get("failures", {})
+
+    for records in type_of_records:
+        success[library] = []
+        failures[library] = []
+
+        if len(records) > 0:
+            oclc_result = oclc_api_function(records)
+            success[library].extend(oclc_result['success'])
+            failures[library].extend(oclc_result['failures'])
+            logger.info(
+                f"Processed {type_of} for {library} successful {len(success[library])} failures {len(failures[library])}"
+            )
+        else:
+            logger.info(f"No {type_of} records for {library}")
+
+
 class OCLCAPIWrapper(object):
     # Helper class for transmitting MARC records to OCLC Worldcat API
 

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -43,19 +43,18 @@ def oclc_records_operation(**kwargs) -> dict:
 
         oclc_api_function = getattr(oclc_api, function_name)
 
-        for records in records:
-            success[library] = []
-            failures[library] = []
+        success[library] = []
+        failures[library] = []
 
-            if len(records) > 0:
-                oclc_result = oclc_api_function(records)
-                success[library].extend(oclc_result['success'])
-                failures[library].extend(oclc_result['failures'])
-                logger.info(
-                    f"Processed {function_name} for {library} successful {len(success[library])} failures {len(failures[library])}"
-                )
-            else:
-                logger.info(f"No {function_name} records for {library}")
+        if len(records) > 0:
+            oclc_result = oclc_api_function(records)
+            success[library].extend(oclc_result['success'])
+            failures[library].extend(oclc_result['failures'])
+            logger.info(
+                f"Processed {function_name} for {library} successful {len(success[library])} failures {len(failures[library])}"
+            )
+        else:
+            logger.info(f"No {function_name} records for {library}")
 
     return {"success": success, "failures": failures}
 

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -201,7 +201,7 @@ def new_to_oclc_task(connection_details: list, new_records: dict) -> dict:
 
 
 @task(multiple_outputs=True)
-def update_oclc_task(connection_details: list, update_records: dict) -> dict:
+def set_holdings_oclc_task(connection_details: list, update_records: dict) -> dict:
 
     connection_lookup = oclc_connections(connection_details)
 

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -169,13 +169,11 @@ def delete_from_oclc_task(connection_details: list, delete_records: dict) -> dic
 
     connection_lookup = oclc_connections(connection_details)
 
-    success, failures = oclc_records_operation(
+    return oclc_records_operation(
         connections=connection_lookup,
-        oclc_api_function="delete",
-        type_of_records=delete_records,
+        oclc_function="delete",
+        records=delete_records,
     )
-
-    return {"success": success, "failures": failures}
 
 
 @task(multiple_outputs=True)
@@ -183,13 +181,11 @@ def match_oclc_task(connection_details: list, new_records: dict) -> dict:
 
     connection_lookup = oclc_connections(connection_details)
 
-    success, failures = oclc_records_operation(
+    return oclc_records_operation(
         connections=connection_lookup,
-        oclc_api_function="delete",
-        type_of_records=new_records,
+        oclc_function="match",
+        records=new_records,
     )
-
-    return {"success": success, "failures": failures}
 
 
 @task(multiple_outputs=True)
@@ -197,13 +193,11 @@ def new_to_oclc_task(connection_details: list, new_records: dict) -> dict:
 
     connection_lookup = oclc_connections(connection_details)
 
-    success, failures = oclc_records_operation(
+    return oclc_records_operation(
         connections=connection_lookup,
-        oclc_api_function="new",
-        type_of_records=new_records,
+        oclc_function="new",
+        records=new_records,
     )
-
-    return {"success": success, "failures": failures}
 
 
 @task(multiple_outputs=True)
@@ -211,13 +205,11 @@ def update_oclc_task(connection_details: list, update_records: dict) -> dict:
 
     connection_lookup = oclc_connections(connection_details)
 
-    success, failures = oclc_records_operation(
+    return oclc_records_operation(
         connections=connection_lookup,
-        oclc_api_function="update",
-        type_of_records=update_records,
+        oclc_function="update",
+        records=update_records,
     )
-
-    return {"success": success, "failures": failures}
 
 
 @task

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -230,6 +230,31 @@ def delete_from_oclc_task(connection_details: list, delete_records: list) -> dic
     return {"success": success, "failures": failures}
 
 
+@task(multiple_outputs=True)
+def match_oclc_task(connection_details: list, new_records: list) -> dict:
+    success: dict = {}
+    failures: dict = {}
+
+    connection_lookup = oclc_connections(connection_details)
+
+    for library, records in new_records.items():
+        oclc_api = OCLCAPIWrapper(
+            client_id=connection_lookup[library]["username"],
+            secret=connection_lookup[library]["password"],
+        )
+
+        oclc_record_operation(
+            library=library,
+            failures=failures,
+            oclc_api_fucntion=oclc_api.match,
+            success=success,
+            type_of="deletes",
+            type_of_records=records,
+        )
+
+    return {"success": success, "failures": failures}
+
+
 @task
 def archive_transmitted_data_task(files):
     """

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -207,7 +207,7 @@ def transmit_data_oclc_api_task(connection_details, libraries) -> dict:
 
 
 @task(multiple_outputs=True)
-def delete_from_oclc_task(connection_details: list, delete_records: list) -> dict:
+def delete_from_oclc_task(connection_details: list, delete_records: dict) -> dict:
     success: dict = {}
     failures: dict = {}
 
@@ -222,7 +222,7 @@ def delete_from_oclc_task(connection_details: list, delete_records: list) -> dic
         oclc_record_operation(
             library=library,
             failures=failures,
-            oclc_api_fucntion=oclc_api.delete,
+            oclc_api_function=oclc_api.delete,
             success=success,
             type_of="deletes",
             type_of_records=records,
@@ -231,7 +231,7 @@ def delete_from_oclc_task(connection_details: list, delete_records: list) -> dic
 
 
 @task(multiple_outputs=True)
-def match_oclc_task(connection_details: list, new_records: list) -> dict:
+def match_oclc_task(connection_details: list, new_records: dict) -> dict:
     success: dict = {}
     failures: dict = {}
 
@@ -246,9 +246,34 @@ def match_oclc_task(connection_details: list, new_records: list) -> dict:
         oclc_record_operation(
             library=library,
             failures=failures,
-            oclc_api_fucntion=oclc_api.match,
+            oclc_api_function=oclc_api.match,
             success=success,
             type_of="deletes",
+            type_of_records=records,
+        )
+
+    return {"success": success, "failures": failures}
+
+
+@task(multiple_outputs=True)
+def update_oclc_task(connection_details: list, update_records: dict) -> dict:
+    success: dict = {}
+    failures: dict = {}
+
+    connection_lookup = oclc_connections(connection_details)
+
+    for library, records in update_records.items():
+        oclc_api = OCLCAPIWrapper(
+            client_id=connection_lookup[library]["username"],
+            secret=connection_lookup[library]["password"],
+        )
+
+        oclc_record_operation(
+            library=library,
+            failures=failures,
+            oclc_api_function=oclc_api.update,
+            success=success,
+            type_of="updates",
             type_of_records=records,
         )
 

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -10,10 +10,8 @@ from airflow.decorators import task
 from airflow.models.connection import Connection
 from airflow.providers.ftp.hooks.ftp import FTPHook
 
-from libsys_airflow.plugins.data_exports.oclc_api import (
-    OCLCAPIWrapper,
-    oclc_records_operation,
-)
+from libsys_airflow.plugins.data_exports.oclc_api import oclc_records_operation
+
 from libsys_airflow.plugins.shared.utils import is_production
 
 logger = logging.getLogger(__name__)
@@ -164,44 +162,6 @@ def transmit_data_ftp_task(conn_id, gather_files) -> dict:
             failures.append(f)
 
     return {"success": success, "failures": failures}
-
-
-@task(multiple_outputs=True)
-def transmit_data_oclc_api_task(connection_details, libraries) -> dict:
-    success: dict = {}
-    failures: dict = {}
-    archive: list = []
-
-    connection_lookup = oclc_connections(connection_details)
-
-    for library, records in libraries.items():
-        success[library] = []
-        failures[library] = []
-
-        oclc_api = OCLCAPIWrapper(
-            client_id=connection_lookup[library]["username"],
-            secret=connection_lookup[library]["password"],
-        )
-        if len(records.get("deletes", [])) > 0:
-            delete_result = oclc_api.delete(records['deletes'])
-            success[library].extend(delete_result['success'])
-            failures[library].extend(delete_result['failures'])
-            archive.extend(delete_result['archive'])
-
-        if len(records.get("new", [])) > 0:
-            new_result = oclc_api.new(records['new'])
-            success[library].extend(new_result['success'])
-            failures[library].extend(new_result['failures'])
-            archive.extend(new_result['archive'])
-
-        if len(records.get("updates", [])) > 0:
-            updated_result = oclc_api.update(records['updates'])
-            success[library].extend(updated_result['success'])
-            failures[library].extend(updated_result['failures'])
-            archive.extend(updated_result['archive'])
-
-    archive = list(set(archive))
-    return {"success": success, "failures": failures, "archive": archive}
 
 
 @task(multiple_outputs=True)

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -213,7 +213,7 @@ def update_oclc_task(connection_details: list, update_records: dict) -> dict:
 
 
 @task
-def consolidate_oclc_success_files(
+def consolidate_oclc_archive_files(
     deleted, matched: list, new_files: list, updated: list
 ) -> list:
     unique_files = set(deleted + matched + new_files + updated)

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -4,9 +4,7 @@ import logging
 import httpx
 
 from pathlib import Path
-from typing import Callable
 from s3path import S3Path
-
 
 from airflow.decorators import task
 from airflow.models.connection import Connection
@@ -263,6 +261,14 @@ def update_oclc_task(connection_details: list, update_records: dict) -> dict:
 
 
 @task
+def consolidate_oclc_success_files(
+    deleted, matched: list, new_files: list, updated: list
+) -> list:
+    unique_files = set(deleted + matched + new_files + updated)
+    return list(unique_files)
+
+
+@task
 def archive_transmitted_data_task(files):
     """
     Given a list of successfully transmitted files, move files to
@@ -271,6 +277,7 @@ def archive_transmitted_data_task(files):
     Also moves the marc files with the same filename as what was transmitted (i.e. GOBI txt files)
     """
     logger.info("Moving transmitted files to archive directory")
+
     if len(files) < 1:
         logger.warning("No files to archive")
         return

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -14,7 +14,7 @@ from airflow.providers.ftp.hooks.ftp import FTPHook
 
 from libsys_airflow.plugins.data_exports.oclc_api import (
     OCLCAPIWrapper,
-    oclc_record_operation,
+    oclc_records_operation,
 )
 from libsys_airflow.plugins.shared.utils import is_production
 
@@ -208,74 +208,56 @@ def transmit_data_oclc_api_task(connection_details, libraries) -> dict:
 
 @task(multiple_outputs=True)
 def delete_from_oclc_task(connection_details: list, delete_records: dict) -> dict:
-    success: dict = {}
-    failures: dict = {}
 
     connection_lookup = oclc_connections(connection_details)
 
-    for library, records in delete_records.items():
-        oclc_api = OCLCAPIWrapper(
-            client_id=connection_lookup[library]["username"],
-            secret=connection_lookup[library]["password"],
-        )
+    success, failures = oclc_records_operation(
+        connections=connection_lookup,
+        oclc_api_function="delete",
+        type_of_records=delete_records,
+    )
 
-        oclc_record_operation(
-            library=library,
-            failures=failures,
-            oclc_api_function=oclc_api.delete,
-            success=success,
-            type_of="deletes",
-            type_of_records=records,
-        )
     return {"success": success, "failures": failures}
 
 
 @task(multiple_outputs=True)
 def match_oclc_task(connection_details: list, new_records: dict) -> dict:
-    success: dict = {}
-    failures: dict = {}
 
     connection_lookup = oclc_connections(connection_details)
 
-    for library, records in new_records.items():
-        oclc_api = OCLCAPIWrapper(
-            client_id=connection_lookup[library]["username"],
-            secret=connection_lookup[library]["password"],
-        )
+    success, failures = oclc_records_operation(
+        connections=connection_lookup,
+        oclc_api_function="delete",
+        type_of_records=new_records,
+    )
 
-        oclc_record_operation(
-            library=library,
-            failures=failures,
-            oclc_api_function=oclc_api.match,
-            success=success,
-            type_of="deletes",
-            type_of_records=records,
-        )
+    return {"success": success, "failures": failures}
+
+
+@task(multiple_outputs=True)
+def new_to_oclc_task(connection_details: list, new_records: dict) -> dict:
+
+    connection_lookup = oclc_connections(connection_details)
+
+    success, failures = oclc_records_operation(
+        connections=connection_lookup,
+        oclc_api_function="new",
+        type_of_records=new_records,
+    )
 
     return {"success": success, "failures": failures}
 
 
 @task(multiple_outputs=True)
 def update_oclc_task(connection_details: list, update_records: dict) -> dict:
-    success: dict = {}
-    failures: dict = {}
 
     connection_lookup = oclc_connections(connection_details)
 
-    for library, records in update_records.items():
-        oclc_api = OCLCAPIWrapper(
-            client_id=connection_lookup[library]["username"],
-            secret=connection_lookup[library]["password"],
-        )
-
-        oclc_record_operation(
-            library=library,
-            failures=failures,
-            oclc_api_function=oclc_api.update,
-            success=success,
-            type_of="updates",
-            type_of_records=records,
-        )
+    success, failures = oclc_records_operation(
+        connections=connection_lookup,
+        oclc_api_function="update",
+        type_of_records=update_records,
+    )
 
     return {"success": success, "failures": failures}
 

--- a/tests/data_exports/test_oclc_api.py
+++ b/tests/data_exports/test_oclc_api.py
@@ -730,3 +730,36 @@ def test_delete_missing_or_multiple_oclc_numbers(mock_oclc_api, tmp_path):
         "958835d2-39cc-4ab3-9c56-53bf7940421b",
         "f19fd2fc-586c-45df-9b0c-127af97aef34",
     ]
+
+
+def test_oclc_records_operation_no_records(mock_oclc_api, caplog):
+    connections = {"STF": {"username": "sul-admin", "password": "123245"}}
+    test_records_dict = {"STF": []}
+
+    result = oclc_api.oclc_records_operation(
+        oclc_function="delete",
+        connections=connections,
+        records=test_records_dict,
+    )
+
+    assert result['success']['STF'] == []
+    assert "No delete records for STF" in caplog.text
+
+
+def test_oclc_records_operation(mocker, mock_oclc_api, tmp_path):
+    connections = {"STF": {"username": "sul-admin", "password": "123245"}}
+
+    marc_file = tmp_path / "2024070113-STF.mrc"
+
+    with marc_file.open('wb+') as fo:
+        marc_writer = pymarc.MARCWriter(fo)
+        for record in missing_or_multiple_oclc_records():
+            marc_writer.write(record)
+
+    test_records_dict = {"STF": [str(marc_file.absolute)]}
+
+    result = oclc_api.oclc_records_operation(
+        oclc_function="delete", connections=connections, records=test_records_dict
+    )
+
+    assert result

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -358,13 +358,17 @@ def test_gather_oclc_files_task(tmp_path):
     updates_stf = updates_path / "20240603113-STF.mrc"
     updates_stf.touch()
 
-    libraries = gather_oclc_files_task.function(airflow=airflow)
+    oclc_ops_libraries = gather_oclc_files_task.function(airflow=airflow)
 
-    assert libraries["STF"] == {
-        "new": [str(new_stf_marc_file)],
-        "updates": [str(updates_stf)],
+    assert oclc_ops_libraries["deletes"] == {
+        "CASUM": [],
+        "HIN": [],
+        "RCJ": [str(deletes_rcj)],
+        "S7Z": [str(deletes_s7z)],
+        "STF": [],
     }
 
-    assert len(libraries["HIN"]["updates"]) == 1
-    assert "deletes" in libraries["RCJ"]
-    assert "updates" not in libraries["CASUM"]
+    assert oclc_ops_libraries["new"]["STF"] == [str(new_stf_marc_file)]
+    assert len(oclc_ops_libraries["new"]["CASUM"]) == 1
+    assert len(oclc_ops_libraries["updates"]["HIN"]) == 1
+    assert len(oclc_ops_libraries["updates"]["CASUM"]) == 0

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -18,6 +18,9 @@ from libsys_airflow.plugins.data_exports.transmission_tasks import (
     archive_transmitted_data_task,
     delete_from_oclc_task,
     gather_oclc_files_task,
+    match_oclc_task,
+    new_to_oclc_task,
+    update_oclc_task,
 )
 
 
@@ -414,4 +417,124 @@ def test_delete_from_oclc_task(mocker, mock_oclc_connection):
     result = delete_from_oclc_task.function(["http-web.oclc-Lane"], delete_records)
 
     assert result['success']["HIN"] == ["160ef499-18a2-47a4-bdab-a31522b10508"]
+    assert result["failures"]["STF"] == ["d0725143-3ab5-472a-bc1e-b11321d72a13"]
+
+
+def test_match_oclc_task(mocker, mock_oclc_connection):
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.transmission_tasks.oclc_connections",
+        return_value={"STF": {"username": "sul-user", "password": "8de1a51e"}},
+    )
+
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.transmission_tasks.oclc_records_operation",
+        return_value={
+            "success": {
+                "CASUM": [],
+                "HIN": [],
+                "RCJ": [],
+                "S7Z": ["160ef499-18a2-47a4-bdab-a31522b10508"],
+                "STF": [],
+            },
+            "failures": {
+                "CASUM": [],
+                "HIN": [],
+                "RCJ": [],
+                "S7Z": [],
+                "STF": ["d0725143-3ab5-472a-bc1e-b11321d72a13"],
+            },
+        },
+    )
+
+    match_records = {
+        "CASUM": [],
+        "HIN": ["/opt/airflow/data-exports/oclc/marc-files/deletes/2024070111-HIN.mrc"],
+        "RCJ": [],
+        "S7Z": [],
+        "STF": ["/opt/airflow/data-exports/oclc/marc-files/deletes/2024070111-STF.mrc"],
+    }
+
+    result = match_oclc_task.function(['http-web.oclc-SUL'], match_records)
+
+    assert result['success']["S7Z"] == ["160ef499-18a2-47a4-bdab-a31522b10508"]
+    assert result["failures"]["STF"] == ["d0725143-3ab5-472a-bc1e-b11321d72a13"]
+
+
+def test_new_to_oclc_task(mocker, mock_oclc_connection):
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.transmission_tasks.oclc_connections",
+        return_value={"STF": {"username": "sul-user", "password": "8de1a51e"}},
+    )
+
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.transmission_tasks.oclc_records_operation",
+        return_value={
+            "success": {
+                "CASUM": [],
+                "HIN": [],
+                "RCJ": [],
+                "S7Z": [],
+                "STF": ["d0725143-3ab5-472a-bc1e-b11321d72a13"],
+            },
+            "failures": {
+                "CASUM": [],
+                "HIN": [],
+                "RCJ": ["160ef499-18a2-47a4-bdab-a31522b10508"],
+                "S7Z": [],
+                "STF": [],
+            },
+        },
+    )
+
+    update_records = {
+        "CASUM": [],
+        "HIN": [],
+        "RCJ": ["/opt/airflow/data-exports/oclc/marc-files/deletes/2024070111-RCJ.mrc"],
+        "S7Z": [],
+        "STF": ["/opt/airflow/data-exports/oclc/marc-files/deletes/2024070111-STF.mrc"],
+    }
+
+    result = new_to_oclc_task.function(['http-web.oclc-SUL'], update_records)
+
+    assert result['success']["STF"] == ["d0725143-3ab5-472a-bc1e-b11321d72a13"]
+    assert result["failures"]["RCJ"] == ["160ef499-18a2-47a4-bdab-a31522b10508"]
+
+
+def test_update_oclc_task(mocker, mock_oclc_connection):
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.transmission_tasks.oclc_connections",
+        return_value={"STF": {"username": "sul-user", "password": "8de1a51e"}},
+    )
+
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.transmission_tasks.oclc_records_operation",
+        return_value={
+            "success": {
+                "CASUM": [],
+                "HIN": [],
+                "RCJ": ["160ef499-18a2-47a4-bdab-a31522b10508"],
+                "S7Z": [],
+                "STF": [],
+            },
+            "failures": {
+                "CASUM": [],
+                "HIN": [],
+                "RCJ": [],
+                "S7Z": [],
+                "STF": ["d0725143-3ab5-472a-bc1e-b11321d72a13"],
+            },
+        },
+    )
+
+    update_records = {
+        "CASUM": [],
+        "HIN": [],
+        "RCJ": ["/opt/airflow/data-exports/oclc/marc-files/deletes/2024070111-RCJ.mrc"],
+        "S7Z": [],
+        "STF": ["/opt/airflow/data-exports/oclc/marc-files/deletes/2024070111-STF.mrc"],
+    }
+
+    result = update_oclc_task.function(['http-web.oclc-SUL'], update_records)
+
+    assert result['success']["RCJ"] == ["160ef499-18a2-47a4-bdab-a31522b10508"]
     assert result["failures"]["STF"] == ["d0725143-3ab5-472a-bc1e-b11321d72a13"]

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -20,7 +20,7 @@ from libsys_airflow.plugins.data_exports.transmission_tasks import (
     gather_oclc_files_task,
     match_oclc_task,
     new_to_oclc_task,
-    update_oclc_task,
+    set_holdings_oclc_task,
 )
 
 
@@ -500,7 +500,7 @@ def test_new_to_oclc_task(mocker, mock_oclc_connection):
     assert result["failures"]["RCJ"] == ["160ef499-18a2-47a4-bdab-a31522b10508"]
 
 
-def test_update_oclc_task(mocker, mock_oclc_connection):
+def test_set_holdings_oclc_task(mocker, mock_oclc_connection):
     mocker.patch(
         "libsys_airflow.plugins.data_exports.transmission_tasks.oclc_connections",
         return_value={"STF": {"username": "sul-user", "password": "8de1a51e"}},
@@ -534,7 +534,7 @@ def test_update_oclc_task(mocker, mock_oclc_connection):
         "STF": ["/opt/airflow/data-exports/oclc/marc-files/deletes/2024070111-STF.mrc"],
     }
 
-    result = update_oclc_task.function(['http-web.oclc-SUL'], update_records)
+    result = set_holdings_oclc_task.function(['http-web.oclc-SUL'], update_records)
 
     assert result['success']["RCJ"] == ["160ef499-18a2-47a4-bdab-a31522b10508"]
     assert result["failures"]["STF"] == ["d0725143-3ab5-472a-bc1e-b11321d72a13"]


### PR DESCRIPTION
Fixes #1094 

Refactors OCLC Transmission DAG by breaking out `deletes`, `updates`, `new` into separate tasks and adds new `match` task as a dependency for the `updates` task. 

New DAG diagram:
![Screenshot 2024-06-25 at 4 29 01 PM](https://github.com/sul-dlss/libsys-airflow/assets/71847/dc6e3973-0eec-4611-8c15-5cbb1b28f3e7)

TODO:
- [x] Increase test coverage for:
  - [x] oclc_api
  - [x] transmission_tasks