### PR TITLE
Fix typos in variable names

### DIFF
--- a/libsys_airflow/plugins/digital_bookplates/bookplates.py
+++ b/libsys_airflow/plugins/digital_bookplates/bookplates.py
@@ -185,13 +185,13 @@ def add_979_marc_tags(druid_instances: dict) -> dict:
     fund name in subfield f, druid in subfield b, image filename in subfield c, and title in subfield d:
     """
 
-    marc_instances_tags: dict = {'979': []}
+    marc_instance_tags: dict = {'979': []}
     for _instance_uuid, druids in druid_instances.items():
         for tag_data in druids:
             fund_name = tag_data.get('fund_name', None)
             if fund_name is None:
                 fund_name = tag_data.get('druid', '')
-            marc_instances_tags['979'].append(
+            marc_instance_tags['979'].append(
                 {
                     'ind1': ' ',
                     'ind2': ' ',
@@ -204,7 +204,7 @@ def add_979_marc_tags(druid_instances: dict) -> dict:
                 }
             )
 
-    return marc_instances_tags  # -> add_marc_tags_to_record
+    return marc_instance_tags  # -> add_marc_tags_to_record
 
 
 @task
@@ -230,7 +230,7 @@ def add_marc_tags_to_record(**kwargs):
         ]
     }
     """
-    marc_tags = kwargs["marc_instances_tags"]
+    marc_tags = kwargs["marc_instance_tags"]
     instance_id = kwargs["instance_uuid"]
     folio_add_marc_tags = utils.FolioAddMarcTags()
     return folio_add_marc_tags.put_folio_records(marc_tags, instance_id)

--- a/libsys_airflow/plugins/shared/utils.py
+++ b/libsys_airflow/plugins/shared/utils.py
@@ -20,7 +20,7 @@ class FolioAddMarcTags(object):
         self.httpx_client = httpx.Client()
         self.folio_client = folio_client()
 
-    def put_folio_records(self, marc_instances_tags: dict, instance_id: str) -> bool:
+    def put_folio_records(self, marc_instance_tags: dict, instance_id: str) -> bool:
         try:
             srs_record = self.__get_srs_record__(instance_id)
             srs_uuid = srs_record["recordId"]  # type: ignore
@@ -41,7 +41,7 @@ class FolioAddMarcTags(object):
                 "relatedRecordVersion": version,
                 "parsedRecord": {
                     "content": self.__marc_json_with_new_tags__(
-                        marc_json, marc_instances_tags
+                        marc_json, marc_instance_tags
                     )
                 },
                 "externalIdsHolder": {
@@ -57,10 +57,10 @@ class FolioAddMarcTags(object):
             return False
         return True
 
-    def __marc_json_with_new_tags__(self, marc_json: dict, marc_instances_tags: dict):
+    def __marc_json_with_new_tags__(self, marc_json: dict, marc_instance_tags: dict):
         reader = pymarc.reader.JSONReader(json.dumps(marc_json))
 
-        for tag_name, indicator_subfields in marc_instances_tags.items():
+        for tag_name, indicator_subfields in marc_instance_tags.items():
             for indsf in indicator_subfields:
                 for sfs in indsf['subfields']:
                     for sf_code, sf_val in sfs.items():

--- a/tests/digital_bookplates/test_add_marc_tags.py
+++ b/tests/digital_bookplates/test_add_marc_tags.py
@@ -128,7 +128,7 @@ def mock_folio_add_marc_tags(mocker):
     return mocker
 
 
-marc_instances_tags = {
+marc_instance_tags = {
     '979': [
         {
             'ind1': ' ',
@@ -147,7 +147,7 @@ marc_instances_tags = {
 def test_put_folio_records_unique_tag(mock_folio_add_marc_tags, caplog):
     add_marc_tag = utils.FolioAddMarcTags()
     put_record_result = add_marc_tag.put_folio_records(
-        marc_instances_tags, "64a5a15b-d89e-4bdd-bbd6-fcd215b367e4"
+        marc_instance_tags, "64a5a15b-d89e-4bdd-bbd6-fcd215b367e4"
     )
     assert put_record_result is True
     assert "Skip adding duplicated 979 field" not in caplog.text
@@ -156,7 +156,7 @@ def test_put_folio_records_unique_tag(mock_folio_add_marc_tags, caplog):
 def test_put_folio_records_duplicate_tag(mock_folio_add_marc_tags, caplog):
     add_marc_tag = utils.FolioAddMarcTags()
     put_record_result = add_marc_tag.put_folio_records(
-        marc_instances_tags, "242c6000-8485-5fcd-9b5e-adb60788ca59"
+        marc_instance_tags, "242c6000-8485-5fcd-9b5e-adb60788ca59"
     )
     assert put_record_result is True
     assert "Skip adding duplicated 979 field" in caplog.text


### PR DESCRIPTION
Fixes #1351 

`marc_instances_tags` should be `marc_instance_tags` (singular) as is the kwargs key.

https://sul-libsys-airflow-dev.stanford.edu/dags/digital_bookplate_979/grid?dag_run_id=manual__2024-10-24T23%3A14%3A06.702858%2B00%3A00&task_id=add_marc_tags_to_record&tab=logs