### PR TITLE
Adds Error checking in UI, replaces requests package, DAG config

### DIFF
--- a/libsys_airflow/dags/new_boundwiths.py
+++ b/libsys_airflow/dags/new_boundwiths.py
@@ -34,6 +34,9 @@ def _folio_client():
     start_date=datetime(2023, 11, 7),
     catchup=False,
     tags=["folio", "boundwith"],
+    default_args={
+        "email_on_failure": False,
+    },
     on_failure_callback=email_failure,
 )
 def add_bw_relationships(**kwargs):

--- a/libsys_airflow/plugins/boundwith/boundwith_view.py
+++ b/libsys_airflow/plugins/boundwith/boundwith_view.py
@@ -52,7 +52,10 @@ class BoundWithView(AppBuilderBaseView):
                 raw_csv = request.files["upload-boundwith"]
                 email_addr = request.form.get("user-email")
                 bw_df = pd.read_csv(raw_csv)
-                if len(bw_df) > 1_000:
+                if ["parts_holdings_hrid", "principle_barcode"] != list(bw_df.columns):
+                    flash(f"Invalid columns: {list(bw_df.columns)} for CSV file")
+                    rendered_page = self.render_template("boundwith/index.html")
+                elif len(bw_df) > 1_000:
                     flash(f"Warning! CSV file has {len(bw_df)} rows, limit is 1,000")
                     rendered_page = self.render_template("boundwith/index.html")
                 else:


### PR DESCRIPTION
Fixes #1448 

In looking at [examples](https://medium.com/@manmeetkaur.rangoola/airflow-logging-and-monitoring-fc3cf32c4d50) of `on_failure_callback`, the `email_on_failure` is set to False to ensure that the `email_failure` function is called once to email errors in the case of failed task.