### PR TITLE
Make sure related marc files get moved to transmitted

### DIFF
--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -284,24 +284,19 @@ def archive_transmitted_data_task(files):
         archive_path.mkdir(exist_ok=True)
         archive_path = archive_path / original_transmitted_file_path.name
 
-        # instance_path = data-export-files/{vendor}/instanceids/new|updates|deletes/*.csv
-        instance_path = (
-            original_transmitted_file_path.parent.parent.parent
-            / f"instanceids/{kind}/{original_transmitted_file_path.stem}.csv"
-        )
-        instance_archive_path = archive_dir / kind / instance_path.name
-
-        marc_path = (
-            original_transmitted_file_path.parent
-            / f"{original_transmitted_file_path.stem}.xml"
-        )
-        marc_archive_path = archive_dir / kind / marc_path.name
-
         # move transmitted files (for GOBI this will be *.txt files; for POD this will be *.gz files)
         logger.info(
             f"Moving transmitted file {original_transmitted_file_path} to {archive_path}"
         )
         original_transmitted_file_path.replace(archive_path)
+
+        # instance_path = data-export-files/{vendor}/instanceids/new|updates|deletes/*.csv
+        # with_suffix('') will remove multiple extentions, e.g. .xml.gz
+        instance_path = (
+            original_transmitted_file_path.parent.parent.parent
+            / f"instanceids/{kind}/{original_transmitted_file_path.with_suffix('').stem}.csv"
+        )
+        instance_archive_path = archive_dir / kind / instance_path.name
 
         # move instance id files with same stem as transmitted filename
         if instance_path.exists():
@@ -309,6 +304,12 @@ def archive_transmitted_data_task(files):
                 f"Moving related instanceid file {instance_path} to {instance_archive_path}"
             )
             instance_path.replace(instance_archive_path)
+
+        marc_path = (
+            original_transmitted_file_path.parent
+            / f"{original_transmitted_file_path.with_suffix('').stem}.mrc"
+        )
+        marc_archive_path = archive_dir / kind / marc_path.name
 
         # move marc files with same stem as transmitted filename (when transmitted file is not *.xml)
         if marc_path.exists():

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -1,5 +1,5 @@
-import pathlib
 import pytest  # noqa
+import pathlib
 
 import httpx
 import pymarc

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -39,16 +39,16 @@ def mock_vendor_marc_files(tmp_path, request):
             "2024020314.xml.gz",
             "2024020314.xml",
             "2024030214.xml",
-            "2024030214.txt",
             "2024030214.mrc",
             "2024020314.mrc",
+            "2024030214.txt",
         ]
     }
     files = []
     for i, x in enumerate(setup_files['filenames']):
         file = pathlib.Path(f"{marc_file_dir}/{x}")
         file.touch()
-        if i in [0, 2, 3]:
+        if i in [0, 2, 5]:
             file.write_text("hello world")
         files.append(str(file))
     return {"file_list": files, "s3": False}

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -1,5 +1,5 @@
-import pytest  # noqa
 import pathlib
+import pytest  # noqa
 
 import httpx
 import pymarc
@@ -36,10 +36,12 @@ def mock_vendor_marc_files(tmp_path, request):
     marc_file_dir.mkdir(parents=True)
     setup_files = {
         "filenames": [
-            "2024020314.gz",
+            "2024020314.xml.gz",
             "2024020314.xml",
             "2024030214.xml",
             "2024030214.txt",
+            "2024030214.mrc",
+            "2024020314.mrc",
         ]
     }
     files = []
@@ -332,8 +334,10 @@ def test_archive_gobi_files(tmp_path, mock_vendor_marc_files):
     transmitted_files = gather_files_task.function(airflow=airflow, vendor="gobi")
     assert len(transmitted_files["file_list"]) == 1
     archive_transmitted_data_task.function(transmitted_files["file_list"])
-    related_marc_file = pathlib.Path(transmitted_files["file_list"][0]).stem
-    related_marc_file = related_marc_file + ".xml"
+    related_marc_file = (
+        pathlib.Path(transmitted_files["file_list"][0]).with_suffix('').stem
+    )
+    related_marc_file = related_marc_file + ".mrc"
     assert (archive_dir / pathlib.Path(transmitted_files["file_list"][0]).name).exists()
     assert (archive_dir / pathlib.Path(related_marc_file)).exists()
     assert (archive_dir / instance_id_file1.name).exists()
@@ -352,8 +356,10 @@ def test_archive_pod_files(tmp_path, mock_vendor_marc_files):
     transmitted_files = gather_files_task.function(airflow=airflow, vendor="pod")
     assert len(transmitted_files["file_list"]) == 1
     archive_transmitted_data_task.function(transmitted_files["file_list"])
-    related_marc_file = pathlib.Path(transmitted_files["file_list"][0]).stem
-    related_marc_file = related_marc_file + ".xml"
+    related_marc_file = (
+        pathlib.Path(transmitted_files["file_list"][0]).with_suffix('').stem
+    )
+    related_marc_file = related_marc_file + ".mrc"
     assert (archive_dir / pathlib.Path(transmitted_files["file_list"][0]).name).exists()
     assert (archive_dir / pathlib.Path(related_marc_file)).exists()
     assert (archive_dir / instance_id_file1.name).exists()

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -334,10 +334,10 @@ def test_archive_gobi_files(tmp_path, mock_vendor_marc_files):
     transmitted_files = gather_files_task.function(airflow=airflow, vendor="gobi")
     assert len(transmitted_files["file_list"]) == 1
     archive_transmitted_data_task.function(transmitted_files["file_list"])
-    related_marc_file = (
+    base_file_name = (
         pathlib.Path(transmitted_files["file_list"][0]).with_suffix('').stem
     )
-    related_marc_file = related_marc_file + ".mrc"
+    related_marc_file = base_file_name + ".mrc"
     assert (archive_dir / pathlib.Path(transmitted_files["file_list"][0]).name).exists()
     assert (archive_dir / pathlib.Path(related_marc_file)).exists()
     assert (archive_dir / instance_id_file1.name).exists()
@@ -356,10 +356,10 @@ def test_archive_pod_files(tmp_path, mock_vendor_marc_files):
     transmitted_files = gather_files_task.function(airflow=airflow, vendor="pod")
     assert len(transmitted_files["file_list"]) == 1
     archive_transmitted_data_task.function(transmitted_files["file_list"])
-    related_marc_file = (
+    base_file_name = (
         pathlib.Path(transmitted_files["file_list"][0]).with_suffix('').stem
     )
-    related_marc_file = related_marc_file + ".mrc"
+    related_marc_file = base_file_name + ".mrc"
     assert (archive_dir / pathlib.Path(transmitted_files["file_list"][0]).name).exists()
     assert (archive_dir / pathlib.Path(related_marc_file)).exists()
     assert (archive_dir / instance_id_file1.name).exists()


### PR DESCRIPTION
The file extensions for 123.xml.gz were not allowing the reference to the related marc file, and the test were not setting up the marc files to be tested.