### PR TITLE
Use default False for full dump retrieval

### DIFF
--- a/libsys_airflow/dags/data_exports/full_dump_retrieval.py
+++ b/libsys_airflow/dags/data_exports/full_dump_retrieval.py
@@ -139,7 +139,7 @@ with DAG(
             for marc_file in marc_files:
                 stem = pathlib.Path(marc_file).suffix
                 xml = marc_file.replace(stem, '.xml')
-                zip_marc_file(xml)
+                zip_marc_file(xml, True)
 
         (
             transform_marc_records_add_holdings(marc_files)

--- a/libsys_airflow/plugins/data_exports/marc/transforms.py
+++ b/libsys_airflow/plugins/data_exports/marc/transforms.py
@@ -160,7 +160,7 @@ def remove_marc_files(marc_file_list: list):
         logger.info(f"Removed {file_path}")
 
 
-def zip_marc_file(marc_file: str, full_dump: bool = True):
+def zip_marc_file(marc_file: str, full_dump: bool = False):
     if full_dump:
         marc_path = S3Path(marc_file)
     else:


### PR DESCRIPTION
Since we will not normally address the `zip_marc_file` function via the full_dump_retrieval, make the default for full_dump: bool = False. 