### PR TITLE
Creates invoice lines limit variable invoice_lines_paid_on_fund task.

### DIFF
--- a/libsys_airflow/plugins/folio/invoices.py
+++ b/libsys_airflow/plugins/folio/invoices.py
@@ -152,6 +152,9 @@ def invoice_lines_paid_on_fund(**kwargs) -> list:
     list of paid invoice lines dictionaries in limit-sized chunks
     """
     folio_client = _folio_client()
+    invoice_line_limit = Variable(
+        description="Number of invoice lines for each list"
+    ).get("INVOICE_LINE_LIMIT", 100)
     all_invoice_lines = []
     params = kwargs.get("params", {})
     funds = params.get("funds", [])
@@ -168,8 +171,8 @@ def invoice_lines_paid_on_fund(**kwargs) -> list:
 
     if len(all_invoice_lines) > 1000:
         invoice_line_chunks = [
-            all_invoice_lines[x : x + 100]
-            for x in range(0, len(all_invoice_lines), 100)
+            all_invoice_lines[x : x + invoice_line_limit]
+            for x in range(0, len(all_invoice_lines), invoice_line_limit)
         ]
     else:
         invoice_line_chunks = [


### PR DESCRIPTION
Running digital_bookplate_instances DAG with LINDER fund configuraiton and 100 invoice line lists on airflow-dev caused the `httpx.RemoteProtocolError: Server disconnected without sending a response.` error. On subsequent retries with 100, it finally worked. Maybe it depends on the time of day? In any case, making this a variable so that we can get the right setting when needed seems like a good idea.