### PR TITLE
Flag to not prompt for accepting remote server cert

### DIFF
--- a/libsys_airflow/plugins/orafin/payments.py
+++ b/libsys_airflow/plugins/orafin/payments.py
@@ -148,6 +148,7 @@ def transfer_to_orafin(feeder_file: str):
     command = [
         "scp",
         "-i /opt/airflow/vendor-keys/apserver.key",
+        "-o StrictHostKeyChecking=no",
         str(feeder_file),
         f"{server_info}/inbound/data/xxdl_ap_lib.dat",
     ]

--- a/libsys_airflow/plugins/orafin/reports.py
+++ b/libsys_airflow/plugins/orafin/reports.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 ap_server_options = [
     "-i /opt/airflow/vendor-keys/apserver.key",
+    "-o StrictHostKeyChecking=n",
 ]
 
 


### PR DESCRIPTION
Prompt was causing the DAG to fail [here](https://sul-libsys-airflow-prod.stanford.edu/dags/payments_to_orafin/grid?run_id=scheduled__2025-02-28T12%3A00%3A00%2B00%3A00&execution_date=2025-02-28+12%3A00%3A00%2B00%3A00&tab=graph&dag_run_id=scheduled__2025-02-28T12%3A00%3A00%2B00%3A00&task_id=sftp_feederfile), 