### PR TITLE
Uses string comparisons in list of strings to check for tag uniqueness.

### DIFF
--- a/tests/digital_bookplates/test_add_marc_tags.py
+++ b/tests/digital_bookplates/test_add_marc_tags.py
@@ -152,7 +152,7 @@ def test_put_folio_records_unique_tag(mock_folio_add_marc_tags, caplog):
     assert put_record_result is True
     assert "Skip adding duplicated 979 field" not in caplog.text
     assert (
-        "ABBOTT druid:ws066yy0421 ws066yy0421_00_0001.jp2 The The Donald P. Abbott Fund for Marine Invertebrates tag is unique"
+        r"=979  \\$fABBOTT$bdruid:ws066yy0421$cws066yy0421_00_0001.jp2$dThe The Donald P. Abbott Fund for Marine Invertebrates tag is unique"
         in caplog.text
     )
 
@@ -164,6 +164,6 @@ def test_put_folio_records_duplicate_tag(mock_folio_add_marc_tags, caplog):
     )
     assert put_record_result is True
     assert (
-        "Skip adding duplicated ABBOTT druid:ws066yy0421 ws066yy0421_00_0001.jp2 The The Donald P. Abbott Fund for Marine Invertebrates field"
+        r"Skip adding duplicated =979  \\$fABBOTT$bdruid:ws066yy0421$cws066yy0421_00_0001.jp2$dThe The Donald P. Abbott Fund for Marine Invertebrates field"
         in caplog.text
     )


### PR DESCRIPTION
Fixes #1375 

