### PR TITLE
 Create a DAG object for dag_run in Poll 979 Sensor

### DIFF
--- a/libsys_airflow/plugins/digital_bookplates/dag_979_sensor.py
+++ b/libsys_airflow/plugins/digital_bookplates/dag_979_sensor.py
@@ -1,6 +1,6 @@
 import logging
 
-from airflow.models import DagRun
+from airflow.models import DAG, DagRun
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 
 from libsys_airflow.plugins.shared.utils import dag_run_url
@@ -25,6 +25,7 @@ class DAG979Sensor(BaseSensorOperator):
             dag_run = dag_runs[0]
             state = dag_run.get_state()
             self.dag_runs[dag_run_id]['state'] = state
+            dag_run.dag = DAG(dag_id='digital_bookplate_979')
             self.dag_runs[dag_run_id]['url'] = dag_run_url(dag_run=dag_run)
             if state in ['success', 'failed']:
                 instances = []


### PR DESCRIPTION
Fixes #1441

Because the dag_runs returned from the `DagRun.find` method call does not include the DAG object.