### PR TITLE
Use regex pattern to get library name from fy_code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ omit =
     tests/*
     vendor_loads_migration/*
     libsys_airflow/plugins/folio/encumbrances/fix_encumbrances.py
-    
+    libsys_airflow/dags/*

--- a/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
@@ -67,7 +67,7 @@ with DAG(
         trigger_rule='all_done',
         op_kwargs={
             "log_file": "{{ ti.xcom_pull('run_fix_encumbrances_script') }}",
-            "library": FY_CODE,
+            "fy_code": FY_CODE,
         },
     )
 

--- a/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
@@ -66,7 +66,7 @@ with DAG(
         trigger_rule='all_done',
         op_kwargs={
             "log_file": "{{ ti.xcom_pull('run_fix_encumbrances_script') }}",
-            "library": FY_CODE,
+            "fy_code": FY_CODE,
         },
     )
 

--- a/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
@@ -67,7 +67,7 @@ with DAG(
         trigger_rule='all_done',
         op_kwargs={
             "log_file": "{{ ti.xcom_pull('run_fix_encumbrances_script') }}",
-            "library": FY_CODE,
+            "fy_code": FY_CODE,
         },
     )
 

--- a/tests/encumbrances/test_fix_encumbrances_run.py
+++ b/tests/encumbrances/test_fix_encumbrances_run.py
@@ -23,16 +23,16 @@ def mock_folio_variables(monkeypatch):
 
             case "EMAIL_ENC_SUL":
                 value = "sul@example.com"
-            
+
             case "EMAIL_ENC_LAW":
                 value = "law@example.com"
-            
+
             case "EMAIL_ENC_LANE":
                 value = "lane@example.com"
 
             case "OKAPI_URL":
                 value = "okapi-test"
-            
+
             case "FOLIO_URL":
                 value = "okapi-test"
 
@@ -87,11 +87,10 @@ def test_fix_encumbrances_email_subject():
 def test_email_to(mocker):
     mocker.patch(
         'libsys_airflow.plugins.shared.utils.send_email_with_server_name',
-        return_value = None
+        return_value=None,
     )
-    
+
     from libsys_airflow.plugins.folio.encumbrances.email import email_to
 
     to_addresses = email_to(fy_code='SUL2025')
     assert to_addresses == ['test@stanford.edu', 'sul@example.com']
-

--- a/tests/encumbrances/test_fix_encumbrances_run.py
+++ b/tests/encumbrances/test_fix_encumbrances_run.py
@@ -23,16 +23,16 @@ def mock_folio_variables(monkeypatch):
 
             case "EMAIL_ENC_SUL":
                 value = "sul@example.com"
-
+            
             case "EMAIL_ENC_LAW":
                 value = "law@example.com"
-
+            
             case "EMAIL_ENC_LANE":
                 value = "lane@example.com"
 
             case "OKAPI_URL":
                 value = "okapi-test"
-
+            
             case "FOLIO_URL":
                 value = "okapi-test"
 
@@ -87,10 +87,11 @@ def test_fix_encumbrances_email_subject():
 def test_email_to(mocker):
     mocker.patch(
         'libsys_airflow.plugins.shared.utils.send_email_with_server_name',
-        return_value=None,
+        return_value = None
     )
-
+    
     from libsys_airflow.plugins.folio.encumbrances.email import email_to
 
     to_addresses = email_to(fy_code='SUL2025')
     assert to_addresses == ['test@stanford.edu', 'sul@example.com']
+


### PR DESCRIPTION
Fixes #1469 

The email function was getting the FY_CODE (e.g. 'SUL2025') not a library string (e.g. 'sul'). This PR separates out a to_email function and implements a regex case matching class to handle matching on the FY_CODE.

Nb. Omitting Dags from Coveralls coverage, since we do not test the dags. Otherwise with this ended up being below the threshold for blacking the PR. https://github.com/sul-dlss/libsys-airflow/blob/40b1dc6ba72487d127736c8509d495ee6ad2ef01/.coveragerc