### PR TITLE
Use common functions to Trigger DAGs

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_979.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_979.py
@@ -7,7 +7,7 @@ from libsys_airflow.plugins.digital_bookplates.bookplates import (
     add_979_marc_tags,
     add_marc_tags_to_record,
     instance_id_for_druids,
-    launch_add_979_fields_task,
+    retrieve_druids_for_instance_task,
 )
 
 
@@ -32,7 +32,7 @@ def digital_bookplate_979():
 
     end = EmptyOperator(task_id="end")
 
-    druids_for_instance_id = launch_add_979_fields_task()
+    druids_for_instance_id = retrieve_druids_for_instance_task()
 
     marc_tags_for_druid_instances = add_979_marc_tags(druids_for_instance_id)
 

--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -8,7 +8,7 @@ from airflow.timetables.interval import CronDataIntervalTimetable
 from libsys_airflow.plugins.digital_bookplates.bookplates import (
     bookplate_funds_polines,
     instances_from_po_lines,
-    launch_add_979_fields_task,
+    trigger_digital_bookplate_979_task,
 )
 
 from libsys_airflow.plugins.folio.invoices import (
@@ -75,14 +75,14 @@ def digital_bookplate_instances():
     retrieve_instances = process_date_range_group.expand(
         invoice_id=retrieve_paid_invoices
     )
-    launch_add_tag = launch_add_979_fields_task(instances=retrieve_instances)
+    launch_add_tag = trigger_digital_bookplate_979_task(instances=retrieve_instances)
 
     # New funds branch
     paid_invoice_lines_new_fund = invoice_lines_paid_on_fund()
     retrieve_instances_new_fund = process_new_funds_group.expand(
         invoice_line=paid_invoice_lines_new_fund
     )
-    launch_add_tag_new_fund = launch_add_979_fields_task(
+    launch_add_tag_new_fund = trigger_digital_bookplate_979_task(
         instances=retrieve_instances_new_fund
     )
 

--- a/libsys_airflow/plugins/digital_bookplates/bookplates.py
+++ b/libsys_airflow/plugins/digital_bookplates/bookplates.py
@@ -1,8 +1,12 @@
 import logging
 
+from typing import Union
+
 from airflow.decorators import task
-from airflow.models import Variable
+from airflow.models import DagBag, Variable
 from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.utils import timezone
+from airflow.utils.state import State
 
 from libsys_airflow.plugins.digital_bookplates.models import DigitalBookplate
 from libsys_airflow.plugins.shared import utils
@@ -39,6 +43,54 @@ def _get_bookplate_metadata_with_fund_uuids() -> dict:
             }
 
     return funds
+
+
+def launch_digital_bookplate_979_dag(**kwargs) -> str:
+    """
+    Triggers digital_bookplate_979 DAG with kwargs
+    """
+    instance_uuid: str = kwargs["instance_uuid"]
+    funds: list = kwargs["funds"]
+    dag_run_id: Union[str, None] = kwargs.get("run_id")
+    dag_payload = {instance_uuid: funds}
+
+    dagbag = DagBag("/opt/airflow/dags")
+    dag = dagbag.get_dag("digital_bookplate_979")
+
+    if dag_run_id is None:
+        execution_date = timezone.utcnow()
+        dag_run_id = f"manual__{execution_date.isoformat()}"
+
+    dag.create_dagrun(
+        run_id=dag_run_id,
+        execution_date=execution_date,
+        state=State.RUNNING,
+        conf={"druids_for_instance_id": dag_payload},
+        external_trigger=True,
+    )
+    logger.info(f"Triggers 979 DAG with dag_id {dag_run_id}")
+    return dag_run_id
+
+
+def launch_poll_for_979_dags(**kwargs):
+    """
+    Triggers poll_for_digital_bookplate_979s DAG with kwargs
+    """
+    dag_runs: list = kwargs["dag_runs"]
+    email: Union[str, None] = kwargs.get("email")
+
+    dagbag = DagBag("/opt/airflow/dags")
+    dag = dagbag.get_dag('poll_for_digital_bookplate_979s')
+    execution_date = timezone.utcnow()
+    run_id = f"manual__{execution_date.isoformat()}"
+    dag.create_dagrun(
+        run_id=run_id,
+        execution_date=execution_date,
+        state=State.RUNNING,
+        conf={"dag_runs": dag_runs, "email": email},
+        external_trigger=True,
+    )
+    logger.info(f"Triggers polling DAG for 979 DAG runs with dag_id {run_id}")
 
 
 def _new_bookplates(funds: list) -> dict:

--- a/libsys_airflow/plugins/digital_bookplates/bookplates.py
+++ b/libsys_airflow/plugins/digital_bookplates/bookplates.py
@@ -239,3 +239,15 @@ def add_marc_tags_to_record(**kwargs):
     instance_id = kwargs["instance_uuid"]
     folio_add_marc_tags = utils.FolioAddMarcTags()
     return folio_add_marc_tags.put_folio_records(marc_tags, instance_id)
+
+
+@task
+def trigger_digital_bookplate_979_task(**kwargs):
+    instances = kwargs["instances"]
+    dag_run_ids = []
+    for instance_uuid, funds in instances.items():
+        run_id = launch_digital_bookplate_979_dag(
+            instance_uuid=instance_uuid, funds=funds
+        )
+        dag_run_ids.append(run_id)
+    return dag_run_ids

--- a/libsys_airflow/plugins/digital_bookplates/bookplates.py
+++ b/libsys_airflow/plugins/digital_bookplates/bookplates.py
@@ -175,15 +175,6 @@ def instances_from_po_lines(**kwargs) -> dict:
 
 
 @task
-def launch_add_979_fields_task(**kwargs):
-    """
-    Trigger add a tag dag with instance UUIDs and fund 979 data. Returns a dict
-    """
-    params = kwargs.get("params", {})
-    return params.get("druids_for_instance_id", {})  # -> add_979_marc_tags
-
-
-@task
 def add_979_marc_tags(druid_instances: dict) -> dict:
     """
     "242c6000-8485-5fcd-9b5e-adb60788ca59": [
@@ -239,6 +230,15 @@ def add_marc_tags_to_record(**kwargs):
     instance_id = kwargs["instance_uuid"]
     folio_add_marc_tags = utils.FolioAddMarcTags()
     return folio_add_marc_tags.put_folio_records(marc_tags, instance_id)
+
+
+@task
+def retrieve_druids_for_instance_task(**kwargs):
+    """
+    Retrieves and returns a dictionary from the DAG params
+    """
+    params = kwargs.get("params", {})
+    return params.get("druids_for_instance_id", {})
 
 
 @task

--- a/tests/apps/digital_bookplates/test_batch_upload_view.py
+++ b/tests/apps/digital_bookplates/test_batch_upload_view.py
@@ -104,10 +104,6 @@ def test_missing_filename(test_airflow_client, mock_db):
 
 
 def test_get_fund(mocker, mock_db, tmp_path):
-    mocker.patch(
-        "libsys_airflow.plugins.digital_bookplates.apps.digital_bookplates_batch_upload_view.DagBag"
-    )
-
     mocker.patch.object(DigitalBookplatesBatchUploadView, "files_base", tmp_path)
 
     from libsys_airflow.plugins.digital_bookplates.apps.digital_bookplates_batch_upload_view import (
@@ -125,7 +121,7 @@ def test_get_fund(mocker, mock_db, tmp_path):
 
 def test_upload_file(mocker, test_airflow_client, mock_db, tmp_path):
     mocker.patch(
-        "libsys_airflow.plugins.digital_bookplates.apps.digital_bookplates_batch_upload_view.DagBag"
+        "libsys_airflow.plugins.digital_bookplates.bookplates.DagBag"
     )
 
     mocker.patch.object(DigitalBookplatesBatchUploadView, "files_base", tmp_path)

--- a/tests/apps/digital_bookplates/test_batch_upload_view.py
+++ b/tests/apps/digital_bookplates/test_batch_upload_view.py
@@ -120,9 +120,7 @@ def test_get_fund(mocker, mock_db, tmp_path):
 
 
 def test_upload_file(mocker, test_airflow_client, mock_db, tmp_path):
-    mocker.patch(
-        "libsys_airflow.plugins.digital_bookplates.bookplates.DagBag"
-    )
+    mocker.patch("libsys_airflow.plugins.digital_bookplates.bookplates.DagBag")
 
     mocker.patch.object(DigitalBookplatesBatchUploadView, "files_base", tmp_path)
 


### PR DESCRIPTION
Fixes #1337, the Digital Bookplates Batch Upload UI and the `digital_bookplates_instances` (through a new task) use the same functions in the bookplates module to trigger the `digital_bookplate_979` DAG. A new function for trigger the polling DAG is added that is used by the UI and now is available for use in follow-up PRs.