### PR TITLE
Adds email_on_failure to digital_bookplate_instances DAG.

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
+++ b/libsys_airflow/dags/digital_bookplates/digital_bookplate_instances.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from airflow.decorators import dag, task, task_group
 from airflow.operators.empty import EmptyOperator
 from airflow.timetables.interval import CronDataIntervalTimetable
+from airflow.models import Variable
 
 
 from libsys_airflow.plugins.digital_bookplates.bookplates import (
@@ -21,11 +22,12 @@ from libsys_airflow.plugins.folio.invoices import (
 )
 
 logger = logging.getLogger(__name__)
-
+devs_to_email_addr = Variable.get("EMAIL_DEVS")
 
 default_args = {
     "owner": "libsys",
     "depends_on_past": False,
+    "email": [devs_to_email_addr],
     "email_on_failure": True,
     "email_on_retry": False,
     "retries": 3,


### PR DESCRIPTION
Closes #1394 

Let's just try the [default airflow email_alert](https://github.com/apache/airflow/blob/32d4b63c5993d1dfb9b66040e2d214880da1fbf8/airflow/models/taskinstance.py#L1430-L1490) for now.