### PR TITLE
 Ignores type error for SQLExecuteQueryOperator

### DIFF
--- a/libsys_airflow/plugins/data_exports/full_dump_marc.py
+++ b/libsys_airflow/plugins/data_exports/full_dump_marc.py
@@ -39,7 +39,9 @@ def fetch_number_of_records(**kwargs) -> int:
         conn_id="postgres_folio",
         database=kwargs.get("database", "okapi"),
         sql=query,
-    ).execute(context)
+    ).execute(
+        context
+    )  # type: ignore
 
     count = result[0][0]
     logger.info(f"Record count: {count}")

--- a/libsys_airflow/plugins/data_exports/instance_ids.py
+++ b/libsys_airflow/plugins/data_exports/instance_ids.py
@@ -51,7 +51,9 @@ def fetch_record_ids(**kwargs) -> dict:
                         "from_date": from_date,
                         "to_date": to_date,
                     },
-                ).execute(context)
+                ).execute(
+                    context
+                )  # type: ignore
             )
 
         results[kind] = list(np.unique(results[kind]))


### PR DESCRIPTION
mypy is getting confused because the execute method does return values (but no type hint is provided for the method) 

https://airflow.apache.org/docs/apache-airflow-providers-common-sql/1.3.1/_modules/airflow/providers/common/sql/operators/sql.html#SQLExecuteQueryOperator