### PR TITLE
Adds OCLC BookOps error to caught exceptions

### DIFF
--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -10,7 +10,7 @@ import pymarc
 from typing import List, Union, Callable
 
 from bookops_worldcat import WorldcatAccessToken, MetadataSession
-from bookops_worldcat.errors import WorldcatRequestError
+from bookops_worldcat.errors import InvalidOclcNumber, WorldcatRequestError
 
 from libsys_airflow.plugins.data_exports.marc.oclc import get_record_id
 from libsys_airflow.plugins.data_exports.marc.excluded_tags import oclc_excluded
@@ -284,7 +284,7 @@ class OCLCAPIWrapper(object):
                         successes=successful_files,
                         failures=failed_files,
                     )
-                except WorldcatRequestError as e:
+                except (InvalidOclcNumber, WorldcatRequestError) as e:
                     msg = f"Instance UUID {instance_uuid} Error: {e}"
                     logger.error(msg)
                     output['failures'].append(


### PR DESCRIPTION
Error raised in this [DAG run](https://sul-libsys-airflow-prod.stanford.edu/dags/send_oclc_records/grid?run_id=manual__2024-12-17T11%3A36%3A39.406148%2B00%3A00&execution_date=2024-12-17+11%3A36%3A39.406148%2B00%3A00&tab=logs&dag_run_id=manual__2024-12-17T11%3A36%3A39.406148%2B00%3A00&task_id=set_holdings_oclc_task)