### PR TITLE
Changes OCLC API to use a Dictionary for Errors

### DIFF
--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -1,5 +1,4 @@
 import copy
-import json
 import logging
 import pathlib
 import re

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -296,22 +296,16 @@ class OCLCAPIWrapper(object):
 
             oclc_id = get_record_id(record)
 
-            if len(oclc_id) != 1:
+            error_payload = self.__test_oclc_numbers__(oclc_id, instance_uuid)
+
+            if error_payload:
+                output['failures'].append(error_payload)
                 failures.add(file_name)
-                output['failures'].append(instance_uuid)
-                match len(oclc_id):
-
-                    case 0:
-                        logger.error(f"{instance_uuid} missing OCLC number")
-
-                    case _:
-                        logger.error(f"Multiple OCLC ids for {instance_uuid}")
-
                 return
 
             response = session.holdings_unset(oclcNumber=oclc_id[0])
             if response:
-                  response = response.json()
+                response = response.json()
 
             if response and response['success']:
                 logger.info(f"Matched {instance_uuid} result {response.json()}")
@@ -376,7 +370,7 @@ class OCLCAPIWrapper(object):
                 update_holding_result = session.holdings_set(oclcNumber=control_number)
 
                 if update_holding_result is not None:
-                      update_holding_result = update_holding_result.json()
+                    update_holding_result = update_holding_result.json()
 
                 if update_holding_result and update_holding_result['success']:
                     logger.info(
@@ -554,12 +548,10 @@ class OCLCAPIWrapper(object):
                 )
                 failures.add(file_name)
                 return
-            
+
             control_number = set_payload['controlNumber']
 
-            modified_marc_record = self.__update_oclc_number__(
-                control_number, record
-            )
+            modified_marc_record = self.__update_oclc_number__(control_number, record)
             if self.__put_folio_record__(instance_uuid, modified_marc_record):
                 output['success'].append(instance_uuid)
                 successes.add(file_name)

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import logging
 import pathlib
 import re
@@ -244,12 +245,44 @@ class OCLCAPIWrapper(object):
                         failures=failed_files,
                     )
                 except WorldcatRequestError as e:
-                    logger.error(f"Instance UUID {instance_uuid} Error: {e}")
-                    output['failures'].append(instance_uuid)
+                    msg = f"Instance UUID {instance_uuid} Error: {e}"
+                    logger.error(msg)
+                    output['failures'].append(
+                        {
+                            "uuid": instance_uuid,
+                            "reason": "WorldcatRequest Error",
+                            "context": str(e),
+                        }
+                    )
                     failed_files.add(file_name)
                     continue
         output["archive"] = list(successful_files.difference(failed_files))
         return output
+
+    def __test_oclc_numbers__(self, oclc_numbers: list, instance_uuid: str):
+        error_payload = None
+        if len(oclc_numbers) != 1:
+            match len(oclc_numbers):
+
+                case 0:
+                    msg = "Missing OCLC number"
+                    error_payload = {
+                        "uuid": instance_uuid,
+                        "reason": msg,
+                        "context": None,
+                    }
+
+                case _:
+                    msg = "Multiple OCLC ids"
+                    error_payload = {
+                        "uuid": instance_uuid,
+                        "reason": msg,
+                        "context": sorted(oclc_numbers),  # type: ignore
+                    }
+
+            logger.error(msg)
+
+        return error_payload
 
     def delete(self, marc_files: List[str]) -> dict:
 
@@ -278,14 +311,20 @@ class OCLCAPIWrapper(object):
                 return
 
             response = session.holdings_unset(oclcNumber=oclc_id[0])
-            if response is None:
-                logger.info(f"Failed to match {instance_uuid}")
-                output['failures'].append(instance_uuid)
-                failures.add(file_name)
-            else:
+            if response:
+                  response = response.json()
+
+            if response and response['success']:
                 logger.info(f"Matched {instance_uuid} result {response.json()}")
                 output['success'].append(instance_uuid)
                 successes.add(file_name)
