### PR TITLE
Triggers Digital Bookplates Instances DAG

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/fetch_digital_bookplates.py
+++ b/libsys_airflow/dags/digital_bookplates/fetch_digital_bookplates.py
@@ -17,6 +17,7 @@ from libsys_airflow.plugins.digital_bookplates.purl_fetcher import (
     extract_bookplate_metadata,
     fetch_druids,
     filter_updates_errors,
+    trigger_instances_dag,
 )
 
 
@@ -81,6 +82,8 @@ def fetch_digital_bookplates():
         )
         >> end
     )
+
+    trigger_instances_dag(new=filtered_data["new"]) >> end
 
     start >> fetch_bookplate_purls >> db_results
 

--- a/libsys_airflow/plugins/digital_bookplates/purl_fetcher.py
+++ b/libsys_airflow/plugins/digital_bookplates/purl_fetcher.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 
 from airflow.decorators import task
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 from jsonpath_ng.ext import parse
@@ -143,6 +144,15 @@ def filter_updates_errors(db_results: list) -> dict:
         f"Totals: New records {len(new):,}, Failures {len(failures):,} and Updates {len(updates):,}"
     )
     return {"failures": failures, "new": new, "updates": updates}
+
+
+@task
+def trigger_instances_dag(**kwargs) -> bool:
+    
+    TriggerDagRunOperator.partial(
+        task_id="new-instance-dag", trigger_dag_id="digital_bookplate_instances"
+    ).expand(**{"logical_date": "2023-08-28T00:00:00+00:00"})
+    return True
 
 
 def _add_bookplate(metadata: dict, session: Session) -> dict:

--- a/libsys_airflow/plugins/digital_bookplates/purl_fetcher.py
+++ b/libsys_airflow/plugins/digital_bookplates/purl_fetcher.py
@@ -148,10 +148,13 @@ def filter_updates_errors(db_results: list) -> dict:
 
 @task
 def trigger_instances_dag(**kwargs) -> bool:
-    
+    new_funds = kwargs.get("new", [])
+    if len(new_funds) < 1:
+        logger.info("No new funds to trigger digital_bookplate_instances DAG")
+        return True
     TriggerDagRunOperator.partial(
         task_id="new-instance-dag", trigger_dag_id="digital_bookplate_instances"
-    ).expand(**{"logical_date": "2023-08-28T00:00:00+00:00"})
+    ).expand(**{"logical_date": "2023-08-28T00:00:00+00:00", "funds": new_funds})
     return True
 
 

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -142,7 +142,7 @@ def invoice_lines_from_invoices(invoices: list) -> list:
 
 
 @task
-def filter_invoice_lines(invoice_lines: list) -> list:
+def filter_invoice_lines(invoice_lines: list, funds: list) -> list:
     """
     Given a list of invoice line dictionaries,
     Filters invoice lines to only those with fund IDs and po line IDs

--- a/tests/digital_bookplates/test_purl_fetcher.py
+++ b/tests/digital_bookplates/test_purl_fetcher.py
@@ -13,6 +13,8 @@ from libsys_airflow.plugins.digital_bookplates.purl_fetcher import (
     check_deleted_from_argo,
     extract_bookplate_metadata,
     fetch_druids,
+    filter_updates_errors,
+    trigger_instances_dag,
 )
 
 rows = Rows(
@@ -186,6 +188,14 @@ def test_failed_bookplate(pg_hook):
     assert result["failure"]["druid"] == "ef919yq2614"
 
 
+def test_filter_updates_errors():
+    db_results = [{"failure": {}}, {"new": {}}, {"update": {}}]
+
+    result = filter_updates_errors.function(db_results)
+
+    assert result['failures'] == [{}]
+
+
 def test_missing_image_file(mocker):
 
     mocker.patch(
@@ -246,6 +256,12 @@ def test_new_bookplate(pg_hook):
     result = add_update_model.function(new_metadata)
 
     assert result["new"]["db_id"] == 4
+
+
+def test_trigger_instances_dag_no_new(caplog):
+    trigger_instances_dag.function(new=[])
+
+    assert "No new funds to trigger digital_bookplate_instances DAG" in caplog.text
 
 
 def test_update_bookplate(pg_hook):

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -162,8 +162,8 @@ def test_invoice_lines_from_invoices(mocker, mock_folio_client, caplog):
     assert len(invoice_lines) == 2
 
 
-def test_filter_invoice_liness(mock_invoice_lines):
-    invoice_lines_data_struct = filter_invoice_lines.function(mock_invoice_lines)
+def test_filter_invoice_lines(mock_invoice_lines):
+    invoice_lines_data_struct = filter_invoice_lines.function(mock_invoice_lines, [])
     assert len(invoice_lines_data_struct) == 2
     for v in invoice_lines_data_struct[0].values():
         assert v["fund_ids"] == ["3eb86c5f-c77b-4cc9-8f29-7de7ce313411"]


### PR DESCRIPTION
Fixes #1221 
New task In the `fetch_digital_bookplates` triggers  `digital_bookplate_instances` when new funds are added.

![Screenshot 2024-10-04 at 12 09 34 PM](https://github.com/user-attachments/assets/e7c4b0bb-564b-49e3-bfee-849b835cfb47)

In the `digital_bookplate_instances` these new funds are retrieved from the context in a new `get_funds` task:


![Screenshot 2024-10-04 at 12 10 01 PM](https://github.com/user-attachments/assets/a5ba6040-f8b1-464c-8043-84d46754bf01)
