### PR TITLE
DAG to fetch purls for druids

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/fetch_digital_bookplates.py
+++ b/libsys_airflow/dags/digital_bookplates/fetch_digital_bookplates.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag
+from airflow.operators.empty import EmptyOperator
+
+from libsys_airflow.plugins.digital_bookplates.purl_fetcher import fetch_druids
+
+default_args = {
+    "owner": "libsys",
+    "depends_on_past": False,
+    "email_on_failure": True,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+}
+
+
+@dag(
+    default_args=default_args,
+    schedule=None,
+    start_date=datetime(2024, 9, 9),
+    catchup=False,
+    tags=["digital bookplates"],
+)
+def fetch_digital_bookplates():
+    start = EmptyOperator(task_id="start")
+
+    end = EmptyOperator(task_id="end")
+
+    fetch_bookplate_purls = fetch_druids()
+
+    start >> fetch_bookplate_purls >> end
+
+
+fetch_digital_bookplates()

--- a/libsys_airflow/plugins/digital_bookplates/purl_fetcher.py
+++ b/libsys_airflow/plugins/digital_bookplates/purl_fetcher.py
@@ -1,0 +1,30 @@
+import httpx
+
+from airflow.decorators import task
+
+
+@task
+def fetch_druids() -> list:
+    collection = _purls()
+    child_druids = map(_child_druid, collection)
+
+    druids = []
+    for druid in child_druids:
+        druid_id = druid.split(":")[-1]
+        druids.append(f"https://purl.stanford.edu/{druid_id}.xml")
+
+    return druids
+
+
+def _child_druid(x):
+    return x['druid']
+
+
+def _purls():
+    params = "per_page=10000"
+    response = httpx.get(
+        "https://purl-fetcher.stanford.edu/collections/druid:nh525xs4538/purls",
+        params=params,
+    )
+
+    return response.json()['purls']

--- a/tests/digital_bookplates/test_purl_fetcher.py
+++ b/tests/digital_bookplates/test_purl_fetcher.py
@@ -1,0 +1,50 @@
+import pytest
+import requests_mock
+from libsys_airflow.plugins.digital_bookplates.purl_fetcher import fetch_druids
+
+
+@pytest.fixture
+def mock_api():
+    with requests_mock.Mocker() as m:
+        yield m
+
+
+@pytest.fixture
+def mock_purl_fetcher_api_response():
+    return [
+        {
+            'druid': 'druid:bm244yj4074',
+            'object_type': 'item',
+            'title': 'Beevis and Budhead Memorial Book Fund',
+            'true_targets': ['SearchWorksPreview', 'ContentSearch'],
+            'false_targets': ['Searchworks'],
+            'collections': ['druid:nh525xs4538'],
+            'updated_at': '2024-05-09T00:50:45Z',
+            'published_at': '2024-05-09T00:50:45Z',
+            'latest_change': '2024-05-09T00:50:45Z',
+        },
+        {
+            'druid': 'druid:bt942vy4674',
+            'object_type': 'item',
+            'title': 'Stanford Law Library in Memory of Niel Peart',
+            'true_targets': ['SearchWorksPreview', 'ContentSearch'],
+            'false_targets': ['Searchworks'],
+            'collections': ['druid:nh525xs4538'],
+            'updated_at': '2024-05-09T00:50:45Z',
+            'published_at': '2024-05-09T00:50:45Z',
+            'latest_change': '2024-05-09T00:50:45Z',
+        },
+    ]
+
+
+def test_purl_fetch_list(mock_api, mocker, mock_purl_fetcher_api_response):
+    mocker.patch(
+        "libsys_airflow.plugins.digital_bookplates.purl_fetcher._purls",
+        return_value=mock_purl_fetcher_api_response,
+    )
+
+    test_druids = fetch_druids.function()
+
+    assert len(test_druids) == 2
+    assert test_druids[0] == "https://purl.stanford.edu/bm244yj4074.xml"
+    assert test_druids[1] == "https://purl.stanford.edu/bt942vy4674.xml"


### PR DESCRIPTION
Fixes #1176 

`fetch_bookplate_purls` returns a list that can be passed to a follow-on task (TBD).