### PR TITLE
OCLC Holdings Set and Unset Reports w/email

### DIFF
--- a/libsys_airflow/dags/data_exports/oclc_transmission.py
+++ b/libsys_airflow/dags/data_exports/oclc_transmission.py
@@ -75,7 +75,7 @@ def send_oclc_records():
 
     filtered_new_records = filter_new_marc_records_task(
         new_records=gather_files["new"],
-        new_instance_uuids=matched_records["failures"],
+        failed_matches=matched_records["failures"],
     )
 
     new_records = new_to_oclc_task(

--- a/libsys_airflow/plugins/data_exports/apps/data_export_oclc_reports_view.py
+++ b/libsys_airflow/plugins/data_exports/apps/data_export_oclc_reports_view.py
@@ -15,6 +15,7 @@ LOOKUP_REPORT_NAME = {
     "match": "Match BIB Record Errors",
     "multiple_oclc_numbers": "Multiple OCLC Numbers",
     "set_holdings": "Set OCLC Holdings Errors",
+    "unset_holdings": "Unset (delete) OCLC Holdings Errors",
 }
 
 

--- a/libsys_airflow/plugins/data_exports/email.py
+++ b/libsys_airflow/plugins/data_exports/email.py
@@ -43,7 +43,8 @@ def generate_holdings_errors_emails(error_reports: dict):
     law_email = Variable.get("OCLC_EMAIL_LAW")
     sul_email = Variable.get("OCLC_EMAIL_SUL")
 
-    airflow_url = conf.get('webserver')  # type: ignore
+    airflow_url = conf.get('webserver', 'base_url')  # type: ignore
+
     if not airflow_url.endswith("/"):
         airflow_url = f"{airflow_url}/"
 

--- a/libsys_airflow/plugins/data_exports/oclc_reports.py
+++ b/libsys_airflow/plugins/data_exports/oclc_reports.py
@@ -134,6 +134,9 @@ def _generate_holdings_set_report(**kwargs) -> dict:
 
     match = kwargs.get("match", False)
 
+    if date not in kwargs:
+        kwargs["date"] = date
+
     error_key = "Failed to update holdings"
     report_name = "set_holdings"
     if match:
@@ -159,6 +162,9 @@ def _generate_holdings_unset_report(**kwargs) -> dict:
     date: datetime = kwargs.get('date', datetime.utcnow())
     failures: dict = kwargs.pop('failures')
 
+    if date not in kwargs:
+        kwargs["date"] = date
+
     library_instances = _library_instances(failures, 'Failed holdings_unset')
 
     kwargs['library_instances'] = library_instances
@@ -168,7 +174,7 @@ def _generate_holdings_unset_report(**kwargs) -> dict:
 
     return _save_reports(
         airflow=kwargs.get('airflow', '/opt/airflow'),
-        name="holdings_unset",
+        name="unset_holdings",
         reports=reports,
         date=date,
     )
@@ -306,7 +312,7 @@ def holdings_set_errors_task(**kwargs):
 @task
 def holdings_unset_errors_task(**kwargs):
     kwargs['folio_url'] = Variable.get("FOLIO_URL")
-    
+
     return _generate_holdings_unset_report(**kwargs)
 
 

--- a/libsys_airflow/plugins/data_exports/oclc_reports.py
+++ b/libsys_airflow/plugins/data_exports/oclc_reports.py
@@ -15,7 +15,7 @@ holdings_set_template = """
   <a href="{{ dag_run.url }}">DAG Run</a>
 </p>
 <h2>FOLIO Instances that failed trying to set Holdings {% if match %}after successful Match{% endif %}</h2>
-<table>
+<table class="table table-striped">
   <thead>
     <tr>
       <th>Instance</th>
@@ -47,7 +47,7 @@ holdings_unset_template = """
   <a href="{{ dag_run.url }}">DAG Run</a>
 </p>
 <h2>FOLIO Instances that failed trying to unset Holdings</h2>
-<table>
+<table class="table table-striped">
   <thead>
     <tr>
       <th>Instance</th>
@@ -93,6 +93,21 @@ multiple_oclc_numbers_template = """
   </ol>
 """
 
+oclc_payload_template = """<ul>
+        <li><strong>Control Number:</strong> {{ instance.oclc_error.controlNumber }}</li>
+        <li><strong>Requested Control Number:</strong> {{ instance.oclc_error.requestedControlNumber }}</li>
+        <li><strong>Institution:</strong>
+           <ul>
+             <li><em>Code:</em> {{ instance.oclc_error.institutionCode }}</li>
+             <li><em>Symbol:</em> {{ instance.oclc_error.institutionSymbol }}</li>
+           </ul>
+        </li>
+        <li><strong>First Time Use:</strong> {{ instance.oclc_error.firstTimeUse }}</li>
+        <li><strong>Success:</strong> {{ instance.oclc_error.success }}</li>
+        <li><strong>Message:</strong> {{ instance.oclc_error.message }}</li>
+        <li><strong>Action:</strong> {{ instance.oclc_error.action }}</li>
+     </ul>
+"""
 
 jinja_env = Environment(
     loader=DictLoader(
@@ -100,6 +115,7 @@ jinja_env = Environment(
             "holdings-set.html": holdings_set_template,
             "holdings-unset.html": holdings_unset_template,
             "multiple-oclc-numbers.html": multiple_oclc_numbers_template,
+            "oclc-payload-template.html": oclc_payload_template,
         }
     )
 )

--- a/libsys_airflow/plugins/data_exports/oclc_reports.py
+++ b/libsys_airflow/plugins/data_exports/oclc_reports.py
@@ -9,6 +9,38 @@ from jinja2 import DictLoader, Environment
 
 logger = logging.getLogger(__name__)
 
+holdings_set_template = """
+<h1>OCLC Holdings {% if match %}Matched {% endif %}Set Errors on {{ date }} for {{ library }}</h1>
+<p>
+  <a href="{{ dag_run.url }}">DAG Run</a>
+</p>
+<h2>FOLIO Instances that failed trying to set Holdings {% if match %}after successful Match{% endif %}</h2>
+<table>
+  <thead>
+    <tr>
+      <th>Instance</th>
+      <th>OCLC Response</th>
+    </tr>
+  </thead>
+  <tbody>
+{% for instance in instances.values() %}
+  <tr>
+    <td>
+      <a href="{{ instance.folio_url }}">{{ instance.uuid }}</a>
+    </td>
+    <td>
+    {% if instance.oclc_error %}
+    {% include 'oclc-payload-template.html' %}
+    {% else %}
+     No response from OCLC set API call
+     {% endif %}
+    </td>
+  </tr>
+{% endfor %}
+  </tbody>
+</table>
+"""
+
 multiple_oclc_numbers_template = """
  <h1>Multiple OCLC Numbers on {{ date }} for {{ library }}</h1>
 
@@ -64,11 +96,50 @@ def _folio_url(folio_base_url: str, instance_uuid: dict):
     return f"{folio_base_url}/inventory/view/{instance_uuid}"
 
 
+def _generate_holdings_set_report(**kwargs) -> dict:
+    date: datetime = kwargs.get('date', datetime.utcnow())
+    failures: dict = kwargs.pop('failures')
+
+    match = kwargs.get("match", False)
+
+    error_key = "Failed to update holdings"
+    report_name = "set_holdings"
+    if match:
+        report_name = "set_holdings_match"
+        error_key = "Failed to update holdings after match"
+
+    kwargs["error_key"] = error_key
+
+    library_instances: dict = {}
+
+    for library_code, errors in failures.items():
+        update_holdings_errors = errors.get(error_key, [])
+        if len(update_holdings_errors) < 1:
+            continue
+        if library_code not in library_instances:
+            library_instances[library_code] = {}
+        for row in update_holdings_errors:
+            library_instances[library_code][row['uuid']] = {
+                "uuid": row['uuid'],
+                "oclc_error": row['context'],
+            }
+
+    kwargs['library_instances'] = library_instances
+    kwargs['report_template'] = "holdings-set.html"
+
+    reports = _reports_by_library(**kwargs)
+
+    return _save_reports(
+        airflow=kwargs.get('airflow', '/opt/airflow'),
+        name=report_name,
+        reports=reports,
+        date=date,
+    )
+
+
 def _generate_multiple_oclc_numbers_report(**kwargs) -> dict:
     multiple_codes: list = kwargs['all_multiple_codes']
     date: datetime = kwargs.get('date', datetime.utcnow())
-
-    reports: dict = {}
 
     library_instances: dict = {}
 
@@ -170,6 +241,13 @@ def filter_failures_task(**kwargs) -> dict:
 
     logger.info(filtered_errors)
     return filtered_errors
+
+
+@task
+def holdings_set_errors_task(**kwargs):
+    kwargs['folio_url'] = Variable.get("FOLIO_URL")
+
+    return _generate_holdings_set_report(**kwargs)
 
 
 @task

--- a/libsys_airflow/plugins/data_exports/templates/data-export-oclc-reports/index.html
+++ b/libsys_airflow/plugins/data_exports/templates/data-export-oclc-reports/index.html
@@ -67,6 +67,24 @@
         </tr>
       </table>
     </div>
+    <div>
+      <h4>Unset Holdings Errors</h4>
+      <table>
+        <tr>
+        {% for column in library.get('unset_holdings', {}).get('reports', [])|slice(3)  %}
+          <td>
+          <ul>
+          {% for report in column %}
+            <li>
+              <a href="{{ url_for('DataExportOCLCReportsView.oclc_report', library_code=code, report_type='unset_holdings', report_name=report.name) }}">{{ report.name }}</a>
+            </li>
+          {% endfor %}
+          </ul>
+          </td>
+        {% endfor %}
+        </tr>
+      </table>
+    </div>
   </div>
   <hr>
   {% endfor %}

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -201,14 +201,14 @@ def __filter_save_marc__(file_str: str, info: list):
 
 
 @task(multiple_outputs=True)
-def filter_new_marc_records_task(new_records: dict, new_instance_uuids: dict) -> dict:
+def filter_new_marc_records_task(new_records: dict, failed_matches: dict) -> dict:
     filtered_new_records: dict = {}
-    for library, uuids in new_instance_uuids.items():
+    for library, info in failed_matches.items():
         filtered_new_records[library] = []
-        if len(uuids) > 0:
+        if len(info) > 0:
             new_files = new_records[library]
             for row in new_files:
-                __filter_save_marc__(row, uuids)
+                __filter_save_marc__(row, info)
             filtered_new_records[library] = new_files
 
     return filtered_new_records

--- a/tests/data_exports/test_oclc_reports.py
+++ b/tests/data_exports/test_oclc_reports.py
@@ -239,12 +239,14 @@ def test_holdings_set_errors_task(tmp_path, mocker, mock_dag_run):
     )
 
     failures = {
-        "RCJ": {
-            "Failed to update holdings": [
-                {"uuid": ERRORS[6]["uuid"], "context": ERRORS[6]["context"]}
-            ]
-        },
-        "STF": {},
+        "RCJ": [
+            {
+                "reason": "Failed to update holdings",
+                "uuid": ERRORS[6]["uuid"],
+                "context": ERRORS[6]["context"],
+            }
+        ],
+        "STF": [],
     }
 
     reports = holdings_set_errors_task.function(

--- a/tests/data_exports/test_oclc_reports.py
+++ b/tests/data_exports/test_oclc_reports.py
@@ -1,10 +1,16 @@
+import copy
 import datetime
 import pathlib
 
 import pytest
 
 from bs4 import BeautifulSoup
-from libsys_airflow.plugins.data_exports import oclc_reports
+
+from libsys_airflow.plugins.data_exports.oclc_reports import (
+    filter_failures_task,
+    holdings_set_errors_task,
+    multiple_oclc_numbers_task,
+)
 
 
 @pytest.fixture
@@ -142,6 +148,7 @@ ERRORS = [
             'requestedControlNumber': '48780294',
             'institutionCode': '158223',
             'institutionSymbol': 'RCJ',
+            'firstTimeUse': False,
             'success': False,
             'message': 'Holding Updated Failed',
             'action': 'Set Holdings',
@@ -159,7 +166,7 @@ def test_filter_failures_task_no_failures(caplog):
 
     update_failures = {'S7Z': [], 'HIN': [], 'CASUM': [], 'RCJ': [], 'STF': []}
 
-    filtered_errors = oclc_reports.filter_failures_task.function(
+    filtered_errors = filter_failures_task.function(
         delete=deleted_failures,
         match=match_failures,
         new=new_failures,
@@ -206,7 +213,7 @@ def test_filter_failures_task(caplog):
 
     update_failures = {'S7Z': [], 'HIN': [], 'CASUM': [], 'RCJ': [ERRORS[6]], 'STF': []}
 
-    filtered_errors = oclc_reports.filter_failures_task.function(
+    filtered_errors = filter_failures_task.function(
         delete=deleted_failures,
         match=match_failures,
         new=new_failures,
@@ -224,13 +231,98 @@ def test_filter_failures_task(caplog):
     assert len(filtered_errors['STF']['Failed to update holdings after match']) == 2
 
 
+def test_holdings_set_errors_task(tmp_path, mocker, mock_dag_run):
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.oclc_reports.Variable.get",
+        return_value="https://folio-stanford.edu",
+    )
+
+    failures = {
+        "RCJ": {
+            "Failed to update holdings": [
+                {"uuid": ERRORS[6]["uuid"], "context": ERRORS[6]["context"]}
+            ]
+        },
+        "STF": {},
+    }
+
+    reports = holdings_set_errors_task.function(
+        airflow=tmp_path,
+        date=datetime.datetime(2024, 8, 9, 12, 15, 13, 445),
+        failures=failures,
+        dag_run=mock_dag_run,
+    )
+
+    law_report = pathlib.Path(reports['RCJ'])
+    law_report_html = BeautifulSoup(law_report.read_text(), 'html.parser')
+
+    h1 = law_report_html.find('h1')
+    assert h1.text.startswith("OCLC Holdings Set Errors on 09 August 2024 for RCJ")
+
+    list_items_oclc_error = law_report_html.select('tbody > tr > td > ul > li')
+    assert list_items_oclc_error[0].text == "Control Number: 48780294"
+    assert list_items_oclc_error[4].text == "Success: False"
+    assert list_items_oclc_error[5].text == 'Message: Holding Updated Failed'
+
+
+def test_holdings_set_errors_match_task(tmp_path, mocker, mock_dag_run):
+    mocker.patch(
+        "libsys_airflow.plugins.data_exports.oclc_reports.Variable.get",
+        return_value="https://folio-stanford.edu",
+    )
+
+    hin_error = copy.deepcopy(ERRORS[5])
+    hin_error['institutionCode'] = "567101"
+    hin_error["institutionSymbol"] = "HIN"
+
+    failures = {
+        "STF": {
+            "Failed to update holdings after match": [
+                {"uuid": ERRORS[5]["uuid"], "context": ERRORS[5]["context"]}
+            ]
+        },
+        "HIN": {
+            "Failed to update holdings after match": [
+                {"uuid": "cd010e25-a846-44b3-bf1b-28c2a128da15", "context": hin_error}
+            ]
+        },
+    }
+
+    reports = holdings_set_errors_task.function(
+        airflow=tmp_path,
+        date=datetime.datetime(2024, 8, 9, 12, 15, 13, 445),
+        failures=failures,
+        match=True,
+        dag_run=mock_dag_run,
+    )
+
+    sul_report = pathlib.Path(reports['STF'])
+    sul_report_html = BeautifulSoup(sul_report.read_text(), 'html.parser')
+
+    h1 = sul_report_html.find("h1")
+    assert h1.text.startswith(
+        "OCLC Holdings Matched Set Errors on 09 August 2024 for STF"
+    )
+
+    dag_a = sul_report_html.select("p > a")
+    assert dag_a[0].text == "DAG Run"
+
+    hoover_report = pathlib.Path(reports['HIN'])
+    hoover_report_html = BeautifulSoup(hoover_report.read_text(), 'html.parser')
+
+    h2 = hoover_report_html.find("h2")
+    assert h2.text.startswith(
+        "FOLIO Instances that failed trying to set Holdings after successful Match"
+    )
+
+
 def test_multiple_oclc_numbers_task(tmp_path, mocker, mock_task_instance, mock_dag_run):
     mocker.patch(
         "libsys_airflow.plugins.data_exports.oclc_reports.Variable.get",
         return_value="https://folio-stanford.edu",
     )
 
-    reports = oclc_reports.multiple_oclc_numbers_task.function(
+    reports = multiple_oclc_numbers_task.function(
         airflow=tmp_path,
         date=datetime.datetime(2024, 7, 29, 14, 19, 34, 245),
         ti=mock_task_instance,

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -513,7 +513,7 @@ def test_filter_new_marc_records_task(mocker, tmp_path):
     }
 
     filter_new_marc_records_task.function(
-        new_records=new_records, new_instance_uuids=new_uuids
+        new_records=new_records, failed_matches=new_uuids
     )
 
     with marc_file.open("rb") as fo:
@@ -543,7 +543,7 @@ def test_filter_new_marc_records_task_no_records(mocker, tmp_path):
     }
 
     filtered_new_records = filter_new_marc_records_task.function(
-        new_records=new_records, new_instance_uuids=new_uuids
+        new_records=new_records, failed_matches=new_uuids
     )
 
     assert filtered_new_records['STF'] == []


### PR DESCRIPTION
Part of fix for ticket #1080. OCLC transmission DAG now has a reports-email Task Group that generates a holdings_set report for both new records and matched records along with a holdings_unset (delete) report. Emails are sent to each of the cohort libraries with links to the reports. 

Here is the overview of the OCLC Transmission DAG:
![Screenshot 2024-08-12 at 3 28 22 PM](https://github.com/user-attachments/assets/3a064171-17ff-42fa-a251-789f0a136db5)

TODO:
- [x] Test with more UUIDs on airflow-dev
- [x] Confirm emails are being generated and sent from airflow-dev.

