### PR TITLE
Increase timeout for client

### DIFF
--- a/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
@@ -18,7 +18,7 @@ default_args = {
     "depends_on_past": False,
     "email_on_failure": True,
     "email_on_retry": False,
-    "retries": 1,
+    "retries": 0,
     "retry_delay": timedelta(minutes=1),
 }
 
@@ -34,7 +34,6 @@ with DAG(
     ),
     start_date=datetime(2024, 8, 29),
     catchup=False,
-    retries=0,
     tags=["folio"],
     params={
         "choice": Param(

--- a/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
@@ -34,6 +34,7 @@ with DAG(
     ),
     start_date=datetime(2024, 8, 29),
     catchup=False,
+    retries=0,
     tags=["folio"],
     params={
         "choice": Param(

--- a/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
@@ -33,6 +33,7 @@ with DAG(
     ),
     start_date=datetime(2024, 8, 29),
     catchup=False,
+    retries=0,
     tags=["folio"],
     params={
         "choice": Param(

--- a/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
@@ -18,7 +18,7 @@ default_args = {
     "depends_on_past": False,
     "email_on_failure": True,
     "email_on_retry": False,
-    "retries": 1,
+    "retries": 0,
     "retry_delay": timedelta(minutes=1),
 }
 
@@ -33,7 +33,6 @@ with DAG(
     ),
     start_date=datetime(2024, 8, 29),
     catchup=False,
-    retries=0,
     tags=["folio"],
     params={
         "choice": Param(

--- a/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
@@ -18,7 +18,7 @@ default_args = {
     "depends_on_past": False,
     "email_on_failure": True,
     "email_on_retry": False,
-    "retries": 1,
+    "retries": 0,
     "retry_delay": timedelta(minutes=1),
 }
 
@@ -34,7 +34,6 @@ with DAG(
     ),
     start_date=datetime(2024, 8, 29),
     catchup=False,
-    retries=0,
     tags=["folio"],
     params={
         "choice": Param(

--- a/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
@@ -34,6 +34,7 @@ with DAG(
     ),
     start_date=datetime(2024, 8, 29),
     catchup=False,
+    retries=0,
     tags=["folio"],
     params={
         "choice": Param(

--- a/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances.py
+++ b/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances.py
@@ -23,7 +23,7 @@ client = httpx.AsyncClient()
 dryrun = False
 
 # request timeout in seconds
-ASYNC_CLIENT_TIMEOUT = 30
+ASYNC_CLIENT_TIMEOUT = 60
 
 # limit the number of parallel threads.
 # Try different values. Bigger values - for increasing performance, but could produce "Connection timeout exception"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ exclude = '''
   /(
     vendor_loads_migration
     | digital_bookplates_migration
+    | libsys_airflow/plugins/folio/encumbrances
   )/
 '''
 skip-string-normalization = true


### PR DESCRIPTION
Let's see if bumping up the `ASYNC_CLIENT_TIMEOUT` helps with the failure.
Also, the print statements are not output to the airflow logs, so change those to logger statements.
Also, set `retries: 0` for DAGS so that we do not get duplicate emails.
Also, ignore black reformatting for `fix_encumbrance` scripts.

`2024-10-21, 02:04:09 PDT] {_client.py:1786} INFO - HTTP Request: GET https://okapi-prod.stanford.edu/finance-storage/transactions?query=encumbrance.sourcePurchaseOrderId%3D%3D032e2233-0d97-40f5-a968-b23bcdaa9011%20AND%20fiscalYearId%3D%3D58622c3a-678b-46fc-a84c-35b3122f36c2&offset=0&limit=2147483647 "HTTP/1.1 200 OK"
[2024-10-21, 02:04:09 PDT] {_client.py:1786} INFO - HTTP Request: GET https://okapi-prod.stanford.edu/finance-storage/transactions?query=encumbrance.sourcePurchaseOrderId%3D%3D032f7a70-177b-4d29-90db-26243ecb6da6%20AND%20fiscalYearId%3D%3D58622c3a-678b-46fc-a84c-35b3122f36c2&offset=0&limit=2147483647 "HTTP/1.1 200 OK"
[2024-10-21, 02:04:09 PDT] {taskinstance.py:2733} ERROR - Task failed due to SystemExit(1)
[2024-10-21, 02:04:09 PDT] {taskinstance.py:1149} INFO - Marking task as FAILED. dag_id=fix_encumbrances_lane, task_id=run_fix_encumbrances_script, `