### PR TITLE
Ignores type checking for indicators usage

### DIFF
--- a/libsys_airflow/plugins/data_exports/marc/transformer.py
+++ b/libsys_airflow/plugins/data_exports/marc/transformer.py
@@ -174,7 +174,7 @@ class Transformer(object):
         return fields
 
     def add_holdings_subfields(self, holding: dict) -> pymarc.Field:
-        field_999 = pymarc.Field(tag="999", indicators=[' ', ' '])
+        field_999 = pymarc.Field(tag="999", indicators=[' ', ' '])  # type: ignore
         if len(holding.get("holdingsTypeId", "")) > 0:
             holdings_type_name = self.holdings_type.get(holding["holdingsTypeId"])
             if holdings_type_name:

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -204,7 +204,7 @@ class OCLCAPIWrapper(object):
         if needs_new_035:
             new_035 = pymarc.Field(
                 tag='035',
-                indicators=[' ', ' '],
+                indicators=[' ', ' '],  # type: ignore
                 subfields=[
                     pymarc.Subfield(code='a', value=f"(OCoLC-M){control_number}")
                 ],

--- a/libsys_airflow/plugins/vendor/marc.py
+++ b/libsys_airflow/plugins/vendor/marc.py
@@ -306,9 +306,9 @@ def _has_matching_field(record: pymarc.Record, field: MarcField):
 
 
 def _field_match(field: MarcField, check_field: pymarc.Field):
-    if field.indicator1 and check_field.indicators[0] != field.indicator1:
+    if field.indicator1 and check_field.indicators[0] != field.indicator1:  # type: ignore
         return False
-    if field.indicator2 and check_field.indicators[1] != field.indicator2:
+    if field.indicator2 and check_field.indicators[1] != field.indicator2:  # type: ignore
         return False
     for subfield in field.subfields:
         check_subfield_value = ''.join(check_field.get_subfields(subfield.code))

--- a/tests/data_exports/test_marc_exports.py
+++ b/tests/data_exports/test_marc_exports.py
@@ -205,7 +205,7 @@ def test_marc_for_instances(mocker, tmp_path, mock_folio_client):
 
 field_035 = pymarc.Field(
     tag='035',
-    indicators=[' ', '9'],
+    indicators=[' ', '9'],  # type: ignore
     subfields=[pymarc.Subfield(code='a', value='gls19291491')],
 )
 
@@ -213,13 +213,13 @@ field_008 = pymarc.Field(tag='008', data='920218s1990    ja a          000 0 jpn
 
 field_590 = pymarc.Field(
     tag="590",
-    indicators=[' ', ' '],
+    indicators=[' ', ' '],  # type: ignore
     subfields=[pymarc.Subfield(code='a', value='MARCit brief record')],
 )
 
 field_915 = pymarc.Field(
     tag="915",
-    indicators=['1', '0'],
+    indicators=['1', '0'],  # type: ignore
     subfields=[
         pymarc.Subfield(code='a', value='NO EXPORT'),
         pymarc.Subfield(code='b', value='FOR SU ONLY'),
@@ -228,7 +228,7 @@ field_915 = pymarc.Field(
 
 field_915_alt = pymarc.Field(
     tag='915',
-    indicators=[' ', '1'],
+    indicators=[' ', '1'],  # type: ignore
     subfields=[pymarc.Subfield(code='a', value='NO EXPORT')],
 )
 


### PR DESCRIPTION
Types hints in pymarc 5.2.0 doesn't account for acceptable alternative uses of new Indicators class.