### PR TITLE
Supports testing with script that deletes digital bookplates table data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ export DATABASE_HOSTNAME="localhost"
 ```
 1.  Run (e.g. using the database name you want to migrate) `poetry run alembic --name digital_bookplates upgrade head`
 
+#### Clearing Digital Bookplates Data
+
+Assuming that you have populated the digital_bookplates database's digital_bookplates table with data, you can clear it out with:
+```
+poetry run bin/truncate_digital_bookplates
+```
+
+In a deployed environment, this can be run as:
+```
+docker exec -it 20230516183735-airflow-webserver-1 bin/truncate_digital_bookplates
+```
+where `20230516183735-airflow-webserver-1` is the container id.
+
 ### Vendor load plugin
 
 Using and developing the vendor load plug in requires its own database. Ensure that the `vendor_loads` database exists in your local postgres and is owned by the airflow user.

--- a/bin/truncate_digital_bookplates
+++ b/bin/truncate_digital_bookplates
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+# A utility for truncating the digital_bookplates table
+
+import os
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, delete
+from sqlalchemy.orm import sessionmaker
+from libsys_airflow.plugins.digital_bookplates.models import DigitalBookplate
+
+load_dotenv()
+
+
+def main():
+    db_url = os.getenv(
+        'AIRFLOW_CONN_DIGITAL_BOOKPLATES',
+        'postgresql+psycopg2://airflow:airflow@localhost:5432/digital_bookplates',
+    )
+    engine = create_engine(db_url, echo=True)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        table = DigitalBookplate.__table__
+        session.execute(delete(table))
+        session.commit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1257 

N.B. the script does not reset the primary key. Since we don't rely on it heavily, I think it's fine to not worry about resetting it.