### PR TITLE
Use dict instead of list for Instance UUIDs

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -61,7 +61,7 @@ def digital_bookplate_instances():
     retrieve_paid_invoices = invoices_paid_within_date_range()
 
     retrieve_instances = process_invoice_lines_group.expand(
-        invoice_id=retrieve_paid_invoices
+        invoice_id=retrieve_paid_invoices["invoice_uuids"]
     )
 
     launch_add_tag_dag = launch_add_979_fields_task(instances=retrieve_instances)

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -106,8 +106,8 @@ def invoices_pending_payment_task(invoice_ids: list):
     return _update_vouchers_to_pending(invoice_ids, folio_client)
 
 
-@task
-def invoices_paid_within_date_range(**kwargs) -> list:
+@task(multiple_outputs=True)
+def invoices_paid_within_date_range(**kwargs) -> dict:
     """
     Get invoices with status=Paid and paymentDate=<range>, return invoice UUIDs
     paymentDate range based on airflow DAG run data intervals end and start dates
@@ -132,7 +132,8 @@ def invoices_paid_within_date_range(**kwargs) -> list:
         )
 
     invoice_ids = _get_all_ids_from_invoices(query, folio_client)
-    return invoice_ids
+
+    return {"invoice_uuids": invoice_ids}
 
 
 @task(max_active_tis_per_dag=10)

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -150,7 +150,7 @@ def test_invoices_paid_since_beginning(
         dag_run=mock_manual_dag_run, params=params
     )
     from_date = params.get("logical_date")
-    assert invoice_ids[0] == "649c0a8e-6741-49a1-a8a9-de1b8c01358f"
+    assert invoice_ids['invoice_uuids'][0] == "649c0a8e-6741-49a1-a8a9-de1b8c01358f"
     assert f"Querying paid invoices with paymentDate >= {from_date}" in caplog.text
 
 
@@ -165,7 +165,7 @@ def test_invoices_paid_within_date_range(
         dag_run=mock_scheduled_dag_run
     )
     assert len(invoice_ids) == 1
-    assert invoice_ids[0] == "34cabbbd-d419-4853-ad3a-d0eafd4310c6"
+    assert invoice_ids['invoice_uuids'][0] == "34cabbbd-d419-4853-ad3a-d0eafd4310c6"
     assert (
         f"Querying paid invoices with paymentDate range >= {mock_scheduled_dag_run.data_interval_start} and <= {mock_scheduled_dag_run.data_interval_end}"
         in caplog.text


### PR DESCRIPTION
Fixes #1285 

This is a simple fix that changes how instance UUIDs are sent via XCOM to downstream tasks. By using a dict with one key instead of list with 10k instance UUIDs we avoid the limit of distinct "things" limit for XCOM.