### PR TITLE
Refactors invoice queries

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -24,7 +24,7 @@ default_args = {
     "depends_on_past": False,
     "email_on_failure": True,
     "email_on_retry": False,
-    "retries": 1,
+    "retries": 3,
     "retry_delay": timedelta(minutes=1),
 }
 

--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -32,8 +32,8 @@ default_args = {
 @task_group(group_id="process-invoice-lines")
 def process_invoice_lines_group(invoice_id: str):
     paid_invoice_lines = invoice_lines_from_invoices(invoice_id)
-    paid_bookplate_polines = bookplate_funds_polines(paid_invoice_lines)
-    return instances_from_po_lines(paid_bookplate_polines)
+    paid_bookplate_polines = bookplate_funds_polines(invoice_lines=paid_invoice_lines)
+    return instances_from_po_lines(po_lines_funds=paid_bookplate_polines)
 
 
 @dag(

--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timedelta
 
-from airflow.decorators import dag, task, task_group
+from airflow.decorators import dag, task_group
 from airflow.operators.empty import EmptyOperator
-from airflow.operators.python import get_current_context
 from airflow.timetables.interval import CronDataIntervalTimetable
 
 

--- a/libsys_airflow/plugins/digital_bookplates/bookplates.py
+++ b/libsys_airflow/plugins/digital_bookplates/bookplates.py
@@ -44,7 +44,7 @@ def _new_bookplates(funds: list) -> dict:
 
 
 @task
-def bookplate_funds_polines(invoice_lines: list, **kwargs) -> list:
+def bookplate_funds_polines(**kwargs) -> list:
     """
     Checks if fund Id from invoice lines contains bookplate fund
     This task gets digital bookplates data from the table or uses
@@ -62,6 +62,7 @@ def bookplate_funds_polines(invoice_lines: list, **kwargs) -> list:
     ]
     """
     bookplates_polines: list = []
+    invoice_lines = kwargs["invoice_lines"]
     params = kwargs.get("params", {})
     funds = params.get("funds", [])
     if len(funds) > 0:

--- a/libsys_airflow/plugins/digital_bookplates/bookplates.py
+++ b/libsys_airflow/plugins/digital_bookplates/bookplates.py
@@ -44,12 +44,12 @@ def _new_bookplates(funds: list) -> dict:
 
 
 @task
-def bookplate_funds_polines(invoice_lines: list, funds: list) -> list:
+def bookplate_funds_polines(invoice_lines: list, **kwargs) -> list:
     """
     Checks if fund Id from invoice lines contains bookplate fund
     This task gets digital bookplates data from the table or uses
-    a list of new funds and returns a list of bookplates metadata and poline ids
-    Returns:
+    a list of new funds from params and returns a list of bookplates
+    metadata and poline ids:
     [
       {
         "bookplate_metadata": { "druid": "", "fund_name": "", "image_filename": "", "title": "" },
@@ -62,6 +62,8 @@ def bookplate_funds_polines(invoice_lines: list, funds: list) -> list:
     ]
     """
     bookplates_polines: list = []
+    params = kwargs.get("params", {})
+    funds = params.get("funds", [])
     if len(funds) > 0:
         bookplates = _new_bookplates(funds)
     else:

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -40,7 +40,7 @@ def _get_all_ids_from_invoices(folio_query: str, folio_client: FolioClient) -> l
     Returns all invoice Ids from invoices given query parameter in `limit`-size chunks
     """
     invoices = folio_client.folio_get_all(
-        "/invoice/invoices", key="invoices", query=folio_query, limit=500
+        "/invoice-storage/invoices", key="invoices", query=folio_query, limit=500
     )
     return [row.get("id") for row in invoices]
 
@@ -50,7 +50,10 @@ def _get_all_invoice_lines(folio_query: str, folio_client: FolioClient) -> list:
     Returns all invoice line given a query parameter in `limit`-size chunks
     """
     invoice_lines = folio_client.folio_get_all(
-        "/invoice/invoice-lines", key="invoiceLines", query=folio_query, limit=500
+        "/invoice-storage/invoice-lines",
+        key="invoiceLines",
+        query=folio_query,
+        limit=500,
     )
     return [row for row in invoice_lines]
 

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -133,18 +133,17 @@ def invoices_paid_within_date_range(**kwargs) -> list:
     return invoice_ids
 
 
-@task
-def invoice_lines_from_invoices(invoices: list) -> list:
+@task(max_active_tis_per_dag=10)
+def invoice_lines_from_invoices(invoice_id: str) -> list:
     """
-    Given a list of invoice UUIDs, returns a list of invoice lines dictionaries
+    Given an invoice UUID, returns a list of invoice lines dictionaries
     """
     folio_client = _folio_client()
     all_invoice_lines = []
-    for id in invoices:
-        logger.info(f"Getting invoice lines for {id}")
-        query = f"""?query=(invoiceId=={id})"""
-        invoice_lines = _get_all_invoice_lines(query, folio_client)
-        for row in invoice_lines:
-            all_invoice_lines.append(row)
+    logger.info(f"Getting invoice lines for {invoice_id}")
+    query = f"""?query=(invoiceId=={invoice_id})"""
+    invoice_lines = _get_all_invoice_lines(query, folio_client)
+    for row in invoice_lines:
+        all_invoice_lines.append(row)
 
     return all_invoice_lines

--- a/libsys_airflow/plugins/folio/orders.py
+++ b/libsys_airflow/plugins/folio/orders.py
@@ -28,7 +28,7 @@ def instances_from_po_lines(po_lines_funds: list) -> dict:
     instances: dict = {}
     for row in po_lines_funds:
         poline_id = row['poline_id']
-        order_line = folio_client.folio_get(f"/orders/order-line/{poline_id}")
+        order_line = folio_client.folio_get(f"/orders/order-lines/{poline_id}")
         instance_id = order_line.get("instanceId")
         if instance_id is None:
             logger.info(f"PO Line {poline_id} not linked to a FOLIO Instance record")

--- a/libsys_airflow/plugins/folio/orders.py
+++ b/libsys_airflow/plugins/folio/orders.py
@@ -1,6 +1,5 @@
 import logging
 
-
 from airflow.decorators import task
 from airflow.models import Variable
 
@@ -19,13 +18,14 @@ def _folio_client():
 
 
 @task
-def instances_from_po_lines(po_lines_funds: list) -> dict:
+def instances_from_po_lines(**kwargs) -> dict:
     """
     Given a list of po lines with fund IDs, retrieves the instanceId
     It is possible for an instance to have multiple 979's
     """
     folio_client = _folio_client()
     instances: dict = {}
+    po_lines_funds = kwargs["po_lines_funds"]
     for row in po_lines_funds:
         poline_id = row['poline_id']
         order_line = folio_client.folio_get(f"/orders/order-lines/{poline_id}")

--- a/tests/digital_bookplates/test_bookplates_funds.py
+++ b/tests/digital_bookplates/test_bookplates_funds.py
@@ -176,7 +176,7 @@ def test_bookplate_funds_polines(
 ):
     new_funds = []
     bookplates_polines = bookplate_funds_polines.function(
-        mock_invoice_lines, params={"funds": new_funds}
+        invoice_lines=mock_invoice_lines, params={"funds": new_funds}
     )
 
     assert bookplates_polines == mock_bookplate_funds_polines
@@ -204,7 +204,7 @@ def test_new_bookplate_funds_polines(
         }
     )
     bookplates_polines = bookplate_funds_polines.function(
-        mock_invoice_lines, params={"funds": mock_new_funds}
+        invoice_lines=mock_invoice_lines, params={"funds": mock_new_funds}
     )
     assert len(bookplates_polines) == 1
     assert (

--- a/tests/digital_bookplates/test_bookplates_funds.py
+++ b/tests/digital_bookplates/test_bookplates_funds.py
@@ -175,7 +175,9 @@ def test_bookplate_funds_polines(
     pg_hook, mock_invoice_lines, mock_bookplate_funds_polines
 ):
     new_funds = []
-    bookplates_polines = bookplate_funds_polines.function(mock_invoice_lines, new_funds)
+    bookplates_polines = bookplate_funds_polines.function(
+        mock_invoice_lines, params={"funds": new_funds}
+    )
 
     assert bookplates_polines == mock_bookplate_funds_polines
 
@@ -202,7 +204,7 @@ def test_new_bookplate_funds_polines(
         }
     )
     bookplates_polines = bookplate_funds_polines.function(
-        mock_invoice_lines, mock_new_funds
+        mock_invoice_lines, params={"funds": mock_new_funds}
     )
     assert len(bookplates_polines) == 1
     assert (

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -56,7 +56,7 @@ def mock_folio_client(mock_invoice_lines):
 
     def mock_get_all(*args, **kwargs):
         # Invoice
-        if args[0].startswith("/invoice/invoices"):
+        if args[0].startswith("/invoice-storage/invoices"):
             if kwargs["query"].startswith(
                 "?query=((paymentDate>=2023-08-28T00:00:00+00:00)"
             ):

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -38,6 +38,22 @@ def mock_invoice_lines():
             "poLineId": "be0af62c-665e-4178-ae13-e3250d89bcc6",
         },
         {
+            "id": "318e17ff-f36a-407d-aa9b-68bde2cf3dd0",
+            "fundDistributions": [
+                {
+                    "code": "JACKMAND-SUL",
+                    "encumbrance": "ae319e1f-3fb8-449e-9e83-7ffeb4bee3b9",
+                    "fundId": "3f59fef1-c089-4ce5-a8c0-00e480346f67",
+                    "distributionType": "percentage",
+                    "value": 100.0,
+                }
+            ],
+            "invoiceId": "29f339e3-dfdc-43e4-9442-eb817fdfb069",
+            "invoiceLineNumber": "11",
+            "invoiceLineStatus": "Paid",
+            "poLineId": "496b5a5d-40c0-49cd-a874-13d5e6ce23cf",
+        },
+        {
             "id": "5c6cffcf-1951-47c9-817f-145cbe931dea",
             "invoiceId": "2dcebfd3-82b0-429d-afbb-dff743602bea",
             "invoiceLineNumber": "29",
@@ -66,9 +82,9 @@ def mock_folio_client(mock_invoice_lines):
         # Invoice Lines
         if args[0].endswith("invoice-lines"):
             if kwargs["query"].startswith("?query=(invoiceId==29f339e3"):
-                return [mock_invoice_lines[0]]
+                return [mock_invoice_lines[0], mock_invoice_lines[1]]
             elif kwargs["query"].startswith("?query=(invoiceId==2dcebfd3"):
-                return [mock_invoice_lines[1]]
+                return [mock_invoice_lines[2]]
             else:
                 return mock_invoice_lines
 
@@ -160,11 +176,9 @@ def test_invoice_lines_from_invoices(mocker, mock_folio_client, caplog):
         "libsys_airflow.plugins.folio.invoices._folio_client",
         return_value=mock_folio_client,
     )
-    invoices = [
-        "29f339e3-dfdc-43e4-9442-eb817fdfb069",
-        "2dcebfd3-82b0-429d-afbb-dff743602bea",
-    ]
-    invoice_lines = invoice_lines_from_invoices.function(invoices)
+    invoice_lines = invoice_lines_from_invoices.function(
+        "29f339e3-dfdc-43e4-9442-eb817fdfb069"
+    )
     assert (
         "Getting invoice lines for 29f339e3-dfdc-43e4-9442-eb817fdfb069" in caplog.text
     )

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -57,7 +57,7 @@ def test_instances_from_po_lines(mocker, mock_folio_client):
             "poline_id": "84701022-43af-401e-bcea-fb5fbd8f49f3",
         },
     ]