Running the digital_bookplate_979 DAG locally against stage with the same configuration from the ticket, it did not add more 979 fields:
```
[2024-10-29, 18:49:04 UTC] {_client.py:1038} INFO - HTTP Request: POST https://okapi-stage.stanford.edu/authn/login-with-expiry "HTTP/1.1 201 Created"
[2024-10-29, 18:49:04 UTC] {_client.py:1038} INFO - HTTP Request: GET https://okapi-stage.stanford.edu/source-storage/source-records?instanceId=b6e80385-3be3-4e84-a530-d89d072af46b "HTTP/1.1 200 OK"
[2024-10-29, 18:49:04 UTC] {_client.py:1038} INFO - HTTP Request: GET https://okapi-stage.stanford.edu/inventory/instances/b6e80385-3be3-4e84-a530-d89d072af46b "HTTP/1.1 200 OK"
[2024-10-29, 18:49:04 UTC] {utils.py:93} INFO - Constructing MARC tag 979
[2024-10-29, 18:49:04 UTC] {utils.py:98} INFO - Record has existing 979's. New fields will be evaluated for uniqueness.
[2024-10-29, 18:49:04 UTC] {utils.py:144} INFO - Skip adding duplicated =979  \\$fSTEINMETZ$bdruid:nc092rd1979$cnc092rd1979_00_0001.jp2$dVerna Pace Steinmetz Endowed Book Fund in History field
[2024-10-29, 18:49:04 UTC] {utils.py:115} INFO - New field 979 is not unique
[2024-10-29, 18:49:04 UTC] {utils.py:144} INFO - Skip adding duplicated =979  \\$fWHITEHEAD$bdruid:ph944pq1002$cph944pq1002_00_0001.jp2$dBarry Whitehead Memorial Book Fund field
[2024-10-29, 18:49:04 UTC] {utils.py:115} INFO - New field 979 is not unique
[2024-10-29, 18:49:04 UTC] {utils.py:121} INFO - Constructing MARC record: {"leader": "00985cam a22003017  4500", "fields": [{"001": "in00000029302"}, {"008": "991209s1907    enk           000 0 eng d"}, {"005": "20231129185408.4"}, {"035": {"ind1": " ", "ind2": " ", "subfields": [{"a": "(OCoLC)ocm42964914 "}]}}, {"040": {"ind1": " ", "ind2": " ", "subfields": [{"a": "IUL"}, {"b": "eng"}, {"c": "IUL"}, {"d": "UKMGB"}, {"d": "OCLCQ"}]}}, {"016": {"ind1": "7", "ind2": " ", "subfields": [{"a": "002263097"}, {"2": "Uk"}]}}, {"035": {"ind1": " ", "ind2": " ", "subfields": [{"a": "(OCoLC)42964914"}]}}, {"050": {"ind1": " ", "ind2": "4", "subfields": [{"a": "PR6023.O7"}, {"b": "C15"}]}}, {"100": {"ind1": "1", "ind2": " ", "subfields": [{"a": "Lorrimer, Charlotte."}]}}, {"245": {"ind1": "1", "ind2": "4", "subfields": [{"a": "The call of the East."}]}}, {"260": {"ind1": " ", "ind2": " ", "subfields": [{"a": "London,"}, {"b": "Gay and Bird,"}, {"c": "1907."}]}}, {"300": {"ind1": " ", "ind2": " ", "subfields": [{"a": "265 pages"}]}}, {"336": {"ind1": " ", "ind2": " ", "subfields": [{"a": "text"}, {"b": "txt"}, {"2": "rdacontent"}]}}, {"337": {"ind1": " ", "ind2": " ", "subfields": [{"a": "unmediated"}, {"b": "n"}, {"2": "rdamedia"}]}}, {"338": {"ind1": " ", "ind2": " ", "subfields": [{"a": "volume"}, {"b": "nc"}, {"2": "rdacarrier"}]}}, {"340": {"ind1": " ", "ind2": " ", "subfields": [{"m": "8vo."}, {"2": "rdabf"}]}}, {"776": {"ind1": "0", "ind2": "8", "subfields": [{"i": "Online version:"}, {"a": "Lorrimer, Charlotte."}, {"t": "Call of the East."}, {"d": "London, Gay and Bird, 1907"}, {"w": "(OCoLC)890949848"}]}}, {"029": {"ind1": "1", "ind2": " ", "subfields": [{"a": "DEBBG"}, {"b": "BV017144610"}]}}, {"029": {"ind1": "1", "ind2": " ", "subfields": [{"a": "NZ1"}, {"b": "6760284"}]}}, {"029": {"ind1": "1", "ind2": " ", "subfields": [{"a": "UKMGB"}, {"b": "002263097"}]}}, {"979": {"ind1": " ", "ind2": " ", "subfields": [{"f": "STEINMETZ"}, {"b": "druid:nc092rd1979"}, {"c": "nc092rd1979_00_0001.jp2"}, {"d": "Verna Pace Steinmetz Endowed Book Fund in History"}]}}, {"979": {"ind1": " ", "ind2": " ", "subfields": [{"f": "WHITEHEAD"}, {"b": "druid:ph944pq1002"}, {"c": "ph944pq1002_00_0001.jp2"}, {"d": "Barry Whitehead Memorial Book Fund"}]}}, {"979": {"ind1": " ", "ind2": " ", "subfields": [{"f": "WHITEHEAD"}, {"b": "druid:ph944pq1002"}, {"c": "ph944pq1002_00_0001.jp2"}, {"d": "Barry Whitehead Memorial Book Fund"}]}}, {"994": {"ind1": " ", "ind2": " ", "subfields": [{"a": "Z0"}, {"b": "STF"}]}}, {"948": {"ind1": " ", "ind2": " ", "subfields": [{"h": "NO HOLDINGS IN STF - 11 OTHER HOLDINGS"}]}}, {"999": {"ind1": "f", "ind2": "f", "subfields": [{"s": "63416ec0-32a1-418f-80dd-973c9028cdd3"}, {"i": "b6e80385-3be3-4e84-a530-d89d072af46b"}]}}]}
[2024-10-29, 18:49:05 UTC] {_client.py:1038} INFO - HTTP Request: PUT https://okapi-stage.stanford.edu/change-manager/parsedRecords/63416ec0-32a1-418f-80dd-973c9028cdd3 "HTTP/1.1 202 Accepted"
[2024-10-29, 18:49:05 UTC] {utils.py:59} INFO - Successfully updated FOLIO Instance b6e80385-3be3-4e84-a530-d89d072af46b with SRS 63416ec0-32a1-418f-80dd-973c9028cdd3
[2024-10-29, 18:49:05 UTC] {python.py:202} INFO - Done. Returned value was: True
```