### PR TITLE
Ignore or Fixes flake8 Linting Errors

### DIFF
--- a/libsys_airflow/plugins/data_exports/apps/data_export_upload_view.py
+++ b/libsys_airflow/plugins/data_exports/apps/data_export_upload_view.py
@@ -93,7 +93,7 @@ class DataExportUploadView(AppBuilderBaseView):
             except Exception as e:
                 flash(f"Error: {e}")
             finally:
-                return default_rendered_page(self)
+                return default_rendered_page(self)  # noqa
 
     @expose("/")
     def data_export_upload_home(self):

--- a/libsys_airflow/plugins/data_exports/marc/transforms.py
+++ b/libsys_airflow/plugins/data_exports/marc/transforms.py
@@ -3,7 +3,7 @@ import logging
 import pathlib
 
 import pymarc
-import xml.etree.ElementTree as etree
+import xml.etree.ElementTree as etree  # noqa
 
 from libsys_airflow.plugins.data_exports.marc.excluded_tags import excluded_tags
 from libsys_airflow.plugins.data_exports.marc.transformer import Transformer
@@ -133,7 +133,7 @@ def marc_clean_serialize(marc_file: str, full_dump: bool, exclude_tags: bool):
             for record in marc_records:
                 try:
                     xml_element = pymarc.record_to_xml_node(record, namespace=True)
-                    etree.fromstring(etree.tostring(xml_element))
+                    etree.fromstring(etree.tostring(xml_element))  # noqa
                     xml_writer.write(record)
 
                 except AttributeError as e:

--- a/libsys_airflow/plugins/data_exports/oclc_api.py
+++ b/libsys_airflow/plugins/data_exports/oclc_api.py
@@ -66,9 +66,9 @@ def oclc_records_operation(**kwargs) -> dict:
                 logger.info(f"No {function_name} records for {library}")
     else:
         for library, records in type_of_records.items():
-            for record in records:
+            for _record in records:
                 logger.info(
-                    f"Skipping OCLC API {function_name} record operation not in production"
+                    f"Skipping OCLC API {function_name} record operation for {library} not in production"
                 )
 
     return {"success": success, "failures": failures}

--- a/libsys_airflow/plugins/data_exports/oclc_reports.py
+++ b/libsys_airflow/plugins/data_exports/oclc_reports.py
@@ -183,7 +183,8 @@ jinja_env = Environment(
             "new-oclc-marc-errors.html": new_oclc_invalid_records,
             "oclc-payload-template.html": oclc_payload_template,
         }
-    )
+    ),
+    autoescape=True,
 )
 
 

--- a/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances.py
+++ b/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances.py
@@ -45,9 +45,7 @@ def login(tenant, username, password):
     login_headers = {'x-okapi-tenant': tenant, 'Content-Type': 'application/json'}
     data = {'username': username, 'password': password}
     try:
-        r = requests.post(
-            okapi_url + '/authn/login', headers=login_headers, json=data, timeout=15
-        )
+        r = requests.post(okapi_url + '/authn/login', headers=login_headers, json=data)
         if r.status_code != 201:
             raise_exception_for_reply(r)
         logger.info('Logged in successfully.')
@@ -91,9 +89,7 @@ async def get_request(url: str, query: str) -> dict:
             return resp.json()
         else:
             print(f'Error getting records by {url} ?query= "{query}": \n{resp.text} ')
-            logger.error(
-                f'Error getting records by {url} ?query= "{query}": \n{resp.text} '
-            )
+            logger.error(f'Error getting records by {url} ?query= "{query}": \n{resp.text} ')
             raise Exception("Exiting Fix Encumbrances script.")
     except Exception as err:
         print(f'Error getting records by {url}?query={query}: {err=}')
@@ -141,10 +137,7 @@ def get_fiscal_years_by_query(query) -> dict:
     params = {'query': query, 'offset': '0', 'limit': ITEM_MAX}
     try:
         r = requests.get(
-            okapi_url + '/finance-storage/fiscal-years',
-            headers=headers,
-            params=params,
-            timeout=15,
+            okapi_url + '/finance-storage/fiscal-years', headers=headers, params=params
         )
         if r.status_code != 200:
             raise_exception_for_reply(r)
