### PR TITLE
Adds branching to avoid not being able to map tasks

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 from airflow.decorators import dag, task_group
-from airflow.models.param import Param
 from airflow.operators.empty import EmptyOperator
 from airflow.timetables.interval import CronDataIntervalTimetable
 
@@ -52,14 +51,6 @@ def process_new_funds_group(invoice_line: str):
     catchup=False,
     max_active_runs=10,
     tags=["digital bookplates"],
-    params={
-        "logical_date": Param(
-            f"{(datetime.now()).strftime('%Y-%m-%d')}",
-            format="datetime",
-            type="string",
-            description="The earliest date to select paid invoices from FOLIO.",
-        )
-    },
 )
 def digital_bookplate_instances():
     start = EmptyOperator(task_id="start")

--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -61,7 +61,7 @@ def digital_bookplate_instances():
     retrieve_paid_invoices = invoices_paid_within_date_range()
 
     retrieve_instances = process_invoice_lines_group.expand(
-        invoice_id=retrieve_paid_invoices["invoice_uuids"]
+        invoice_id=retrieve_paid_invoices
     )
 
     launch_add_tag_dag = launch_add_979_fields_task(instances=retrieve_instances)

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -106,8 +106,8 @@ def invoices_pending_payment_task(invoice_ids: list):
     return _update_vouchers_to_pending(invoice_ids, folio_client)
 
 
-@task(multiple_outputs=True)
-def invoices_paid_within_date_range(**kwargs) -> dict:
+@task
+def invoices_paid_within_date_range(**kwargs) -> list:
     """
     Get invoices with status=Paid and paymentDate=<range>, return invoice UUIDs
     paymentDate range based on airflow DAG run data intervals end and start dates
@@ -136,7 +136,7 @@ def invoices_paid_within_date_range(**kwargs) -> dict:
         logger.info(
             f"NO PAID INVOICES between {from_date} and {to_date}. Downstream tasks will be skiped."
         )
-    return {"invoice_uuids": invoice_ids}
+    return invoice_ids
 
 
 @task(max_active_tis_per_dag=10)

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -164,7 +164,7 @@ def test_invoices_paid_since_beginning(
         dag_run=mock_manual_dag_run, params=params
     )
     from_date = params.get("logical_date")
-    assert invoice_ids['invoice_uuids'][0] == "649c0a8e-6741-49a1-a8a9-de1b8c01358f"
+    assert invoice_ids[0] == "649c0a8e-6741-49a1-a8a9-de1b8c01358f"
     assert f"Querying paid invoices with paymentDate >= {from_date}" in caplog.text
 
 
@@ -179,7 +179,7 @@ def test_invoices_paid_within_date_range(
         dag_run=mock_scheduled_dag_run
     )
     assert len(invoice_ids) == 1
-    assert invoice_ids['invoice_uuids'][0] == "34cabbbd-d419-4853-ad3a-d0eafd4310c6"
+    assert invoice_ids[0] == "34cabbbd-d419-4853-ad3a-d0eafd4310c6"
     assert (
         f"Querying paid invoices with paymentDate range >= {mock_scheduled_dag_run.data_interval_start} and <= {mock_scheduled_dag_run.data_interval_end}"
         in caplog.text


### PR DESCRIPTION
Closes #1311 
When we have a new digital bookplate, we need to be able to get all possible paid invoices since on Folio to add 979 tags to MARC records. It is possible that a Folio fund could later get a bookplate, so querying since start on Folio is necessary. However, querying paid invoices since 8/28/2023 returns too many invoice Ids to map to tasks. We can't turn the return of invoices_paid_within_date_range task to a dict because all the mapped tasks only use the first invoice Id returned (see #1311). We want to use dynamic task mapping because it allows us to easily retry the failed task (some bug in FolioClient and httpx connection pooling is causing the dropped connections, see https://github.com/sul-dlss/libsys-airflow/issues/1259 for details). For the scheduled DAG runs of digital_bookplate_instances, it will have a weekly date range and likely never run into the issue of too many paid invoices to map to dynamic task mapping. When we have a new digital bookplate, we know the fund UUID and do not need to query for paid invoices but could query for paid invoice lines with a fundDistribution that has the fund UUID of our new fund. By branching the DAG, we check if the DAG is triggered with a funds param (or conf from fetch_digital_bookplates DAG). If it has a funds param/conf, we skip querying paid invoices in a date range. If the fund doesn't have a fund UUID, we skip the rest of the DAG (see #1324 for work to not trigger this DAG if there isn't a fund in Folio).

Here is a screenshot of the overall DAG structure with branching:
![Screenshot 2024-10-23 at 2 23 38 PM](https://github.com/user-attachments/assets/5449c49f-bddb-44de-a61b-46fbee53ea87)

Here is a screenshot of the details when the DAG is manually triggered with a funds config:
![Screenshot 2024-10-23 at 2 26 42 PM](https://github.com/user-attachments/assets/e4fa63d9-6775-43ab-a71e-ed46ddb594b1)

In this screenshot, you can see that the path followed is when the DAG is triggred with a funds config:
![Screenshot 2024-10-23 at 2 27 04 PM](https://github.com/user-attachments/assets/348c60b8-8997-4c32-bec3-ac4b1a1cbba9)

Here is an example of the XCOM for instances_from_po_lines task. This data should be used to trigger the digital_bookplate_979 DAG:
![Screenshot 2024-10-23 at 2 27 36 PM](https://github.com/user-attachments/assets/1cfca642-00d0-4f96-8c0d-23d15bed6cd6)
