### PR TITLE
DAG and Task Adjustments to Constrain Parallelism 

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_979.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_979.py
@@ -25,7 +25,7 @@ default_args = {
     schedule=None,
     start_date=datetime(2023, 8, 28),
     catchup=False,
-    max_active_runs=20,
+    max_active_runs=5,
     tags=["digital bookplates"],
 )
 def digital_bookplate_979():

--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -89,13 +89,13 @@ def date_range_or_funds_path(**kwargs):
     ),
     start_date=datetime(2023, 8, 28),
     catchup=False,
-    max_active_runs=10,
+    max_active_runs=5,
     tags=["digital bookplates"],
 )
 def digital_bookplate_instances():
     start = EmptyOperator(task_id="start")
 
-    end = EmptyOperator(task_id="end")
+    end = EmptyOperator(task_id="end", trigger_rule="none_failed_min_one_success")
 
     choose_branch = date_range_or_funds_path()
 

--- a/libsys_airflow/dags/digital_bookplates/poll_for_979s.py
+++ b/libsys_airflow/dags/digital_bookplates/poll_for_979s.py
@@ -40,6 +40,7 @@ def poll_979_dags(**kwargs):
     start_date=datetime(2024, 10, 15),
     catchup=False,
     tags=["digital bookplates"],
+    max_active_runs=3,
 )
 def poll_for_digital_bookplate_979s():
     start = EmptyOperator(task_id="start")

--- a/libsys_airflow/plugins/digital_bookplates/bookplates.py
+++ b/libsys_airflow/plugins/digital_bookplates/bookplates.py
@@ -109,7 +109,7 @@ def _new_bookplates(funds: list) -> dict:
     return bookplates
 
 
-@task
+@task(max_active_tis_per_dag=5)
 def bookplate_funds_polines(**kwargs) -> list:
     """
     Checks if fund Id from invoice lines contains bookplate fund

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -129,7 +129,7 @@ def invoices_paid_within_date_range(**kwargs) -> list:
     return invoice_ids
 
 
-@task(max_active_tis_per_dag=10)
+@task(max_active_tis_per_dag=5)
 def invoice_lines_from_invoices(invoice_id: str) -> list:
     """
     Given an invoice UUID, returns a list of invoice lines dictionaries
@@ -145,7 +145,7 @@ def invoice_lines_from_invoices(invoice_id: str) -> list:
     return all_invoice_lines
 
 
-@task(max_active_tis_per_dag=10)
+@task(max_active_tis_per_dag=5)
 def invoice_lines_paid_on_fund(**kwargs) -> list:
     """
     Given a list of fund objects with a fund_uuid key, returns a


### PR DESCRIPTION
Current settings seemed to overwhelm the available resources for Airflow; these changes constrain the number of simultaneous tasks and DAGs.