### PR TITLE
Remove task to refresh materialized view

### DIFF
--- a/libsys_airflow/dags/data_exports/full_dump_retrieval.py
+++ b/libsys_airflow/dags/data_exports/full_dump_retrieval.py
@@ -13,7 +13,6 @@ from airflow.decorators import task, task_group
 from libsys_airflow.plugins.data_exports.full_dump_marc import (
     fetch_number_of_records,
     fetch_full_dump_marc,
-    refresh_view,
     reset_s3,
 )
 from libsys_airflow.plugins.data_exports.marc.transformer import Transformer
@@ -59,10 +58,6 @@ with DAG(
 ) as dag:
 
     start = EmptyOperator(task_id='start')
-
-    @task
-    def refresh_materialized_view():
-        refresh_view()
 
     @task
     def reset_s3_bucket():
@@ -166,8 +161,6 @@ with DAG(
         number_in_batch=batch_size,
     )
 
-    update_view = refresh_materialized_view()
-
     delete_s3_files = reset_s3_bucket()
 
     start_stop = calculate_start_stop.partial(div=record_div).expand(job=number_of_jobs)
@@ -182,5 +175,5 @@ with DAG(
         task_id="finish_marc",
     )
 
-    start >> update_view >> delete_s3_files >> total_records
+    start >> delete_s3_files >> total_records
     finish_transforms >> finish_processing_marc

--- a/libsys_airflow/plugins/data_exports/full_dump_marc.py
+++ b/libsys_airflow/plugins/data_exports/full_dump_marc.py
@@ -46,28 +46,6 @@ def fetch_number_of_records(**kwargs) -> int:
     return int(count)
 
 
-def refresh_view(**kwargs) -> None:
-    context = get_current_context()
-    params = context.get("params", {})  # type: ignore
-    refresh = params.get("refresh_view", True)
-
-    if refresh:
-        query = "refresh materialized view data_export_marc"
-
-        result = SQLExecuteQueryOperator(
-            task_id="postgres_full_count_query",
-            conn_id="postgres_folio",
-            database=kwargs.get("database", "okapi"),
-            sql=query,
-        ).execute(context)
-
-        logger.info(result)
-    else:
-        logger.info("Skipping refresh of materialized view")
-
-    return None
-
-
 def reset_s3(**kwargs) -> None:
     context = get_current_context()
     params = context.get("params", {})  # type: ignore


### PR DESCRIPTION
There is now an ORDER BY clause in the materialized view's defining query, so the original contents of the materialized view will be ordered that way; but REFRESH MATERIALIZED VIEW does not guarantee to preserve that ordering. We will need to drop and recreate the view and its indices each time we want to run a full record selection in prod.