### PR TITLE
Returns a list of lists for invoice_lines_paid_on_fund task.

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -46,12 +46,12 @@ def process_date_range_group(invoice_id: str):
 
 
 @task_group(group_id="process-new-funds")
-def process_new_funds_group(invoice_line: dict):
+def process_new_funds_group(invoice_lines: list):
     """
     See https://s3.amazonaws.com/foliodocs/api/mod-invoice-storage/p/invoice.html#invoice_storage_invoice_lines_get
-    Input: an single invoice line dictionary, wrapped in a list:
+    Input: a list of invoice line dictionaries wrapped in a list, e.g. [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]
     """
-    paid_bookplate_polines = bookplate_funds_polines(invoice_lines=[invoice_line])
+    paid_bookplate_polines = bookplate_funds_polines(invoice_lines=invoice_lines)
     return instances_from_po_lines(
         po_lines_funds=paid_bookplate_polines
     )  # -> launch_add_979_fields_task
@@ -110,8 +110,9 @@ def digital_bookplate_instances():
     # New funds branch
     paid_invoice_lines_new_fund = invoice_lines_paid_on_fund()
     retrieve_instances_new_fund = process_new_funds_group.expand(
-        invoice_line=paid_invoice_lines_new_fund
+        invoice_lines=paid_invoice_lines_new_fund
     )
+
     launch_add_tag_new_fund = trigger_digital_bookplate_979_task(
         instances=retrieve_instances_new_fund
     )

--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -149,7 +149,7 @@ def invoice_lines_from_invoices(invoice_id: str) -> list:
 def invoice_lines_paid_on_fund(**kwargs) -> list:
     """
     Given a list of fund objects with a fund_uuid key, returns a
-    list of paid invoice lines dictionaries
+    list of paid invoice lines dictionaries in limit-sized chunks
     """
     folio_client = _folio_client()
     all_invoice_lines = []
@@ -166,4 +166,14 @@ def invoice_lines_paid_on_fund(**kwargs) -> list:
         else:
             logger.info(f"Fund does not have fund_uuid: {row}")
 
-    return all_invoice_lines
+    if len(all_invoice_lines) > 1000:
+        invoice_line_chunks = [
+            all_invoice_lines[x : x + 100]
+            for x in range(0, len(all_invoice_lines), 100)
+        ]
+    else:
+        invoice_line_chunks = [
+            all_invoice_lines[x : x + 5] for x in range(0, len(all_invoice_lines), 5)
+        ]
+
+    return invoice_line_chunks

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -230,7 +230,8 @@ def test_invoice_lines_paid_on_fund(mocker, mock_folio_client, mock_new_funds, c
         f"Getting paid invoice lines for {mock_new_funds[0].get('fund_uuid')}"
         in caplog.text
     )
-    assert len(invoice_lines) == 3
+    assert len(invoice_lines) == 1
+    assert len(invoice_lines[0]) == 3
 
 
 def test_invoice_lines_paid_on_fund_not_in_folio(mocker, mock_folio_client, caplog):


### PR DESCRIPTION
Fixes #1335

When triggering the digital_bookplate_instances DAG with a conf with a new fund, the funds branch will be used so that invoice_lines_paid_on_fund task will query folio for the fund_uuid in fundDistributions list of paid invoice lines. In some cases, there are more invoice lines than can be mapped to dynamic tasks (currently in prod there are 2,026 paid invoice lines with the LINDER fund). I've changed invoice_lines_paid_on_fund task to return a list of lists, e.g.
```
[
  [{folio invoice line dict}, {folio invoice line dict}, {folio invoice line dict}, ...],
  [{folio invoice line dict}, {folio invoice line dict}, {folio invoice line dict}, ...]
]
```
If all paid invoice lines for a particular fund is greater than 1,000, then each inner list of folio invoice line dicts will be 100. For all others it will be 5. I am a little worried that we will see a lot of dropped connections once we get to the instances_from_po_lines task for each 100 paid invoice lines, since we will be hitting okapi hard at this point and possibly seeing dropped connections for the connection pooling bug in httpx implementation of FolioClient.