### PR TITLE
[DRAFT] Multiple DAG triggers for Digital Bookplates Fetch and Instances DAGs

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -4,6 +4,7 @@ from airflow.decorators import dag, task_group
 from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.timetables.interval import CronDataIntervalTimetable
+from airflow.utils import timezone
 
 
 from libsys_airflow.plugins.digital_bookplates.bookplates import (
@@ -50,7 +51,12 @@ def process_invoice_lines_group(invoice_id: str):
             format="datetime",
             type="string",
             description="The earliest date to select paid invoices from FOLIO.",
-        )
+        ),
+        "digital_bookplate_979_run_id": Param(
+            f"manual__{timezone.utcnow().isoformat()}",
+            type="string",
+            description="The run id for the digital_bookplate_979 DAG run",
+        ),
     },
 )
 def digital_bookplate_instances():

--- a/libsys_airflow/dags/digital_bookplates/fetch_digital_bookplates.py
+++ b/libsys_airflow/dags/digital_bookplates/fetch_digital_bookplates.py
@@ -18,6 +18,7 @@ from libsys_airflow.plugins.digital_bookplates.purl_fetcher import (
     fetch_druids,
     filter_updates_errors,
     trigger_instances_dag,
+    trigger_polling_979_dag,
 )
 
 
@@ -83,7 +84,9 @@ def fetch_digital_bookplates():
         >> end
     )
 
-    trigger_instances_dag(new=filtered_data["new"]) >> end
+    digital_bookplate_979_dag_runs = trigger_instances_dag(new=filtered_data["new"])
+
+    trigger_polling_979_dag(dag_runs=digital_bookplate_979_dag_runs) >> end
 
     start >> fetch_bookplate_purls >> db_results
 


### PR DESCRIPTION
Fixes #1238 

Because the `fetch_digital_bookplates` DAG triggers one or more `digital_book_plates_instances` DAG runs, and
each `digital_book_plates_instances` DAG run in turn triggers a `digital_bookplate_979` DAG to add the 979 MARC fields, each `digital_bookplate_979`  DAG run id is generated and passed as a parameter to the `digital_book_plates_instances` DAG run. The generated `digital_bookplate_979`  DAG run ids are collected and then passed as a parameter to the triggered `poll_for_digital_bookplate_979s` in the `fetch_digital_bookplates`. 

The `poll_for_digital_bookplate_979s` polls for the status of all of the `digital_bookplate_979` DAG until they exist and the status is either success or failed. 

Here is a diagram of the DAG trigger interactions:

```mermaid
graph TD
fetch_digital_bookplates --> digital_bookplate_instances[1+ DAG runs]
digital_bookplate_instances[1+  digital_book_plates_instances DAG runs] --> digital_bookplate_979[1+ digital_bookplate_979]
fetch_digital_bookplates --> poll_for_digital_bookplate_979s
poll_for_digital_bookplate_979s --> digital_bookplate_979[1+ digital_bookplate_979]
```

TODO:
- [ ] Full end-to-end test 
- [ ] Unit testing of new code