### PR TITLE
Correct issues with Boundwith App 

### DIFF
--- a/libsys_airflow/dags/new_boundwiths.py
+++ b/libsys_airflow/dags/new_boundwiths.py
@@ -102,7 +102,7 @@ def add_bw_relationships(**kwargs):
 
     admin_note = generate_admin_note()
 
-    start >> [rows, admin_note]
+    start >> rows >> admin_note
 
     bw_records = add_bw_record.expand(row=rows)
 

--- a/libsys_airflow/plugins/boundwith/boundwith_view.py
+++ b/libsys_airflow/plugins/boundwith/boundwith_view.py
@@ -52,7 +52,7 @@ class BoundWithView(AppBuilderBaseView):
                 raw_csv = request.files["upload-boundwith"]
                 email_addr = request.form.get("user-email")
                 bw_df = pd.read_csv(raw_csv)
-                if ["parts_holdings_hrid", "principle_barcode"] != list(bw_df.columns):
+                if ["part_holdings_hrid", "principle_barcode"] != list(bw_df.columns):
                     flash(f"Invalid columns: {list(bw_df.columns)} for CSV file")
                     rendered_page = self.render_template("boundwith/index.html")
                 elif len(bw_df) > 1_000:


### PR DESCRIPTION
Fixes #1457, basically the sunid wasn't being retrieved properly because of an incorrect upstream dependency in the DAG. Also fixed the column headers check in the BW UI view.

**NOTE** See [comment](https://github.com/sul-dlss/libsys-airflow/issues/1457#issuecomment-2515582191) on the reason why we're seeing the 401 error for the item PUT with the app_libsys user.