### PR TITLE
Fix encumbrance script configs

### DIFF
--- a/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
@@ -64,7 +64,7 @@ with DAG(
     send_logs = PythonOperator(
         task_id="email_fix_encumbrances_log",
         python_callable=email_log,
-        trigger_rule='always',
+        trigger_rule='all_done',
         op_kwargs={
             "log_file": "{{ ti.xcom_pull('run_fix_encumbrances_script') }}",
             "fy_code": FY_CODE,

--- a/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/lane_fix_encumbrances.py
@@ -18,7 +18,7 @@ default_args = {
     "depends_on_past": False,
     "email_on_failure": True,
     "email_on_retry": False,
-    "retries": 1,
+    "retries": 0,
     "retry_delay": timedelta(minutes=1),
 }
 

--- a/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
@@ -63,7 +63,7 @@ with DAG(
     send_logs = PythonOperator(
         task_id="email_fix_encumbrances_log",
         python_callable=email_log,
-        trigger_rule='always',
+        trigger_rule='all_done',
         op_kwargs={
             "log_file": "{{ ti.xcom_pull('run_fix_encumbrances_script') }}",
             "fy_code": FY_CODE,

--- a/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/law_fix_encumbrances.py
@@ -18,7 +18,7 @@ default_args = {
     "depends_on_past": False,
     "email_on_failure": True,
     "email_on_retry": False,
-    "retries": 1,
+    "retries": 0,
     "retry_delay": timedelta(minutes=1),
 }
 

--- a/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
@@ -64,7 +64,7 @@ with DAG(
     send_logs = PythonOperator(
         task_id="email_fix_encumbrances_log",
         python_callable=email_log,
-        trigger_rule='always',
+        trigger_rule='all_done',
         op_kwargs={
             "log_file": "{{ ti.xcom_pull('run_fix_encumbrances_script') }}",
             "fy_code": FY_CODE,

--- a/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
+++ b/libsys_airflow/dags/folio_finance/sul_fix_encumbrances.py
@@ -18,7 +18,7 @@ default_args = {
     "depends_on_past": False,
     "email_on_failure": True,
     "email_on_retry": False,
-    "retries": 1,
+    "retries": 0,
     "retry_delay": timedelta(minutes=1),
 }
 

--- a/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances.py
+++ b/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances.py
@@ -58,7 +58,7 @@ def login(tenant, username, password):
     except Exception as err:
         print('Error during login:', err)
         logger.error('Error during login:', err)
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
 
 
 async def get_request_without_query(url: str) -> dict:
@@ -70,11 +70,11 @@ async def get_request_without_query(url: str) -> dict:
         else:
             print(f'Error getting record with url {url} : \n{resp.text} ')
             logger.error(f'Error getting record with url {url} : \n{resp.text} ')
-            raise SystemExit(1)
+            raise Exception("Exiting Fix Encumbrances script.")
     except Exception as err:
         print(f'Error getting record with url {url} : {err=}')
         logger.error(f'Error getting record with url {url} : {err=}')
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
 
 
 async def get_request(url: str, query: str) -> dict:
@@ -90,11 +90,11 @@ async def get_request(url: str, query: str) -> dict:
         else:
             print(f'Error getting records by {url} ?query= "{query}": \n{resp.text} ')
             logger.error(f'Error getting records by {url} ?query= "{query}": \n{resp.text} ')
-            raise SystemExit(1)
+            raise Exception("Exiting Fix Encumbrances script.")
     except Exception as err:
         print(f'Error getting records by {url}?query={query}: {err=}')
         logger.error(f'Error getting records by {url}?query={query}: {err=}')
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
 
 
 async def put_request(url: str, data):
@@ -108,12 +108,12 @@ async def put_request(url: str, data):
             return
         print(f'Error updating record {url} "{data}": {resp.text}')
         logger.error(f'Error updating record {url} "{data}": {resp.text}')
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
 
     except Exception as err:
         print(f'Error updating record {url} "{data}": {err=}')
         logger.error(f'Error updating record {url} "{data}": {err=}')
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
 
 
 async def delete_request(url: str):
@@ -125,12 +125,12 @@ async def delete_request(url: str):
             return
         print(f'Error deleting record {url}: {resp.text}')
         logger.error(f'Error deleting record {url}: {resp.text}')
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
 
     except Exception as err:
         print(f'Error deleting record {url}: {err=}')
         logger.error(f'Error deleting record {url}: {err=}')
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
 
 
 def get_fiscal_years_by_query(query) -> dict:
@@ -145,7 +145,7 @@ def get_fiscal_years_by_query(query) -> dict:
     except Exception as err:
         print(f'Error getting fiscal years with query "{query}": {err}')
         logger.error(f'Error getting fiscal years with query "{query}": {err}')
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
 
 
 def get_by_chunks(url, query, key) -> list:
@@ -185,7 +185,7 @@ def get_order_ids_by_query(query) -> list:
     except Exception as err:
         print(f'Error getting order ids with query "{query}": {err}')
         logger.error(f'Error getting order ids with query "{query}": {err}')
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
     return ids
 
 
@@ -213,7 +213,7 @@ def get_fiscal_year(fiscal_year_code) -> dict:
     if len(fiscal_years) == 0:
         print(f'Could not find fiscal year "{fiscal_year_code}".')
         logger.error(f'Could not find fiscal year "{fiscal_year_code}".')
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
     return fiscal_years[0]
 
 
@@ -267,7 +267,7 @@ async def get_budget_by_fund_id(fund_id, fiscal_year_id) -> dict:
         logger.error(
             f'Could not find budget for fund "{fund_id}" and fiscal year "{fiscal_year_id}".'
         )
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
     return budgets[0]
 
 
@@ -645,7 +645,7 @@ async def fix_order_status_and_release_encumbrances(order_id, encumbrances):
         logger.error(
             f'Error when fixing order status in encumbrances for order {order_id}:', err
         )
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
 
 
 async def fix_order_encumbrances_order_status(order_id, encumbrances):
@@ -672,7 +672,7 @@ async def fix_order_encumbrances_order_status(order_id, encumbrances):
         logger.error(
             f'Error when fixing order status in encumbrances for order {order_id}:', err
         )
-        raise SystemExit(1)
+        raise Exception("Exiting Fix Encumbrances script.")
 
 
 async def fix_encumbrance_order_status_for_closed_order(


### PR DESCRIPTION
- Raise `Exception` in Exception block instead of `SystemExit(1)`
- Go back to using `all_done` instead of `always` as the latter will kick off the task before the upstream is complete.
- Do not use any retries when task fails