### PR TITLE
OCLC Error Reporting UI and multiple_oclc_numbers report

### DIFF
--- a/libsys_airflow/plugins/data_exports/apps/data_export_oclc_reports_view.py
+++ b/libsys_airflow/plugins/data_exports/apps/data_export_oclc_reports_view.py
@@ -1,0 +1,62 @@
+import pathlib
+
+from flask_appbuilder import expose, BaseView as AppBuilderBaseView
+
+
+LOOKUP_LIBRARY_CODE = {
+    "CASUM": "Lane Medical Library",
+    "HIN": "Hoover Institution Library and Archives",
+    "RCJ": "Robert Crown Law Library",
+    "S7Z": "Graduate School of Business",
+    "STF": "Stanford University Libraries",
+}
+
+LOOKUP_REPORT_NAME = {
+    "match": "Match BIB Record Errors",
+    "multiple_oclc_numbers": "Multiple OCLC Numbers",
+    "set_holdings": "Set OCLC Holdings Errors",
+}
+
+
+class DataExportOCLCReportsView(AppBuilderBaseView):
+    default_view = "data_export_oclc_reports_home"
+    route_base = "/data_export_oclc_reports"
+    # files_base = "data-export-files"
+
+    @expose("/")
+    def data_export_oclc_reports_home(self):
+        oclc_reports_home = pathlib.Path("/opt/airflow/data-export-files/oclc/reports")
+        libraries = {}
+        for library in oclc_reports_home.iterdir():
+            if not library.is_dir():
+                continue
+            libraries[library.name] = {
+                "name": LOOKUP_LIBRARY_CODE[library.name],
+            }
+
+            for report_type in library.iterdir():
+                if not report_type.is_dir():
+                    continue
+                libraries[library.name][report_type.name] = {
+                    "name": LOOKUP_REPORT_NAME[report_type.name],
+                    "reports": [],
+                }
+                for report in report_type.glob("*.html"):
+                    libraries[library.name][report_type.name]["reports"].append(report)
+
+        return self.render_template(
+            "data-export-oclc-reports/index.html", libraries=libraries
+        )
+
+    @expose("/<library_code>/<report_type>/<report_name>")
+    def oclc_report(self, library_code, report_type, report_name):
+        report_path = pathlib.Path(
+            f"/opt/airflow/data-export-files/oclc/reports/{library_code}/{report_type}/{report_name}"
+        )
+
+        return self.render_template(
+            "data-export-oclc-reports/report.html",
+            library_name=LOOKUP_LIBRARY_CODE[library_code],
+            report_name=LOOKUP_REPORT_NAME[report_type],
+            contents=report_path.read_text(),
+        )

