### PR TITLE
Ensure encumbrance emails always get sent

### DIFF
--- a/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
@@ -64,7 +64,7 @@ with DAG(
     send_logs = PythonOperator(
         task_id="email_fix_encumbrances_log",
         python_callable=email_log,
-        trigger_rule='all_done',
+        trigger_rule='always',
         op_kwargs={
             "log_file": "{{ ti.xcom_pull('run_fix_encumbrances_script') }}",
             "fy_code": FY_CODE,

--- a/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
@@ -63,7 +63,7 @@ with DAG(
     send_logs = PythonOperator(
         task_id="email_fix_encumbrances_log",
         python_callable=email_log,
-        trigger_rule='all_done',
+        trigger_rule='always',
         op_kwargs={
             "log_file": "{{ ti.xcom_pull('run_fix_encumbrances_script') }}",
             "fy_code": FY_CODE,

--- a/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
@@ -64,7 +64,7 @@ with DAG(
     send_logs = PythonOperator(
         task_id="email_fix_encumbrances_log",
         python_callable=email_log,
-        trigger_rule='all_done',
+        trigger_rule='always',
         op_kwargs={
             "log_file": "{{ ti.xcom_pull('run_fix_encumbrances_script') }}",
             "fy_code": FY_CODE,

--- a/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances_run.py
+++ b/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances_run.py
@@ -20,6 +20,7 @@ def fix_encumbrances_run(*args, **kwargs):
     library = kwargs.get("library", "")
     log_path = pathlib.Path(airflow) / f"fix_encumbrances/{library}-{run_id}.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
+    log = str(log_path.absolute())
 
     with log_path.open("w+", 1) as log:
         with contextlib.redirect_stdout(log):
@@ -31,6 +32,6 @@ def fix_encumbrances_run(*args, **kwargs):
                 )
             except Exception as e:
                 logger.error(f"fix_encumbrance_script failed with: {e}")
-                return str(log_path.absolute())
+                return log
 
-    return str(log_path.absolute())
+    return log

--- a/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances_run.py
+++ b/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances_run.py
@@ -20,7 +20,6 @@ def fix_encumbrances_run(*args, **kwargs):
     library = kwargs.get("library", "")
     log_path = pathlib.Path(airflow) / f"fix_encumbrances/{library}-{run_id}.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    log = str(log_path.absolute())
 
     with log_path.open("w+", 1) as log:
         with contextlib.redirect_stdout(log):
@@ -32,6 +31,6 @@ def fix_encumbrances_run(*args, **kwargs):
                 )
             except Exception as e:
                 logger.error(f"fix_encumbrance_script failed with: {e}")
-                return log
+                return str(log_path.absolute())
 
-    return log
+    return str(log_path.absolute())

--- a/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances_run.py
+++ b/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances_run.py
@@ -1,7 +1,10 @@
 import asyncio
 import contextlib
+import logging
 import pathlib
 import libsys_airflow.plugins.folio.encumbrances.fix_encumbrances as fix_encumbrances_script
+
+logger = logging.getLogger(__name__)
 
 
 def fix_encumbrances_run(*args, **kwargs):
@@ -20,10 +23,14 @@ def fix_encumbrances_run(*args, **kwargs):
 
     with log_path.open("w+", 1) as log:
         with contextlib.redirect_stdout(log):
-            asyncio.run(
-                fix_encumbrances_script.run_operation(
-                    int(choice), fiscal_year_code, tenant, username, password
+            try:
+                asyncio.run(
+                    fix_encumbrances_script.run_operation(
+                        int(choice), fiscal_year_code, tenant, username, password
+                    )
                 )
-            )
+            except Exception as e:
+                logger.error(f"fix_encumbrance_script failed with: {e}")
+                return str(log_path.absolute())
 
     return str(log_path.absolute())


### PR DESCRIPTION
`all_done` does not include failed upstream tasks, we need to use `always`.

Use a try/except black to ensure com has a return value.