-    instances_dict = instances_from_po_lines.function(incoming_data)
+    instances_dict = instances_from_po_lines.function(po_lines_funds=incoming_data)
     assert instances_dict["e6803f0b-ed22-48d7-9895-60bea6826e93"][0] == {
         "druid": "gc698jf6425",
         "failure": None,
@@ -88,7 +88,7 @@ def test_instances_from_po_lines_no_instance(mocker, mock_folio_client, caplog):
         }
     ]
 
-    instances_dict = instances_from_po_lines.function(incoming_data)
+    instances_dict = instances_from_po_lines.function(po_lines_funds=incoming_data)
 
     assert len(instances_dict) == 0
     assert (

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -19,7 +19,7 @@ mock_order_lines = {
 def mock_folio_client():
     def mock_get(*args, **kwargs):
         output = {}
-        if str(args[0]).startswith("/orders/order-line"):
+        if str(args[0]).startswith("/orders/order-lines"):
             poline_id = args[0].split("/")[-1]
             output = mock_order_lines[poline_id]
         return output


### PR DESCRIPTION
Closes #1273
- uses the storage endpoints instead to reduce internal okapi calls
- expands the list of invoice UUIDs into mapped tasks and groups the filtering down of invoice lines to getting instances paid on bookplate funds
- `_get_all_invoice_lines` uses the FolioClient `folio_get_all` which ends up just using `folio_get`. The intermittent `httpx.RemoteProtocolError: Server disconnected without sending a response.` error still occurs but since the tasks are mapped into task groups, we have a more granular way to retry.

![Screenshot 2024-10-15 at 10 57 20 AM](https://github.com/user-attachments/assets/7b65f88b-2c82-4fee-a90d-619f950eacc7)

Payload to trigger add 979 DAG for each mapped task:
![Screenshot 2024-10-15 at 10 58 19 AM](https://github.com/user-attachments/assets/74a0a5e6-d75b-4d0a-a811-5296a8c0dc9f)
