### PR TITLE
Guardrail for misnamed OCLC MARC files

### DIFF
--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -94,7 +94,11 @@ def gather_oclc_files_task(**kwargs) -> dict:
     oclc_directory = Path(airflow) / "data-export-files/oclc/marc-files/"
     for marc_file_path in oclc_directory.glob("**/*.mrc"):
         type_of = marc_file_path.parent.name
-        library = marc_file_path.stem.split("-")[1]
+        name_parts = marc_file_path.stem.split("-")
+        if len(name_parts) < 2:
+            logger.error(f"Cannot determine library from {marc_file_path}")
+            continue
+        library = name_parts[1]
         output[type_of][library].append(str(marc_file_path))
     return output
 

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -370,7 +370,7 @@ def test_archive_transmitted_data_task_no_files(caplog):
     assert "No files to archive" in caplog.text
 
 
-def test_gather_oclc_files_task(tmp_path):
+def test_gather_oclc_files_task(tmp_path, caplog):
     airflow = tmp_path
     oclc_marc_path = airflow / "data-export-files/oclc/marc-files"
     oclc_marc_path.mkdir(parents=True, exist_ok=True)
@@ -395,6 +395,9 @@ def test_gather_oclc_files_task(tmp_path):
     updates_hin.touch()
     updates_stf = updates_path / "20240603113-STF.mrc"
     updates_stf.touch()
+    # MARC file  missing library code
+    updates_unknown = updates_path / "2024102923.mrc"
+    updates_unknown.touch()
 
     oclc_ops_libraries = gather_oclc_files_task.function(airflow=airflow)
 
@@ -410,6 +413,8 @@ def test_gather_oclc_files_task(tmp_path):
     assert len(oclc_ops_libraries["new"]["CASUM"]) == 1
     assert len(oclc_ops_libraries["updates"]["HIN"]) == 1
     assert len(oclc_ops_libraries["updates"]["CASUM"]) == 0
+
+    assert f"Cannot determine library from {updates_unknown}" in caplog.text
 
 
 def test_delete_from_oclc_task(mocker, mock_oclc_connection):


### PR DESCRIPTION
Fixes #1318 

Also deleted old files on Airflow Stage for old files that didn't follow the naming conventions.