### PR TITLE
Return True unless False for testing whether tag is unique

### DIFF
--- a/libsys_airflow/plugins/shared/utils.py
+++ b/libsys_airflow/plugins/shared/utils.py
@@ -79,6 +79,7 @@ class FolioAddMarcTags(object):
                             if self.__tag_is_unique__(existing_tags, new_tag):
                                 record.add_field(new_tag)
 
+        logger.info(f"Constructing MARC record: {record.as_json()}")
         return record.as_json()
 
     def __get_srs_record__(self, instance_uuid: str) -> Union[dict, None]:
@@ -117,4 +118,4 @@ class FolioAddMarcTags(object):
                         return False
                     else:
                         return True
-        return False
+        return True

--- a/libsys_airflow/plugins/shared/utils.py
+++ b/libsys_airflow/plugins/shared/utils.py
@@ -55,12 +55,17 @@ class FolioAddMarcTags(object):
                 f"Failed to update FOLIO for Instance {instance_id} with SRS {srs_uuid}"
             )
             return False
+        else:
+            logger.info(
+                f"Successfully updated FOLIO Instance {instance_id} with SRS {srs_uuid}"
+            )
         return True
 
     def __marc_json_with_new_tags__(self, marc_json: dict, marc_instance_tags: dict):
         reader = pymarc.reader.JSONReader(json.dumps(marc_json))
 
         for tag_name, indicator_subfields in marc_instance_tags.items():
+            logger.info(f"Constructing MARC tag {tag_name}")
             for indsf in indicator_subfields:
                 for sfs in indsf['subfields']:
                     for sf_code, sf_val in sfs.items():

--- a/libsys_airflow/plugins/shared/utils.py
+++ b/libsys_airflow/plugins/shared/utils.py
@@ -79,8 +79,9 @@ class FolioAddMarcTags(object):
                             if self.__tag_is_unique__(existing_tags, new_tag):
                                 record.add_field(new_tag)
 
-        logger.info(f"Constructing MARC record: {record.as_json()}")
-        return record.as_json()
+        record_json = record.as_json()
+        logger.info(f"Constructing MARC record: {record_json}")
+        return record_json
 
     def __get_srs_record__(self, instance_uuid: str) -> Union[dict, None]:
         source_storage_result = self.folio_client.folio_get(


### PR DESCRIPTION
The default return for `FolioAddMarcTags.__tag_is_unique__` was False :-/ Also, adds some extra logging.

https://sul-libsys-airflow-dev.stanford.edu/dags/digital_bookplate_979/grid?dag_run_id=manual__2024-10-24T23%3A14%3A06.651308%2B00%3A00&task_id=add_marc_tags_to_record&tab=logs

https://folio-test.stanford.edu/inventory/view/b0fc4cdb-8271-5c14-90b5-648a19e4c7f7?qindex=id&query=b0fc4cdb-8271-5c14-90b5-648a19e4c7f7&sort=title
