### PR TITLE
Gets logical_date from params so fetch_digital_bookplates can trigger dag with correct date

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from airflow.decorators import dag, task_group
+from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.timetables.interval import CronDataIntervalTimetable
 
@@ -45,6 +46,14 @@ def process_invoice_lines_group(invoice_id: str):
     catchup=False,
     max_active_runs=10,
     tags=["digital bookplates"],
+    params={
+        "logical_date": Param(
+            f"{(datetime.now()).strftime('%Y-%m-%d')}",
+            format="datetime",
+            type="string",
+            description="The earliest date to select paid invoices from FOLIO.",
+        )
+    },
 )
 def digital_bookplate_instances():
     start = EmptyOperator(task_id="start")

--- a/libsys_airflow/plugins/digital_bookplates/purl_fetcher.py
+++ b/libsys_airflow/plugins/digital_bookplates/purl_fetcher.py
@@ -173,8 +173,7 @@ def trigger_instances_dag(**kwargs) -> bool:
         TriggerDagRunOperator(
             task_id=f"new-instance-dag-{i}",
             trigger_dag_id="digital_bookplate_instances",
-            logical_date="2023-08-28T00:00:00+00:00",
-            conf={"funds": [fund]},
+            conf={"logical_date": "2023-08-28T00:00:00+00:00", "funds": [fund]},
         ).execute(
             kwargs  # type: ignore
         )

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -111,16 +111,18 @@ def invoices_paid_within_date_range(**kwargs) -> list:
     """
     Get invoices with status=Paid and paymentDate=<range>, return invoice UUIDs
     paymentDate range based on airflow DAG run data intervals end and start dates
-    Query paymentDate greater than logical_date when run_id starts with "manual_"
+    Query paymentDate greater than params logical_date when run_id starts with "manual_"
     """
     folio_client = _folio_client()
     dag_run = kwargs["dag_run"]
+    params = kwargs.get("params", {})
+    logical_date = params.get("logical_date")
     dag_run_id = dag_run.run_id
     from_date = dag_run.data_interval_start
     to_date = dag_run.data_interval_end
     query = f"""?query=((paymentDate>="{from_date}" and paymentDate<="{to_date}") and status=="Paid")"""
-    if dag_run_id.startswith("manual_"):
-        from_date = dag_run.logical_date
+    if dag_run_id.startswith("manual_") and logical_date is not None:
+        from_date = logical_date
         logger.info(f"Querying paid invoices with paymentDate >= {from_date}")
         query = f"""?query=((paymentDate>="{from_date}") and status=="Paid")"""
 

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -110,7 +110,6 @@ def mock_manual_dag_run(mocker):
     dag_run.run_id = "manual__2024-09-19"
     dag_run.data_interval_end = ("2023-08-23T09:00:00+00:00",)
     dag_run.data_interval_start = ("2023-08-16T09:00:00+00:00",)
-    dag_run.logical_date = "2023-08-28 00:00:33.619135+00:00"
 
     return dag_run
 
@@ -131,7 +130,7 @@ def test_invoices_awaiting_payment_task(mocker, mock_folio_client):
 
 
 def test_get_invoices(mock_folio_client, mock_manual_dag_run):
-    date = mock_manual_dag_run.logical_date
+    date = "2023-08-28 00:00:33.619135+00:00"
     invoice_ids = _get_all_ids_from_invoices(
         f"""?query=((paymentDate>="{date}") and status=="Paid")""",
         mock_folio_client,
@@ -146,12 +145,13 @@ def test_invoices_paid_since_beginning(
         "libsys_airflow.plugins.folio.invoices._folio_client",
         return_value=mock_folio_client,
     )
-    invoice_ids = invoices_paid_within_date_range.function(dag_run=mock_manual_dag_run)
-    assert invoice_ids[0] == "649c0a8e-6741-49a1-a8a9-de1b8c01358f"
-    assert (
-        f"Querying paid invoices with paymentDate >= {mock_manual_dag_run.logical_date}"
-        in caplog.text
+    params = {"logical_date": "2023-08-28 00:00:33.619135+00:00"}
+    invoice_ids = invoices_paid_within_date_range.function(
+        dag_run=mock_manual_dag_run, params=params
     )
+    from_date = params.get("logical_date")
+    assert invoice_ids[0] == "649c0a8e-6741-49a1-a8a9-de1b8c01358f"
+    assert f"Querying paid invoices with paymentDate >= {from_date}" in caplog.text
 
 
 def test_invoices_paid_within_date_range(


### PR DESCRIPTION
Fixes #1281 

🤞 this works. I gave up trying to do a test for triggering the dag run with correct parameters. I kept getting the error `airflow.exceptions.DagNotFound: Dag id digital_bookplate_instances not found in DagModel` when trying to mock it and gave up.