--- a/libsys_airflow/plugins/data_exports/main.py
+++ b/libsys_airflow/plugins/data_exports/main.py
@@ -8,7 +8,7 @@ from libsys_airflow.plugins.data_exports.apps.data_export_download_view import (
     DataExportDownloadView,
 )
 from libsys_airflow.plugins.data_exports.apps.data_export_oclc_reports_view import (
-    DataExportOCLCReportsView
+    DataExportOCLCReportsView,
 )
 
 data_export_upload_bp = Blueprint(
@@ -39,8 +39,9 @@ data_export_oclc_reports_view = DataExportOCLCReportsView()
 data_export_oclc_reports_view_package = {
     "name": "Data Export OCLC Reports",
     "category": "FOLIO",
-    "view": data_export_oclc_reports_view
+    "view": data_export_oclc_reports_view,
 }
+
 
 class DataExportUploadPlugin(AirflowPlugin):
     name = "Data Export CSV Upload"

--- a/libsys_airflow/plugins/data_exports/main.py
+++ b/libsys_airflow/plugins/data_exports/main.py
@@ -7,12 +7,18 @@ from libsys_airflow.plugins.data_exports.apps.data_export_upload_view import (
 from libsys_airflow.plugins.data_exports.apps.data_export_download_view import (
     DataExportDownloadView,
 )
+from libsys_airflow.plugins.data_exports.apps.data_export_oclc_reports_view import (
+    DataExportOCLCReportsView
+)
 
 data_export_upload_bp = Blueprint(
     "data_export_upload", __name__, template_folder="templates"
 )
 data_export_download_bp = Blueprint(
     "data_export_download", __name__, template_folder="templates"
+)
+data_export_oclc_reports_bp = Blueprint(
+    "data_export_oclc_reports", __name__, template_folder="templates"
 )
 
 data_export_upload_view = DataExportUploadView()
@@ -29,6 +35,12 @@ data_export_download_view_package = {
     "view": data_export_download_view,
 }
 
+data_export_oclc_reports_view = DataExportOCLCReportsView()
+data_export_oclc_reports_view_package = {
+    "name": "Data Export OCLC Reports",
+    "category": "FOLIO",
+    "view": data_export_oclc_reports_view
+}
 
 class DataExportUploadPlugin(AirflowPlugin):
     name = "Data Export CSV Upload"
@@ -49,4 +61,15 @@ class DataExportDownloadPlugin(AirflowPlugin):
     executors = []
     admin_views = []
     appbuilder_views = [data_export_download_view_package]
+    appbuilder_menu_items = []
+
+
+class DataExportOCLCReportsPlugin(AirflowPlugin):
+    name = "Data Export OCLC Reports"
+    operators = []  # type: ignore
+    flask_blueprints = [data_export_oclc_reports_bp]
+    hooks = []
+    executors = []
+    admin_views = []
+    appbuilder_views = [data_export_oclc_reports_view_package]
     appbuilder_menu_items = []

--- a/libsys_airflow/plugins/data_exports/oclc_reports.py
+++ b/libsys_airflow/plugins/data_exports/oclc_reports.py
@@ -1,0 +1,119 @@
+import logging
+
+from datetime import datetime, UTC
+from pathlib import Path
+
+from airflow.decorators import task
+from airflow.models import Variable
+from jinja2 import Template
+
+logger = logging.getLogger(__name__)
+
+multiple_oclc_numbers_template = """
+ <h1>Multiple OCLC Numbers on {{ date }} for {{ library }}</h1>
+
+ <p>
+  <a href="{{ dag_run.url }}">DAG Run</a>
+ </p>
+
+ <h2>FOLIO Instances with Multiple OCLC Numbers</h2>
+ <ol>
+{% for instance in instances.values() %}
+ <li>
+   <a href="{{ instance.folio_url }}">{{ instance.uuid }}</a>:
+   <ul>
+   {% for num in instance.oclc_numbers %}
+    <li>{{ num }}</li>
+   {% endfor %}
+   </ul>
+ </li>
+{% endfor %}
+  </ol>
+"""
+
+
+def _generate_multiple_oclc_numbers_report(**kwargs) -> dict:
+    airflow_dir: str = kwargs.get('airflow', '/opt/airflow')
+    airflow = Path(airflow_dir)
+    dag_run: dict = kwargs['dag_run']
+    multiple_codes: list = kwargs['all_multiple_codes']
+    folio_base_url: str = kwargs['folio_url']
+    date: datetime = kwargs.get('date', datetime.now(UTC))
+
+    def _folio_url(instance_uuid: dict):
+        return f"{folio_base_url}/inventory/view/{instance_uuid}"
+
+    reports: dict = {}
+    report_template = Template(multiple_oclc_numbers_template)
+
+    library_instances: dict = {}
+
+    for row in multiple_codes:
+        instance_uuid = row[0]
+        library_code = row[1]
+        oclc_codes = row[2]
+
+        if library_code in library_instances:
+            library_instances[library_code][instance_uuid] = {
+                "oclc_numbers": oclc_codes
+            }
+        else:
+            library_instances[library_code] = {
+                instance_uuid: {"oclc_numbers": oclc_codes}
+            }
+
+    for library, instances in library_instances.items():
+        for uuid, info in instances.items():
+            info['folio_url'] = _folio_url(uuid)
+            info['uuid'] = uuid
+        reports[library] = report_template.render(
+            dag_run=dag_run,
+            date=date.strftime("%d %B %Y"),
+            library=library,
+            instances=instances,
+        )
+
+    reports_path = airflow / "data-export-files/oclc/reports"
+
+    return _save_reports(
+        name="multiple_oclc_numbers",
+        reports=reports,
+        reports_path=reports_path,
+        date=date,
+    )
+
+
+def _save_reports(**kwargs) -> dict:
+    name: str = kwargs['name']
+    libraries_reports: dict = kwargs['reports']
+    reports_directory: Path = kwargs['reports_path']
+    time_stamp: datetime = kwargs['date']
+
+    output: dict = {}
+
+    for library, report in libraries_reports.items():
+        reports_path = reports_directory / library / name
+        reports_path.mkdir(parents=True, exist_ok=True)
+        report_path = reports_path / f"{time_stamp.isoformat()}.html"
+        report_path.write_text(report)
+        logger.info(f"Created {name} report for {library} at {report_path}")
+        output[library] = str(report_path)
+
+    return output
+
+
+@task
+def multiple_oclc_numbers_task(**kwargs):
+    task_instance = kwargs['ti']
+
+    new_multiple_records = task_instance.xcom_pull(
+        task_ids='divide_new_records_by_library'
+    )
+    deletes_multiple_records = task_instance.xcom_pull(
+        task_ids='divide_delete_records_by_library'
+    )
+    kwargs['all_multiple_codes'] = new_multiple_records + deletes_multiple_records
+
+    kwargs['folio_url'] = Variable.get("FOLIO_URL")
+
+    return _generate_multiple_oclc_numbers_report(**kwargs)

--- a/libsys_airflow/plugins/data_exports/oclc_reports.py
+++ b/libsys_airflow/plugins/data_exports/oclc_reports.py
@@ -1,6 +1,6 @@
 import logging
 
-from datetime import datetime, UTC
+from datetime import datetime
 from pathlib import Path
 
 from airflow.decorators import task
@@ -38,7 +38,7 @@ def _generate_multiple_oclc_numbers_report(**kwargs) -> dict:
     dag_run: dict = kwargs['dag_run']
     multiple_codes: list = kwargs['all_multiple_codes']
     folio_base_url: str = kwargs['folio_url']
-    date: datetime = kwargs.get('date', datetime.now(UTC))
+    date: datetime = kwargs.get('date', datetime.utcnow())
 
     def _folio_url(instance_uuid: dict):
         return f"{folio_base_url}/inventory/view/{instance_uuid}"

--- a/libsys_airflow/plugins/data_exports/templates/data-export-oclc-reports/index.html
+++ b/libsys_airflow/plugins/data_exports/templates/data-export-oclc-reports/index.html
@@ -1,0 +1,74 @@
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+<div>
+  <h2>OCLC Data Export Reports</h2>
+  <ul>
+    <li><a href="#STF">Stanford University Libraries</a></li>
+    <li><a href="#CASUM">Lane Medical Library</a></li>
+    <li><a href="#RCJ">Robert Crown Law Library</a></li>
+    <li><a href="#HIN">Hoover Institution Library and Archives</a></li>
+    <li><a href="#S7Z">Graduate School of Business</a></li>
+  </ul>
+  {% for code, library in libraries.items() %}
+  <div id="{{ code }}">
+    <h3>{{ library.name }}</h3>
+    <div>
+      <h4>Multiple OCLC Numbers</h4>
+      <table>
+        <tr>
+      {% for column in library.get('multiple_oclc_numbers', {}).get('reports', [])|slice(3)  %}
+        <td>
+          <ul>
+          {% for report in column %}
+           <li>
+             <a href="{{ url_for('DataExportOCLCReportsView.oclc_report', library_code=code, report_type='multiple_oclc_numbers', report_name=report.name) }}">{{ report.name }}</a>
+            </li>
+          {% endfor %}
+          </ul>
+         </td>
+      {% endfor %} 
+        </tr>
+      </table>
+    </div>
+    <div>
+      <h4>Match Errors</h4>
+      <table>
+        <tr>
+        {% for column in library.get('match', {}).get('reports', [])|slice(3)  %}
+        <td>
+          <ul>
+            {% for report in column %}
+            <li>
+              <a href="{{ url_for('DataExportOCLCReportsView.oclc_report', library_code=code, report_type='match', report_name=report.name) }}">{{ report.name }}</a>
+             </li>
+            {% endfor %}
+          </ul>
+        </td>
+        {% endfor %}
+        </tr>
+      </table>
+    </div>
+    <div>
+      <h4>Set Holdings Errors</h4>
+      <table>
+        <tr>
+        {% for column in library.get('set_holdings', {}).get('reports', [])|slice(3)  %}
+          <td>
+          <ul>
+          {% for report in column %}
+            <li>
+              <a href="{{ url_for('DataExportOCLCReportsView.oclc_report', library_code=code, report_type='set_holdings', report_name=report.name) }}">{{ report.name }}</a>
+            </li>
+          {% endfor %}
+          </ul>
+          </td>
+        {% endfor %}
+        </tr>
+      </table>
+    </div>
+  </div>
+  <hr>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/libsys_airflow/plugins/data_exports/templates/data-export-oclc-reports/report.html
+++ b/libsys_airflow/plugins/data_exports/templates/data-export-oclc-reports/report.html
@@ -1,0 +1,10 @@
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+<div>
+  <h3>{{ library_name }}</h3>
+  <div>
+    {{ contents|safe }}
+  </div>
+</div>
+{% endblock %}

--- a/tests/data_exports/test_oclc_reports.py
+++ b/tests/data_exports/test_oclc_reports.py
@@ -1,0 +1,79 @@
+import datetime
+import pathlib
+
+import pytest
+
+from bs4 import BeautifulSoup
+from libsys_airflow.plugins.data_exports import oclc_reports
+
+
+@pytest.fixture
+def mock_dag_run(mocker):
+    mock_dag = mocker.MagicMock()
+    mock_dag.url = "https://folio-airflow.edu/scheduled__2024-07-29T19:00:00:00:00"
+    return mock_dag
+
+
+@pytest.fixture
+def mock_task_instance(mocker):
+
+    def mock_xcom_pull(**kwargs):
+        output = []
+        match kwargs['task_ids']:
+
+            case 'divide_delete_records_by_library':
+                output = [
+                    ('f82cb6d4-2d8a-41af-aa32-72b7ad881e3c', 'CASUM', ['4', '67']),
+                    ('16f3b2ba-caf3-467e-bcb1-9463356bd5fb', 'STF', ['89', '91']),
+                ]
+
+            case 'divide_new_records_by_library':
+                output = [
+                    (
+                        'eb20e968-3f24-4987-9635-55fb7b1f906c',
+                        'STF',
+                        ['276045320', '145453718'],
+                    )
+                ]
+
+        return output
+
+    mock_ti = mocker.MagicMock()
+    mock_ti.xcom_pull = mock_xcom_pull
+    return mock_ti
+
+
+def test_multiple_oclc_numbers_task(tmp_path, mocker, mock_task_instance, mock_dag_run):
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.oclc_reports.Variable.get",
+        return_value="https://folio-stanford.edu",
+    )
+
+    reports = oclc_reports.multiple_oclc_numbers_task.function(
+        airflow=tmp_path,
+        date=datetime.datetime(2024, 7, 29, 14, 19, 34, 245),
+        ti=mock_task_instance,
+        dag_run=mock_dag_run,
+    )
+
+    sul_report = pathlib.Path(reports['STF'])
+    lane_report = pathlib.Path(reports['CASUM'])
+
+    sul_report_html = BeautifulSoup(sul_report.read_text(), 'html.parser')
+    lane_report_html = BeautifulSoup(lane_report.read_text(), 'html.parser')
+
+    h1_sul = sul_report_html.find('h1')
+    assert h1_sul.text.startswith("Multiple OCLC Numbers on 29 July 2024 for STF")
+
+    sul_li_instances = sul_report_html.select('ol > li')
+    assert len(sul_li_instances) == 2
+
+    instance_01_oclc_numbers = sul_li_instances[0].find_all("li")
+    assert instance_01_oclc_numbers[0].text.startswith("276045320")
+    assert instance_01_oclc_numbers[1].text.startswith("145453718")
+
+    dag_anchor = lane_report_html.find("a")
+    assert dag_anchor.text.startswith("DAG Run")
+    assert dag_anchor.attrs['href'].startswith(
+        "https://folio-airflow.edu/scheduled__2024-07-29"
+    )


### PR DESCRIPTION
Partial fixes #1080 

This PR implements a `multiple_oclc_numbers` report and creates a new OCLC Report view with all error reports being written as HTML file to a new `data-exports-files/oclc/reports` top-level directory that contains subfolders for SUL and cohort libraries. Each library folder contains folders for the different type of reports. Report file structure:

```
data-export-files/oclc/reports/
  CASUM/
  HIN/
  RCJ/
  S7Z/ 
  STF/
    bib_create/
    match/
    multiple_oclc_numbers/
      2024-07-28T13:34:00.00000.html
      2024-07-31T10:00:00.00000.html
      ...
    set_holdings/
    unset_holdings/
```

The UI exposes each report as an URL that will be included in a notification email. The remaining work on ticket #1080 includes generating the reports for `match`, `set_holdings`, `unset_holdings`, and `bib_create` failures and adding email notifications with links to the corresponding reports in the emails.

## UI Screenshots
Main page:
<img width="1112" alt="Screenshot 2024-07-31 at 12 46 38 PM" src="https://github.com/user-attachments/assets/677fca06-b9cd-499c-b675-22606ab0e43a">

Single `multiple_oclc_numbers`  Report:
<img width="1043" alt="Screenshot 2024-07-31 at 12 20 16 PM" src="https://github.com/user-attachments/assets/f81736b7-f409-44d2-90bd-3f37afc6719b">



