### PR TITLE
Fixes counting of instances passed to trigger 979 dag runs

### DIFF
--- a/libsys_airflow/plugins/digital_bookplates/bookplates.py
+++ b/libsys_airflow/plugins/digital_bookplates/bookplates.py
@@ -283,22 +283,16 @@ def retrieve_druids_for_instance_task(**kwargs):
 @task
 def trigger_digital_bookplate_979_task(**kwargs):
     instances = kwargs["instances"]
-    instances_list = [item for row in instances for item in row]
     dag_run_ids = []
-    logger.info(f"Total incoming lists of instances {len(instances)}")
-    total_instances: int = 0
-    for row in instances_list:
+    logger.info(f"Total incoming instances {len(instances)}")
+    for row in instances:
         if len(row) < 1:
             continue
-
-        total_instances += len(row.keys())
         for instance_uuid, funds in row.items():
             run_id = launch_digital_bookplate_979_dag(
                 instance_uuid=instance_uuid, funds=funds
             )
             dag_run_ids.append(run_id)
-
-    logger.info(f"Total incoming instances {total_instances}")
     return dag_run_ids
 
 

--- a/libsys_airflow/plugins/digital_bookplates/bookplates.py
+++ b/libsys_airflow/plugins/digital_bookplates/bookplates.py
@@ -284,15 +284,18 @@ def retrieve_druids_for_instance_task(**kwargs):
 def trigger_digital_bookplate_979_task(**kwargs):
     instances = kwargs["instances"]
     dag_run_ids = []
-    logger.info(f"Total incoming instances {len(instances)}")
+    total_instances: int = 0
     for row in instances:
         if len(row) < 1:
             continue
+
+        total_instances += len(row)
         for instance_uuid, funds in row.items():
             run_id = launch_digital_bookplate_979_dag(
                 instance_uuid=instance_uuid, funds=funds
             )
             dag_run_ids.append(run_id)
+    logger.info(f"Total incoming instances {total_instances}")
     return dag_run_ids
 
 

--- a/tests/digital_bookplates/test_bookplates.py
+++ b/tests/digital_bookplates/test_bookplates.py
@@ -418,57 +418,25 @@ def test_trigger_digital_bookplate_979_task(mocker, mock_dag_bag, caplog):
         return_value=mock_dag_bag,
     )
     incoming_instances = [
-        [
-            {},
-            {
-                'a855e551-47da-4621-9e05-5da512f526f7': [
-                    {
-                        'fund_name': 'TANENBAUM',
-                        'druid': 'yv459xj8957',
-                        'image_filename': 'yv459xj8957_00_0001.jp2',
-                        'title': 'The Mary M. Tanenbaum Chinese Art Fund',
-                    }
-                ]
-            },
-            {},
-        ],
-        [
-            {
-                "e6803f0b-ed22-48d7-9895-60bea6826e93": [
-                    {
-                        "druid": "gc698jf6425",
-                        "fund_name": "RHOADES",
-                        "image_filename": "gc698jf6425_00_0001.jp2",
-                        "title": "John Skylstead and Carmel Cole Rhoades Fund for California History and the History of the North American West",
-                    },
-                    {
-                        "druid": "kp761xz4568",
-                        "fund_name": "ASHENR",
-                        "image_filename": "dp698zx8237_00_0001.jp2",
-                        "title": "Ruth Geraldine Ashen Memorial Book Fund",
-                    },
-                ]
-            },
-            {
-                "eefe185b-2f25-4d5a-ba6f-cfc60b79e33e": [
-                    {
-                        "druid": "xg474qk4925",
-                        "fund_name": "LINDER",
-                        "image_filename": "xg474qk4925_00_0001.jp2",
-                        "title": "The Doris H. Linder Book Fund",
-                    }
-                ],
-            },
-        ],
+        {},
+        {
+            'a855e551-47da-4621-9e05-5da512f526f7': [
+                {
+                    'fund_name': 'TANENBAUM',
+                    'druid': 'yv459xj8957',
+                    'image_filename': 'yv459xj8957_00_0001.jp2',
+                    'title': 'The Mary M. Tanenbaum Chinese Art Fund',
+                }
+            ]
+        },
+        {},
     ]
     dag_run_ids = trigger_digital_bookplate_979_task.function(
         instances=incoming_instances
     )
 
-    assert "Total incoming lists of instances 2" in caplog.text
     assert "Total incoming instances 3" in caplog.text
-    assert len(dag_run_ids) == 3
-    assert len(set(dag_run_ids)) == 3
+    assert len(dag_run_ids) == 1
 
 
 def test_trigger_digital_bookplate_979_task_no_instances(mocker, mock_dag_bag, caplog):

--- a/tests/digital_bookplates/test_bookplates.py
+++ b/tests/digital_bookplates/test_bookplates.py
@@ -435,7 +435,7 @@ def test_trigger_digital_bookplate_979_task(mocker, mock_dag_bag, caplog):
         instances=incoming_instances
     )
 
-    assert "Total incoming instances 3" in caplog.text
+    assert "Total incoming instances 1" in caplog.text
     assert len(dag_run_ids) == 1
 
 


### PR DESCRIPTION
Fixes #1434 

I realized that this trigger_digital_bookplate_979_task function works as it should, just that the logging was wrong. See the [prod dag run for LINDER fund](https://sul-libsys-airflow-prod.stanford.edu/dags/digital_bookplate_instances/grid?run_id=scheduled__2024-11-06T10%3A00%3A00%2B00%3A00&execution_date=2024-11-06+10%3A00%3A00%2B00%3A00&dag_run_id=manual__2024-10-30T18%3A23%3A24.742223%2B00%3A00&tab=graph), where the mapped tasks are reported in the log for trigger_digital_bookplate_979_task__1 is `INFO - Total incoming instances 21`. This PR fixes what was not necessary (reverts commit c6742fb) and adds the row length to total_instances to get accurate count.

After this is merged and deployed, we need to re-run [this failed dag run](https://sul-libsys-airflow-prod.stanford.edu/dags/digital_bookplate_instances/grid?run_id=scheduled__2024-11-06T10:00:00%2B00:00&execution_date=2024-11-06+10:00:00%2B00:00&tab=graph&dag_run_id=scheduled__2024-11-06T10:00:00%2B00:00).