### PR TITLE
Adds logic and test for passing url_params for pod full dump transmission.

### DIFF
--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -5,6 +5,7 @@ import httpx
 
 from pathlib import Path
 from s3path import S3Path
+from datetime import datetime
 
 from airflow.decorators import task
 from airflow.models.connection import Connection
@@ -110,6 +111,11 @@ def transmit_data_http_task(gather_files, **kwargs) -> dict:
     url_params = kwargs.get("url_params", {})
     params = kwargs.get("params", {})
     conn_id = params["vendor"]
+    # sets stream for POD full dumps
+    if conn_id == "pod" and gather_files["s3"]:
+        url_params = {"stream": datetime.now().strftime('%Y-%m-%d')}
+        logger.info(f"Setting url_params to {url_params}")
+
     logger.info(f"Transmit data to {conn_id}")
     connection = Connection.get_connection_from_secrets(conn_id)
     if gather_files["s3"]:

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -117,7 +117,9 @@ def transmit_data_http_task(gather_files, **kwargs) -> dict:
     else:
         path_module = Path
     with httpx.Client(
-        headers=connection.extra_dejson, params=vendor_url_params(conn_id, gather_files["s3"]), follow_redirects=True
+        headers=connection.extra_dejson,
+        params=vendor_url_params(conn_id, gather_files["s3"]),
+        follow_redirects=True,
     ) as client:
         for f in gather_files["file_list"]:
             files = {files_params: path_module(f).open("rb")}
@@ -300,7 +302,7 @@ def vendor_url_params(conn_id, is_s3_path) -> dict:
         logger.info(f"Setting URL params to {url_params}")
     else:
         url_params = {}
-    
+
     return url_params
 
 

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -263,6 +263,7 @@ def test_transmit_data_from_s3_task(
         params={"vendor": "pod", "bucket": "data-export-test"},
     )
     assert len(transmit_data_from_s3["success"]) == 3
+    assert "Setting url_params to" in caplog.text
 
 
 def test_transmit_data_failed(

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -238,7 +238,7 @@ def test_transmit_data_task(
     )
     assert len(transmit_data["success"]) == 3
     assert "Transmit data to pod" in caplog.text
-    assert not "Setting URL params to" in caplog.text
+    assert "Setting URL params to" not in caplog.text
 
 
 def test_transmit_data_from_s3_task(

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -4,6 +4,7 @@ import pathlib
 import httpx
 
 from http import HTTPStatus
+from datetime import datetime
 
 from airflow.models import Connection
 
@@ -237,6 +238,7 @@ def test_transmit_data_task(
     )
     assert len(transmit_data["success"]) == 3
     assert "Transmit data to pod" in caplog.text
+    assert not "Setting URL params to" in caplog.text
 
 
 def test_transmit_data_from_s3_task(
@@ -263,7 +265,8 @@ def test_transmit_data_from_s3_task(
         params={"vendor": "pod", "bucket": "data-export-test"},
     )
     assert len(transmit_data_from_s3["success"]) == 3
-    assert "Setting url_params to" in caplog.text
+    stream = {"stream": datetime.now().strftime('%Y-%m-%d')}
+    assert f"Setting URL params to {stream}" in caplog.text
 
 
 def test_transmit_data_failed(


### PR DESCRIPTION
Closes #1114 

This seemed the safest way to add a JSON object to the url_params for just POD for full dump.