@@ -165,7 +158,7 @@ def get_by_chunks(url, query, key) -> list:
         else:
             modified_query = query + f' AND id > {last_id} sortBy id'
         params = {'query': modified_query, 'offset': 0, 'limit': MAX_BY_CHUNK}
-        r = requests.get(url, headers=headers, params=params, timeout=15)
+        r = requests.get(url, headers=headers, params=params)
         if r.status_code != 200:
             raise_exception_for_reply(r)
         j = r.json()
@@ -400,9 +393,9 @@ async def remove_duplicate_encumbrances(open_and_closed_orders_ids, fiscal_year_
     print('Removing duplicate encumbrances...')
     futures = []
     sem = asyncio.Semaphore(MAX_ACTIVE_THREADS)
-    for _idx, order_id in enumerate(open_and_closed_orders_ids):
+    for idx, order_id in enumerate(open_and_closed_orders_ids):
         await sem.acquire()
-        # progress(_idx, len(open_and_closed_orders_ids))
+        # progress(idx, len(open_and_closed_orders_ids))
         futures.append(
             asyncio.ensure_future(
                 remove_duplicate_encumbrances_in_order(order_id, fiscal_year_id, sem)
@@ -566,9 +559,9 @@ async def fix_poline_encumbrances_relations(
         return
     orders_futures = []
     order_sem = asyncio.Semaphore(MAX_ACTIVE_THREADS)
-    for _idx, order_id in enumerate(open_orders_ids):
+    for idx, order_id in enumerate(open_orders_ids):
         await order_sem.acquire()
-        # progress(_idx, len(open_orders_ids))
+        # progress(idx, len(open_orders_ids))
         orders_futures.append(
             asyncio.ensure_future(
                 process_order_encumbrances_relations(
@@ -622,9 +615,9 @@ def build_ids_2d_array(entities) -> list:
     # prepare two-dimensional array of ids for requesting the records by ids in bulks
     ids_2d_array = []
     index = 0
-    for _row in range(ITEM_MAX):
+    for row in range(ITEM_MAX):
         inner_list = []
-        for _col in range(20):
+        for col in range(20):
             if index == len(entities):
                 break
             inner_list.append(entities[index]['id'])
@@ -704,9 +697,9 @@ async def fix_encumbrance_order_status_for_closed_orders(
     fix_encumbrance_futures = []
     max_active_order_threads = 5
     sem = asyncio.Semaphore(max_active_order_threads)
-    for _idx, order_id in enumerate(closed_orders_ids):
+    for idx, order_id in enumerate(closed_orders_ids):
         await sem.acquire()
-        # progress(_idx, len(closed_orders_ids))
+        # progress(idx, len(closed_orders_ids))
         fixed_encumbrance_future = asyncio.ensure_future(
             fix_encumbrance_order_status_for_closed_order(order_id, fiscal_year_id, sem)
         )
@@ -763,9 +756,9 @@ async def unrelease_open_orders_encumbrances_with_nonzero_amounts(
         return
     enc_futures = []
     sem = asyncio.Semaphore(MAX_ACTIVE_THREADS)
-    for _idx, order_id in enumerate(open_orders_ids):
+    for idx, order_id in enumerate(open_orders_ids):
         await sem.acquire()
-        # progress(_idx, len(open_orders_ids))
+        # progress(idx, len(open_orders_ids))
         enc_futures.append(
             asyncio.ensure_future(
                 unrelease_encumbrances_with_non_zero_amounts(
@@ -828,9 +821,9 @@ async def release_open_orders_encumbrances_with_negative_amounts(
         return
     enc_futures = []
     sem = asyncio.Semaphore(MAX_ACTIVE_THREADS)
-    for _idx, order_id in enumerate(open_orders_ids):
+    for idx, order_id in enumerate(open_orders_ids):
         await sem.acquire()
-        # progress(_idx, len(open_orders_ids))
+        # progress(idx, len(open_orders_ids))
         enc_futures.append(
             asyncio.ensure_future(
                 release_encumbrances_with_negative_amounts(
@@ -888,9 +881,9 @@ async def release_cancelled_order_line_encumbrances(fiscal_year_id, open_orders_
         return
     enc_futures = []
     sem = asyncio.Semaphore(MAX_ACTIVE_THREADS)
-    for _idx, order_id in enumerate(open_orders_ids):
+    for idx, order_id in enumerate(open_orders_ids):
         await sem.acquire()
-        # progress(_idx, len(open_orders_ids))
+        # progress(idx, len(open_orders_ids))
         enc_futures.append(
             asyncio.ensure_future(
                 release_cancelled_pol_encumbrances(order_id, fiscal_year_id, sem)
@@ -932,9 +925,9 @@ async def recalculate_budget_encumbered(open_and_closed_orders_ids, fiscal_year_
     )
     enc_future = []
     sem = asyncio.Semaphore(MAX_ACTIVE_THREADS)
-    for _idx, order_id in enumerate(open_and_closed_orders_ids):
+    for idx, order_id in enumerate(open_and_closed_orders_ids):
         await sem.acquire()
-        # progress(_idx, len(open_and_closed_orders_ids))
+        # progress(idx, len(open_and_closed_orders_ids))
         enc_future.append(
             asyncio.ensure_future(get_order_encumbrances(order_id, fiscal_year_id, sem))
         )
@@ -1000,9 +993,9 @@ async def release_unreleased_encumbrances_for_closed_orders(
     nb_released_encumbrance_futures = []
     sem = asyncio.Semaphore(MAX_ACTIVE_THREADS)
 
-    for _idx, order_id in enumerate(closed_orders_ids):
+    for idx, order_id in enumerate(closed_orders_ids):
         await sem.acquire()
-        # progress(_idx, len(closed_orders_ids))
+        # progress(idx, len(closed_orders_ids))
         nb_released_encumbrance_futures.append(
             asyncio.ensure_future(
                 release_order_encumbrances(order_id, fiscal_year_id, sem)

--- a/libsys_airflow/plugins/folio/helpers/bw.py
+++ b/libsys_airflow/plugins/folio/helpers/bw.py
@@ -53,7 +53,7 @@ def _bw_summary_body(task_instance, file_name) -> str:
     ):
         errors.append(row)
     total_success = 0
-    for row in task_instance.xcom_pull(
+    for _ in task_instance.xcom_pull(
         task_ids="new_bw_record", key="success", default=[]
     ):
         total_success += 1

--- a/libsys_airflow/plugins/orafin/emails.py
+++ b/libsys_airflow/plugins/orafin/emails.py
@@ -117,7 +117,7 @@ def _ap_report_paid_email_body(
 
 
 def _excluded_email_body(grouped_reasons: dict, folio_url: str) -> str:
-    jinja_env = Environment()
+    jinja_env = Environment()  # noqa
     jinja_env.filters["invoice_line_links"] = _invoice_line_links
 
     template = jinja_env.from_string(
@@ -149,7 +149,7 @@ def _summary_email_body(invoices: list, folio_url: str):
         return ""
 
     converter = models_converter()
-    jinja_env = Environment()
+    jinja_env = Environment(autoescape=True)
 
     template = jinja_env.from_string(
         """

--- a/libsys_airflow/plugins/vendor/download.py
+++ b/libsys_airflow/plugins/vendor/download.py
@@ -1,5 +1,5 @@
 import logging
-import ftplib
+import ftplib  # noqa
 import pathlib
 import re
 

--- a/libsys_airflow/plugins/vendor/extract.py
+++ b/libsys_airflow/plugins/vendor/extract.py
@@ -58,7 +58,7 @@ def _filter_filenames(filenames: list[str], regex: Optional[str]) -> str:
             f for f in filenames if re.compile(regex, flags=re.IGNORECASE).match(f)
         ]
     if len(filtered_filenames) != 1:
-        raise Exception(
+        raise ValueError(
             f"Expected to extract 1 file, but found {len(filtered_filenames)}"
         )
     return filtered_filenames[0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,4 @@ max-line-length = 88
 # S101 "Use of assert detected"
 # W503 "Line break before binary operator"
 extend-ignore = D,E203,E225,E501,I,S101,W503
-exclude = .git,__pycache__,circ,logs,old,vendor-data,vendor_loads_migration,digital_bookplates_migration
+exclude = .git,__pycache__,circ,logs,old,vendor-data,vendor_loads_migration,digital_bookplates_migration,libsys_airflow/plugins/folio/encumbrances/fix_encumbrances*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,12 @@ addopts = --cov=libsys_airflow --cov-report=xml --cov-report=term
 [flake8]
 # Flake8 cannot be configured via pyproject.toml  see https://pypi.org/project/Flake8-pyproject/
 max-line-length = 88
+# D Various docstring related checks
 # E203 "Whitespace before ':'" conflicts with black
 # E225 "Missing whitespace around operator"
 # E501 "Line too long"
+# I Various import related checks
+# S101 "Use of assert detected"
 # W503 "Line break before binary operator"
-extend-ignore = E203,E225,E501,W503
+extend-ignore = D,E203,E225,E501,I,S101,W503
 exclude = .git,__pycache__,circ,logs,old,vendor-data,vendor_loads_migration,digital_bookplates_migration

--- a/tests/apps/data_exports/test_data_exports_download_view.py
+++ b/tests/apps/data_exports/test_data_exports_download_view.py
@@ -16,7 +16,7 @@ def test_airflow_client():
 
     app = application.create_app(testing=True)
     app.config['WTF_CSRF_ENABLED'] = False
-    setattr(DataExportDownloadView, "files_base", files_base)
+    setattr(DataExportDownloadView, "files_base", files_base)  # noqa
     app.appbuilder.add_view(
         DataExportDownloadView, "DataExport", category="Data export"
     )

--- a/tests/apps/data_exports/test_exports_oclc_reports_view.py
+++ b/tests/apps/data_exports/test_exports_oclc_reports_view.py
@@ -16,7 +16,7 @@ def test_airflow_client():
 
     app = application.create_app(testing=True)
     app.config['WTF_CSRF_ENABLED'] = False
-    setattr(DataExportOCLCReportsView, "files_base", files_base)
+    setattr(DataExportOCLCReportsView, "files_base", files_base)  # noqa
     app.appbuilder.add_view(
         DataExportOCLCReportsView, "DataExport", category="Data export"
     )

--- a/tests/apps/digital_bookplates/test_digital_bookplates_download_view.py
+++ b/tests/apps/digital_bookplates/test_digital_bookplates_download_view.py
@@ -18,7 +18,7 @@ def test_airflow_client():
 
     app = application.create_app(testing=True)
     app.config['WTF_CSRF_ENABLED'] = False
-    setattr(DigitalBookplatesDownloadView, "files_base", files_base)
+    setattr(DigitalBookplatesDownloadView, "files_base", files_base)  # noqa
     app.appbuilder.add_view(
         DigitalBookplatesDownloadView,
         "DigitalBookplates",

--- a/tests/apps/orafin/test_orafin_files_view.py
+++ b/tests/apps/orafin/test_orafin_files_view.py
@@ -19,7 +19,7 @@ def test_airflow_client():
 
     app = application.create_app(testing=True)
     app.config['WTF_CSRF_ENABLED'] = False
-    setattr(OrafinFilesView, "files_base", files_base)
+    setattr(OrafinFilesView, "files_base", files_base)  # noqa
     app.appbuilder.add_view(OrafinFilesView, "Orafin", category="Folio")
     app.blueprints['OrafinFilesView'].template_folder = templates_folder
     app.response_class = HTMLResponse

--- a/tests/data_exports/test_full_dump_selections.py
+++ b/tests/data_exports/test_full_dump_selections.py
@@ -47,7 +47,7 @@ def mock_marc_records():
 
 @pytest.fixture
 def mock_airflow_connection():
-    return Connection(
+    return Connection(  # noqa
         conn_id="postgres-folio",
         conn_type="postgres",
         host="example.com",

--- a/tests/data_exports/test_oclc_api.py
+++ b/tests/data_exports/test_oclc_api.py
@@ -345,7 +345,7 @@ def mock_metadata_session(authorization=None, timeout=None):
     mock_session._url_manage_bibs_create = (
         lambda: 'https://metadata.api.oclc.org/worldcat'
     )
-    mock_session.authorization.token_str = "ab3565ackelas"
+    mock_session.authorization.token_str = "ab3565ackelas"  # noqa: S105
     mock_session.bib_create = mock_bib_create
     mock_session.bib_match = mock_bib_match
     mock_session.holdings_set = mock_holdings_set
@@ -514,18 +514,21 @@ def mock_oclc_api(mocker):
 
 def test_oclc_api_class_init(mock_oclc_api):
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
 
     assert oclc_api_instance.folio_client.okapi_url == "https://okapi.stanford.edu"
-    assert oclc_api_instance.oclc_token == "tk_6e302a204c2bfa4d266813cO647d62a77b10"
+    assert (
+        oclc_api_instance.oclc_token
+        == "tk_6e302a204c2bfa4d266813cO647d62a77b10"  # noqa
+    )
 
 
 def test_oclc_api_class_no_new_records(mock_oclc_api, caplog):
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -544,7 +547,7 @@ def test_oclc_api_class_new_records(tmp_path, mock_oclc_api):
         for record in [marc_record, no_srs_record]:
             marc_writer.write(record)
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -576,7 +579,7 @@ def test_oclc_api_class_updated_records(tmp_path, mock_oclc_api):
         for record in [marc_record, no_srs_record]:
             marc_writer.write(record)
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -590,7 +593,7 @@ def test_oclc_api_class_updated_records(tmp_path, mock_oclc_api):
 def test_oclc_api_failed_authentication(mock_oclc_api):
 
     with pytest.raises(Exception, match="Unable to Retrieve Worldcat Access Token"):
-        oclc_api.OCLCAPIWrapper(
+        oclc_api.OCLCAPIWrapper(  # noqa
             client_id="n0taVal1dC1i3nt", secret="c867b1dd75e6490f99d1cd1c9252ef22"
         )
 
@@ -628,10 +631,10 @@ def test_failed_oclc_new_record(tmp_path, mock_oclc_api):
 
     with marc_file.open('wb+') as fo:
         marc_writer = pymarc.MARCWriter(fo)
-        for record in [error_records[1], error_records[4], error_records[5], record]:
-            marc_writer.write(record)
+        for rec in [error_records[1], error_records[4], error_records[5], record]:
+            marc_writer.write(rec)
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -678,7 +681,7 @@ def test_failed_oclc_new_record(tmp_path, mock_oclc_api):
 
 
 def test_new_no_control_number(mock_oclc_api, tmp_path):
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -718,7 +721,7 @@ def test_new_no_control_number(mock_oclc_api, tmp_path):
 
 def test_bad_srs_put_in_new_context(tmp_path, mock_oclc_api):
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -742,7 +745,7 @@ def test_bad_srs_put_in_new_context(tmp_path, mock_oclc_api):
 
 
 def test_no_update_records(mock_oclc_api, caplog):
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -762,7 +765,7 @@ def test_already_exists_control_number(tmp_path, mock_oclc_api):
         ),
     )
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -775,7 +778,7 @@ def test_already_exists_control_number(tmp_path, mock_oclc_api):
 
 
 def test_missing_srs_record_id(mock_oclc_api, caplog):
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -822,7 +825,7 @@ def test_oclc_update_errors(mock_oclc_api, caplog, tmp_path):
         for record in missing_or_multiple_oclc_records():
             marc_writer.write(record)
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -868,7 +871,7 @@ def test_oclc_update_errors(mock_oclc_api, caplog, tmp_path):
 
 def test_failed_folio_put(mock_oclc_api, caplog):
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -888,7 +891,7 @@ def test_delete_missing_or_multiple_oclc_numbers(mock_oclc_api, tmp_path):
         for record in missing_or_multiple_oclc_records():
             marc_writer.write(record)
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -921,7 +924,7 @@ def test_delete_result_success_and_errors(mock_oclc_api, tmp_path, caplog):
         for record in [error_records[0], error_records[2], good_record]:
             marc_writer.write(record)
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -977,7 +980,7 @@ def test_match_oclc_number(mock_oclc_api, tmp_path, caplog):
         for row in [existing_record, new_record, bad_oclc_num, bad_srs_record]:
             marc_writer.write(row)
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )
@@ -1109,7 +1112,7 @@ def test_worldcat_error(mocker, mock_oclc_api, tmp_path):
         marc_writer = pymarc.MARCWriter(fo)
         marc_writer.write(bad_records()[0])
 
-    oclc_api_instance = oclc_api.OCLCAPIWrapper(
+    oclc_api_instance = oclc_api.OCLCAPIWrapper(  # noqa
         client_id="EDIoHuhLbdRvOHDjpEBtcEnBHneNtLUDiPRYtAqfTlpOThrxzUwHDUjMGEakoIJSObKpICwsmYZlmpYK",
         secret="c867b1dd75e6490f99d1cd1c9252ef22",
     )

--- a/tests/data_exports/test_save_instance_ids.py
+++ b/tests/data_exports/test_save_instance_ids.py
@@ -65,7 +65,7 @@ def test_save_ids_to_fs(tmp_path, mock_task_instance):
     assert "updates" in save_path[1]
     assert "deletes" in save_path[2]
 
-    for i, path in enumerate(save_path):
+    for _, path in enumerate(save_path):
         file = pathlib.Path(path)
         assert file.exists()
         with file.open('r') as fo:

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -105,7 +105,7 @@ def mock_httpx_connection():
 
 @pytest.fixture
 def mock_ftphook_connection():
-    return Connection(
+    return Connection(  # noqa
         conn_id="ftp-example.com",
         conn_type="ftp",
         host="ftp://www.example.com",
@@ -118,7 +118,7 @@ def mock_ftphook_connection():
 
 @pytest.fixture
 def mock_oclc_connection():
-    return Connection(
+    return Connection(  # noqa
         conn_id="http.oclc-LIB",
         conn_type="http",
         host=None,

--- a/tests/orafin/test_ap_reports.py
+++ b/tests/orafin/test_ap_reports.py
@@ -154,7 +154,7 @@ def test_extract_rows_large_file(tmp_path):
     existing_csv = orafin_reports / "xxdl_ap_payment_112820231000.csv"
     with existing_csv.open('w+') as fo:
         fo.write(f"{report[0]}\n")
-        for i in range(1200):
+        for _ in range(1200):
             fo.write(f"{report[1]}\n")
 
     assert existing_csv.exists()

--- a/tests/test_circ_rules.py
+++ b/tests/test_circ_rules.py
@@ -1,5 +1,5 @@
 import pytest
-import requests
+import httpx
 
 from pytest_mock import MockerFixture
 
@@ -125,7 +125,7 @@ def mock_requests(monkeypatch, mocker: MockerFixture):  # noqa
         get_response.json = json_func
         return get_response
 
-    monkeypatch.setattr(requests, "get", mock_get)
+    monkeypatch.setattr(httpx, "get", mock_get)
 
 
 @pytest.fixture

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -51,7 +51,7 @@ def test_connection_does_not_exist(db_session):
 
 def test_connection_already_exists(db_session):
     delete_connection("ftp-example.com-user", db_session)
-    prev_conn = Connection(
+    prev_conn = Connection(  # noqa
         conn_id="ftp-example.com",
         conn_type="ftp",
         host="prev.example.com",

--- a/tests/vendor/test_download.py
+++ b/tests/vendor/test_download.py
@@ -1,4 +1,4 @@
-import ftplib
+import ftplib  # noqa
 import pytest  # noqa
 from datetime import datetime
 from pytest_mock_resources import create_sqlite_fixture, Rows
@@ -228,9 +228,9 @@ def test_sftp_download(sftp_hook, download_path, pg_hook):
 
 
 def test_download_error(ftp_hook, download_path, pg_hook):
-    ftp_hook.retrieve_file.side_effect = Exception("Error")
+    ftp_hook.retrieve_file.side_effect = Exception("Server Error")
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="Server Error"):
         download(
             ftp_hook,
             "oclc",

--- a/tests/vendor/test_extract.py
+++ b/tests/vendor/test_extract.py
@@ -42,10 +42,10 @@ def test_extract_regex(download_path):
 
 
 def test_extract_no_file(download_path):
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         extract(pathlib.Path(download_path) / "0720230118.tar.gz", r"^.*\.EDI$")
 
 
 def test_extract_multiple_files(download_path):
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         extract(pathlib.Path(download_path) / "download.tar.gz", None)

--- a/tests/vendor/test_marc.py
+++ b/tests/vendor/test_marc.py
@@ -67,7 +67,7 @@ def test_batch(tmp_path, marc_path):
     count = 0
     with batch_path.open("rb") as fo:
         marc_reader = pymarc.MARCReader(fo)
-        for record in marc_reader:
+        for _ in marc_reader:
             count += 1
     assert count == 10
 


### PR DESCRIPTION
- Ignoring all **D** related linting errors related to missing `doctstrings` at the module, class, and function/method levels. 
- Ignoring all **I** [isort](https://pycqa.github.io/isort/) linting errors
- Ignore all S101 errors as `assert` is used extensively in our tests
- Individual fixes/ignore remaining **S** (Security)
- Remaining linting errors either ignored or fixed.  