+            else:
+                msg = "Failed holdings_unset"
+                logger.info(f"{msg} for {instance_uuid} OCLC response: {response}")
+                output['failures'].append(
+                    {"uuid": instance_uuid, "reason": msg, "context": response}
+                )
+                failures.add(file_name)
 
         output = self.__oclc_operations__(
             marc_files=marc_files,
@@ -316,7 +355,13 @@ class OCLCAPIWrapper(object):
             logger.info(f"Matched Record Result {matched_record_result.json()}")
             matched_record = matched_record_result.json()
             if matched_record['numberOfRecords'] < 1:
-                output['failures'].append(instance_uuid)
+                output['failures'].append(
+                    {
+                        "uuid": instance_uuid,
+                        "reason": "Match failed",
+                        "context": matched_record,
+                    }
+                )
                 failures.add(file_name)
                 return
 
@@ -326,23 +371,38 @@ class OCLCAPIWrapper(object):
 
             modified_marc_record = self.__update_oclc_number__(control_number, record)
 
-            successful_match = False
             if self.__put_folio_record__(instance_uuid, modified_marc_record):
 
                 # Sets holdings using the OCLC number
                 update_holding_result = session.holdings_set(oclcNumber=control_number)
 
-                if update_holding_result:
+                if update_holding_result is not None:
+                      update_holding_result = update_holding_result.json()
+
+                if update_holding_result and update_holding_result['success']:
                     logger.info(
                         f"Sets new holdings for {instance_uuid} OCLC {update_holding_result}"
                     )
-                    successful_match = True
+                    output['success'].append(instance_uuid)
+                    successes.add(file_name)
+                    return
 
-            if successful_match:
-                output['success'].append(instance_uuid)
-                successes.add(file_name)
+                output['failures'].append(
+                    {
+                        "uuid": instance_uuid,
+                        "reason": "Failed to update holdings after match",
+                        "context": update_holding_result,
+                    }
+                )
+                failures.add(file_name)
             else:
-                output['failures'].append(instance_uuid)
+                output['failures'].append(
+                    {
+                        "uuid": instance_uuid,
+                        "reason": "FOLIO failed to Add OCLC number",
+                        "context": control_number,
+                    }
+                )
                 failures.add(file_name)
 
         output = self.__oclc_operations__(
@@ -353,6 +413,40 @@ class OCLCAPIWrapper(object):
         return output
 
     def new(self, marc_files: dict) -> dict:
+
+        def __add_update_control_number__(**kwargs):
+            session: MetadataSession = kwargs["session"]
+            control_number: str = kwargs["control_number"]
+            record: pymarc.Record = kwargs["record"]
+            output: dict = kwargs["output"]
+            instance_uuid: str = kwargs["instance_uuid"]
+            file_name: str = kwargs["file_name"]
+            failures: set = kwargs["failures"]
+
+            modified_marc_record = self.__update_oclc_number__(control_number, record)
+            successful_add = False
+
+            if self.__put_folio_record__(instance_uuid, modified_marc_record):
+                # Sets holdings using the OCLC number
+                new_holding_result = session.holdings_set(oclcNumber=control_number)
+                if new_holding_result:
+                    payload = new_holding_result.json()
+                    if payload['success']:
+                        logger.info(
+                            f"Sets new holdings for {instance_uuid} OCLC {payload}"
+                        )
+                        output['success'].append(instance_uuid)
+                        successful_add = True
+                    else:
+                        output['failures'].append(
+                            {
+                                "uuid": instance_uuid,
+                                "reason": "Failed to update holdings for new record",
+                                "context": payload,
+                            }
+                        )
+                        failures.add(file_name)
+            return successful_add
 
         def __new_oclc__(**kwargs):
             session: MetadataSession = kwargs["session"]
@@ -378,25 +472,40 @@ class OCLCAPIWrapper(object):
 
             successful_add = False
             if control_number:
-                modified_marc_record = self.__update_oclc_number__(
-                    control_number, record
+                successful_add = __add_update_control_number__(
+                    session=session,
+                    instance_uuid=instance_uuid,
+                    control_number=control_number,
+                    output=output,
+                    record=record,
+                    successes=successes,
+                    failures=failures,
+                    file_name=file_name,
                 )
 
-                if self.__put_folio_record__(instance_uuid, modified_marc_record):
-                    # Sets holdings using the OCLC number
-                    new_holding_result = session.holdings_set(oclcNumber=control_number)
-                    if new_holding_result:
-                        logger.info(
-                            f"Sets new holdings for {instance_uuid} OCLC {new_holding_result}"
-                        )
-                        successful_add = True
+            else:
+                output['failures'].append(
+                    {
+                        "uuid": instance_uuid,
+                        "reason": "Failed to extract OCLC number",
+                        "context": None,
+                    }
+                )
+                failures.add(file_name)
+                return
 
             if successful_add:
-                output['success'].append(instance_uuid)
+                if instance_uuid not in output['success']:
+                    output['success'].append(instance_uuid)
                 successes.add(file_name)
             else:
-                output['failures'].append(instance_uuid)
-                failures.add(file_name)
+                output['failures'].append(
+                    {
+                        "uuid": instance_uuid,
+                        "reason": "FOLIO failed to Add OCLC number",
+                        "context": control_number,
+                    }
+                )
 
         output = self.__oclc_operations__(
             marc_files=marc_files,
@@ -416,32 +525,53 @@ class OCLCAPIWrapper(object):
             failures: set = kwargs["failures"]
 
             oclc_id = get_record_id(record)
-            if len(oclc_id) != 1:
-                output['failures'].append(instance_uuid)
+            error_payload = self.__test_oclc_numbers__(oclc_id, instance_uuid)
+            if error_payload:
+                output['failures'].append(error_payload)
                 failures.add(file_name)
-
-                match len(oclc_id):
-
-                    case 0:
-                        logger.error(f"{instance_uuid} missing OCLC number")
-
-                    case _:
-                        logger.error(f"Multiple OCLC ids for {instance_uuid}")
-
                 return
+
             response = session.holdings_set(oclcNumber=oclc_id[0])
+
             if response is None:
-                output['failures'].append(instance_uuid)
+                output['failures'].append(
+                    {
+                        "uuid": instance_uuid,
+                        "reason": "No response from OCLC",
+                        "context": None,
+                    }
+                )
                 failures.add(file_name)
                 return
+
+            set_payload = response.json()
+            if not set_payload['success']:
+                output["failures"].append(
+                    {
+                        "uuid": instance_uuid,
+                        "reason": "Failed to update holdings",
+                        "context": set_payload,
+                    }
+                )
+                failures.add(file_name)
+                return
+            
+            control_number = set_payload['controlNumber']
+
             modified_marc_record = self.__update_oclc_number__(
-                response.json()['controlNumber'], record
+                control_number, record
             )
             if self.__put_folio_record__(instance_uuid, modified_marc_record):
                 output['success'].append(instance_uuid)
                 successes.add(file_name)
             else:
-                output['failures'].append(instance_uuid)
+                output['failures'].append(
+                    {
+                        "uuid": instance_uuid,
+                        "reason": "FOLIO failed to Add OCLC number",
+                        "context": control_number,
+                    }
+                )
                 failures.add(file_name)
 
         output = self.__oclc_operations__(

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -180,8 +180,11 @@ def delete_from_oclc_task(connection_details: list, delete_records: dict) -> dic
     )
 
 
-def __filter_save_marc__(file_str: str, instance_uuids: list):
-    new_records = []
+def __filter_save_marc__(file_str: str, info: list):
+    new_records, instance_uuids = [], []
+    for row in info:
+        if row['reason'].startswith("Match failed"):
+            instance_uuids.append(row['uuid'])
     file_path = Path(file_str)
     with file_path.open('rb') as fo:
         marc_reader = pymarc.MARCReader(fo)

--- a/tests/data_exports/test_oclc_api.py
+++ b/tests/data_exports/test_oclc_api.py
@@ -112,6 +112,41 @@ def bad_records():
         ),
     )
     sample.append(no_response_record)
+    failed_response_record = pymarc.Record()
+    failed_response_record.add_field(
+        pymarc.Field(
+            tag='035',
+            indicators=['', ''],
+            subfields=[pymarc.Subfield(code='a', value='(OCoLC)17032778')],
+        ),
+        pymarc.Field(
+            tag='999',
+            indicators=['f', 'f'],
+            subfields=[
+                pymarc.Subfield(code='i', value='ce4b5983-ff44-4b27-ab3c-d63a38095e30')
+            ],
+        ),
+    )
+    sample.append(failed_response_record)
+    bad_oclc_num = pymarc.Record()
+
+    bad_oclc_num.add_field(
+        pymarc.Field(tag='008', data="a7340114"),
+        pymarc.Field(
+            tag='035',
+            indicators=[" ", " "],
+            subfields=[pymarc.Subfield(code='a', value="(OCoLC)39301853")],
+        ),
+        pymarc.Field(
+            tag='999',
+            indicators=['f', 'f'],
+            subfields=[
+                pymarc.Subfield(code='i', value='7063655a-6196-416f-94e7-8d540e014805'),
+                pymarc.Subfield(code='s', value='08ca5a68-241a-4a5f-89b9-5af5603981ad'),
+            ],
+        ),
+    )
+    sample.append(bad_oclc_num)
     return sample
 
 
@@ -492,7 +527,13 @@ def test_failed_oclc_new_record(tmp_path, mock_oclc_api):
     new_response = oclc_api_instance.new([str(marc_file.absolute())])
 
     assert new_response["success"] == []
-    assert new_response["failures"] == ['e15e3707-f012-482f-a13b-34556b6d0946']
+    assert new_response["failures"] == [
+        {
+            "uuid": 'e15e3707-f012-482f-a13b-34556b6d0946',
+            "reason": "WorldcatRequest Error",
+            "context": "b'400 Client Error'",
+        }
+    ]
 
 
 def test_new_no_control_number(mock_oclc_api, tmp_path):
@@ -525,7 +566,13 @@ def test_new_no_control_number(mock_oclc_api, tmp_path):
     new_response = oclc_api_instance.new([str(marc_file.absolute())])
 
     assert new_response["success"] == []
-    assert new_response["failures"] == [instance_uuid]
+    assert new_response["failures"] == [
+        {
+            "uuid": instance_uuid,
+            "reason": 'Failed to extract OCLC number',
+            "context": None,
+        }
+    ]
 
 
 def test_bad_srs_put_in_new_context(tmp_path, mock_oclc_api):
@@ -544,7 +591,13 @@ def test_bad_srs_put_in_new_context(tmp_path, mock_oclc_api):
     new_results = oclc_api_instance.new([str(marc_file.absolute())])
 
     assert new_results['success'] == []
-    assert new_results['failures'] == ['f19fd2fc-586c-45df-9b0c-127af97aef34']
+    assert new_results['failures'] == [
+        {
+            "uuid": 'f19fd2fc-586c-45df-9b0c-127af97aef34',
+            "reason": "FOLIO failed to Add OCLC number",
+            "context": "445667",
+        }
+    ]
     assert new_results['archive'] == []
 
 
@@ -576,11 +629,41 @@ def test_bad_holdings_set_call(tmp_path, mock_oclc_api, caplog):
     update_result = oclc_api_instance.update([str(marc_file.absolute())])
 
     assert update_result['success'] == []
-    assert sorted(update_result['failures']) == [
-        '00b492cb-704d-41f4-bd12-74cfe643aea9',
-        '8c9447fa-0556-47cc-98af-c8d5e0d763fb',
-        'f8fa3682-fef8-4810-b8da-8f51b73785ac',
-    ]
+    sorted_failures = sorted(update_result['failures'], key=lambda x: x['uuid'])
+
+    assert sorted_failures[0] == {
+        "uuid": '00b492cb-704d-41f4-bd12-74cfe643aea9',
+        "reason": 'FOLIO failed to Add OCLC number',
+        "context": "439887343",
+    }
+    assert sorted_failures[1] == {
+        'uuid': '7063655a-6196-416f-94e7-8d540e014805',
+        'reason': 'Failed to update holdings',
+        'context': {
+            'controlNumber': '39301853',
+            'requestedControlNumber': '39301853',
+            'institutionCode': '158223',
+            'institutionSymbol': 'STF',
+            'success': False,
+            'message': 'Holding Updated Failed',
+            'action': 'Set Holdings',
+        },
+    }
+    assert sorted_failures[2] == {
+        "uuid": '8c9447fa-0556-47cc-98af-c8d5e0d763fb',
+        "reason": "WorldcatRequest Error",
+        "context": "b'400 Client Error'",
+    }
+    assert sorted_failures[3] == {
+        "uuid": 'ce4b5983-ff44-4b27-ab3c-d63a38095e30',
+        "reason": "FOLIO failed to Add OCLC number",
+        "context": '439887343',
+    }
+    assert sorted_failures[4] == {
+        "uuid": 'f8fa3682-fef8-4810-b8da-8f51b73785ac',
+        "reason": 'No response from OCLC',
+        "context": None,
+    }
 
     assert "400 Client Error" in caplog.text
 
@@ -641,10 +724,19 @@ def test_missing_or_multiple_oclc_numbers(mock_oclc_api, caplog, tmp_path):
 
     update_results = oclc_api_instance.update([str(marc_file)])
 
-    assert sorted(update_results["failures"]) == [
-        "958835d2-39cc-4ab3-9c56-53bf7940421b",
-        "f19fd2fc-586c-45df-9b0c-127af97aef34",
-    ]
+    sorted_errors = sorted(update_results["failures"], key=lambda x: x['uuid'])
+
+    assert sorted_errors[0] == {
+        "uuid": "958835d2-39cc-4ab3-9c56-53bf7940421b",
+        "reason": "Missing OCLC number",
+        "context": None,
+    }
+
+    assert sorted_errors[1] == {
+        "uuid": "f19fd2fc-586c-45df-9b0c-127af97aef34",
+        "reason": "Multiple OCLC ids",
+        "context": ['2369001', '456789'],
+    }
 
 
 def test_failed_folio_put(mock_oclc_api, caplog):
@@ -722,11 +814,39 @@ def test_delete_errors(mock_oclc_api, caplog, tmp_path):
 
     result = oclc_api_instance.delete([str(marc_file)])
 
-    assert result['success'] == ['00b492cb-704d-41f4-bd12-74cfe643aea9']
-    assert sorted(result['failures']) == [
-        '8c9447fa-0556-47cc-98af-c8d5e0d763fb',
-        'f8fa3682-fef8-4810-b8da-8f51b73785ac',
+    assert result['success'] == [
+        '00b492cb-704d-41f4-bd12-74cfe643aea9',
+        '7063655a-6196-416f-94e7-8d540e014805',
     ]
+
+    sorted_failures = sorted(result['failures'], key=lambda x: x['uuid'])
+
+    assert sorted_failures[0] == {
+        "uuid": '8c9447fa-0556-47cc-98af-c8d5e0d763fb',
+        "reason": "WorldcatRequest Error",
+        "context": "b'400 Client Error'",
+    }
+
+    assert sorted_failures[1] == {
+        "uuid": 'ce4b5983-ff44-4b27-ab3c-d63a38095e30',
+        "reason": "Failed holdings_unset",
+        "context": {
+            'controlNumber': '17032778',
+            'requestedControlNumber': '17032778',
+            'institutionCode': '158223',
+            'institutionSymbol': 'STF',
+            'firstTimeUse': False,
+            'success': False,
+            'message': 'Unset Holdings Failed',
+            'action': 'Unset Holdings',
+        },
+    }
+    assert sorted_failures[2] == {
+        "uuid": 'f8fa3682-fef8-4810-b8da-8f51b73785ac',
+        "reason": "Failed holdings_unset",
+        "context": None,
+    }
+
     assert result['archive'] == []
 
 
@@ -745,10 +865,19 @@ def test_delete_missing_or_multiple_oclc_numbers(mock_oclc_api, tmp_path):
 
     results = oclc_api_instance.delete([str(marc_file)])
 
-    assert sorted(results["failures"]) == [
-        "958835d2-39cc-4ab3-9c56-53bf7940421b",
-        "f19fd2fc-586c-45df-9b0c-127af97aef34",
-    ]
+    sorted_failures = sorted(results["failures"], key=lambda x: x['uuid'])
+
+    assert sorted_failures[0] == {
+        "uuid": "958835d2-39cc-4ab3-9c56-53bf7940421b",
+        "reason": "Missing OCLC number",
+        "context": None,
+    }
+
+    assert sorted_failures[1] == {
+        "uuid": "f19fd2fc-586c-45df-9b0c-127af97aef34",
+        "reason": 'Multiple OCLC ids',
+        "context": ['2369001', '456789'],
+    }
 
 
 def test_match_oclc_number(mock_oclc_api, tmp_path, caplog):
@@ -778,18 +907,7 @@ def test_match_oclc_number(mock_oclc_api, tmp_path, caplog):
         ),
     )
 
-    bad_oclc_num = pymarc.Record()
-
-    bad_oclc_num.add_field(
-        pymarc.Field(tag='008', data="a9007876"),
-        pymarc.Field(
-            tag='999',
-            indicators=['f', 'f'],
-            subfields=[
-                pymarc.Subfield(code='i', value='00b492cb-704d-41f4-bd12-74cfe643aea9')
-            ],
-        ),
-    )
+    bad_oclc_num = bad_records()[-1]
 
     marc_file = tmp_path / "2024070114-STF.mrc"
 
@@ -805,11 +923,35 @@ def test_match_oclc_number(mock_oclc_api, tmp_path, caplog):
 
     result = oclc_api_instance.match([str(marc_file)])
 
-    result["success"] == ['958835d2-39cc-4ab3-9c56-53bf7940421b']
-    result["failures"] == [
-        '2023473e-802a-4bd2-9ca1-5d2e360a0fbd',
-        '00b492cb-704d-41f4-bd12-74cfe643aea9',
-    ]
+    assert result["success"] == ['958835d2-39cc-4ab3-9c56-53bf7940421b']
+
+    sorted_failures = sorted(result["failures"], key=lambda x: x['uuid'])
+
+    assert sorted_failures[0] == {
+        "uuid": '2023473e-802a-4bd2-9ca1-5d2e360a0fbd',
+        "reason": 'Match failed',
+        "context": {'numberOfRecords': 0, 'briefRecords': []},
+    }
+
+    assert sorted_failures[1] == {
+        "uuid": '7063655a-6196-416f-94e7-8d540e014805',
+        "reason": 'Failed to update holdings after match',
+        "context": {
+            'controlNumber': '39301853',
+            'requestedControlNumber': '39301853',
+            'institutionCode': '158223',
+            'institutionSymbol': 'STF',
+            'success': False,
+            'message': 'Holding Updated Failed',
+            'action': 'Set Holdings',
+        },
+    }
+
+    assert sorted_failures[2] == {
+        "uuid": 'f19fd2fc-586c-45df-9b0c-127af97aef34',
+        "reason": "FOLIO failed to Add OCLC number",
+        "context": '445667',
+    }
 
     assert "Sets new holdings for 958835d2-39cc-4ab3-9c56-53bf7940421b" in caplog.text
 

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -499,8 +499,16 @@ def test_filter_new_marc_records_task(mocker, tmp_path):
         'CASUM': [],
         'RCJ': [],
         'STF': [
-            '4fb17691-4984-4407-81de-c30894c1226e',
-            'd50e776b-a2ed-4740-a94d-9d858db98ccb',
+            {
+                "uuid": '4fb17691-4984-4407-81de-c30894c1226e',
+                "reason": "Match failed",
+                "context": {'numberOfRecords': 0, 'briefRecords': []},
+            },
+            {
+                "uuid": 'd50e776b-a2ed-4740-a94d-9d858db98ccb',
+                "reason": "Match failed",
+                "context": {'numberOfRecords': 0, 'briefRecords': []},
+            },
         ],
     }
 


### PR DESCRIPTION
Needed better way to record and pass errors through the OCLC transmission DAG to support the types of reports in #1080. This PR switch from using tuples when a failure occurs to using a dictionary. 

The error dictionary is easier to reason about and use in the oclc_reports.py module. This PR will be used in a follow-up PR to add the `holdings_set` and `holdings_unset` Reports.