### PR TITLE
Adjust export sched

### DIFF
--- a/libsys_airflow/dags/data_exports/default_schedules.json
+++ b/libsys_airflow/dags/data_exports/default_schedules.json
@@ -1,6 +1,7 @@
 {
   "schedule_gobi_days": 7,
-  "schedule_gobi_hours": 13,
+  "schedule_gobi_hours": 3,
+  "transmit_gobi_hours": 7,
   "schedule_google_days": 1,
   "schedule_google_hours": 13,
   "schedule_hathi_days": 1,
@@ -10,7 +11,8 @@
   "schedule_oclc_days": 7,
   "schedule_oclc_hours": 13,
   "schedule_pod_days": 1,
-  "schedule_pod_hours": 13,
+  "schedule_pod_hours": 2,
+  "transmit_pod_hours": 6,
   "schedule_sharevde_days": 1,
   "schedule_sharevde_hours": 13
 }

--- a/libsys_airflow/dags/data_exports/gobi_selections.py
+++ b/libsys_airflow/dags/data_exports/gobi_selections.py
@@ -32,7 +32,7 @@ with DAG(
     default_args=default_args,
     schedule=timedelta(
         days=int(Variable.get("schedule_gobi_days", 7)),
-        hours=int(Variable.get("schedule_gobi_hours", 7)),
+        hours=int(Variable.get("schedule_gobi_hours", 3)),
     ),
     start_date=datetime(2024, 2, 26),
     catchup=False,

--- a/libsys_airflow/dags/data_exports/gobi_transmission.py
+++ b/libsys_airflow/dags/data_exports/gobi_transmission.py
@@ -30,8 +30,8 @@ default_args = {
 @dag(
     default_args=default_args,
     schedule=timedelta(
-        days=int(Variable.get("schedule_gobi_days", 7)),
-        hours=int(Variable.get("schedule_gobi_hours", 7)),
+        days=int(Variable.get("transmit_gobi_days", 7)),
+        hours=int(Variable.get("transmit_gobi_hours", 7)),
     ),
     start_date=datetime(2024, 1, 1),
     catchup=False,

--- a/libsys_airflow/dags/data_exports/gobi_transmission.py
+++ b/libsys_airflow/dags/data_exports/gobi_transmission.py
@@ -31,7 +31,7 @@ default_args = {
     default_args=default_args,
     schedule=timedelta(
         days=int(Variable.get("schedule_gobi_days", 7)),
-        hours=int(Variable.get("schedule_gobi_hours", 13)),
+        hours=int(Variable.get("schedule_gobi_hours", 7)),
     ),
     start_date=datetime(2024, 1, 1),
     catchup=False,

--- a/libsys_airflow/dags/data_exports/google_transmission.py
+++ b/libsys_airflow/dags/data_exports/google_transmission.py
@@ -30,8 +30,8 @@ default_args = {
 @dag(
     default_args=default_args,
     schedule=timedelta(
-        days=int(Variable.get("schedule_google_days", 1)),
-        hours=int(Variable.get("schedule_google_hours", 13)),
+        days=int(Variable.get("transmit_google_days", 1)),
+        hours=int(Variable.get("transmit_google_hours", 13)),
     ),
     start_date=datetime(2024, 1, 1),
     catchup=False,

--- a/libsys_airflow/dags/data_exports/hathi_transmission.py
+++ b/libsys_airflow/dags/data_exports/hathi_transmission.py
@@ -30,8 +30,8 @@ default_args = {
 @dag(
     default_args=default_args,
     schedule=timedelta(
-        days=int(Variable.get("schedule_hathi_days", 1)),
-        hours=int(Variable.get("schedule_hathi_hours", 13)),
+        days=int(Variable.get("transmit_hathi_days", 1)),
+        hours=int(Variable.get("transmit_hathi_hours", 13)),
     ),
     start_date=datetime(2024, 1, 1),
     catchup=False,

--- a/libsys_airflow/dags/data_exports/nielsen_transmission.py
+++ b/libsys_airflow/dags/data_exports/nielsen_transmission.py
@@ -30,8 +30,8 @@ default_args = {
 @dag(
     default_args=default_args,
     schedule=timedelta(
-        days=int(Variable.get("schedule_nielsen_days", 1)),
-        hours=int(Variable.get("schedule_nielsen_hours", 13)),
+        days=int(Variable.get("transmit_nielsen_days", 1)),
+        hours=int(Variable.get("transmit_nielsen_hours", 13)),
     ),
     start_date=datetime(2024, 1, 1),
     catchup=False,

--- a/libsys_airflow/dags/data_exports/oclc_transmission.py
+++ b/libsys_airflow/dags/data_exports/oclc_transmission.py
@@ -47,8 +47,8 @@ connections = [
 @dag(
     default_args=default_args,
     schedule=timedelta(
-        days=int(Variable.get("schedule_oclc_days", 7)),
-        hours=int(Variable.get("schedule_oclc_hours", 13)),
+        days=int(Variable.get("transmit_oclc_days", 7)),
+        hours=int(Variable.get("transmit_oclc_hours", 13)),
     ),
     start_date=datetime(2024, 1, 1),
     catchup=False,

--- a/libsys_airflow/dags/data_exports/pod_selections.py
+++ b/libsys_airflow/dags/data_exports/pod_selections.py
@@ -35,7 +35,7 @@ with DAG(
     default_args=default_args,
     schedule=timedelta(
         days=int(Variable.get("schedule_pod_days", 1)),
-        hours=int(Variable.get("schedule_pod_hours", 7)),
+        hours=int(Variable.get("schedule_pod_hours", 2)),
     ),
     start_date=datetime(2024, 2, 26),
     catchup=False,

--- a/libsys_airflow/dags/data_exports/pod_transmission.py
+++ b/libsys_airflow/dags/data_exports/pod_transmission.py
@@ -30,8 +30,8 @@ default_args = {
 @dag(
     default_args=default_args,
     schedule=timedelta(
-        days=int(Variable.get("schedule_pod_days", 1)),
-        hours=int(Variable.get("schedule_pod_hours", 13)),
+        days=int(Variable.get("transmit_pod_days", 1)),
+        hours=int(Variable.get("transmit_pod_hours", 6)),
     ),
     start_date=datetime(2024, 1, 1),
     catchup=False,

--- a/libsys_airflow/dags/data_exports/remove-archived.py
+++ b/libsys_airflow/dags/data_exports/remove-archived.py
@@ -22,7 +22,7 @@ with DAG(
     "data_export_purge_archived_files",
     default_args=default_args,
     start_date=datetime(2024, 5, 30),
-    schedule=timedelta(days=1),
+    schedule=timedelta(days=1, hours=9),
     catchup=False,
     tags=["data export"],
 ) as dag:

--- a/libsys_airflow/dags/data_exports/sharevde_transmission.py
+++ b/libsys_airflow/dags/data_exports/sharevde_transmission.py
@@ -30,8 +30,8 @@ default_args = {
 @dag(
     default_args=default_args,
     schedule=timedelta(
-        days=int(Variable.get("schedule_sharevde_days", 1)),
-        hours=int(Variable.get("schedule_sharevde_hours", 13)),
+        days=int(Variable.get("transmit_sharevde_days", 1)),
+        hours=int(Variable.get("transmit_sharevde_hours", 13)),
     ),
     start_date=datetime(2024, 1, 1),
     catchup=False,


### PR DESCRIPTION
Getting pod and Gobi ready to run at 7pm/8pm and transmit 4 hours later. Archive files after midnight. Change schedule var name so that selection and transmission can be overridden separately.  