### PR TITLE
instance discoverySuppress could be null in Q CSP 8.

### DIFF
--- a/libsys_airflow/plugins/data_exports/sql/new/instances_new.sql
+++ b/libsys_airflow/plugins/data_exports/sql/new/instances_new.sql
@@ -6,4 +6,4 @@ where (jsonb->>'statusId')::uuid in (
   where jsonb->>'name' = 'Cataloged'
 )
 and jsonb->>'catalogedDate' between %(from_date)s and %(to_date)s
-and (jsonb->>'discoverySuppress')::boolean is false)
+and ((jsonb->>'discoverySuppress')::boolean is false or (jsonb->>'discoverySuppress') is null))

--- a/libsys_airflow/plugins/data_exports/sql/updates/holdings_updated_instances.sql
+++ b/libsys_airflow/plugins/data_exports/sql/updates/holdings_updated_instances.sql
@@ -5,7 +5,7 @@ where id in (
   from sul_mod_inventory_storage.holdings_record
   where jsonb->'metadata'->>'updatedDate' between %(from_date)s and %(to_date)s
 )
-and (jsonb->>'discoverySuppress')::boolean is false
+and ((jsonb->>'discoverySuppress')::boolean is false or (jsonb->>'discoverySuppress') is null)
 and jsonb->>'catalogedDate' similar to '\d{4}-\d{2}-\d{2}'
 and (jsonb->>'statusId')::uuid in (
   select id

--- a/libsys_airflow/plugins/data_exports/sql/updates/items_updated_instances.sql
+++ b/libsys_airflow/plugins/data_exports/sql/updates/items_updated_instances.sql
@@ -9,7 +9,7 @@ where id in (
     where jsonb->'metadata'->>'updatedDate' between %(from_date)s and %(to_date)s
   )
 )
-and (jsonb->>'discoverySuppress')::boolean is false
+and ((jsonb->>'discoverySuppress')::boolean is false or (jsonb->>'discoverySuppress') is null)
 and jsonb->>'catalogedDate' similar to '\d{4}-\d{2}-\d{2}'
 and (jsonb->>'statusId')::uuid in (
   select id

--- a/libsys_airflow/plugins/data_exports/sql/updates/marc_instance_updated.sql
+++ b/libsys_airflow/plugins/data_exports/sql/updates/marc_instance_updated.sql
@@ -12,4 +12,4 @@ and (jsonb->>'statusId')::uuid in (
 )
 and jsonb->'metadata'->>'updatedDate' between %(from_date)s and %(to_date)s
 and jsonb->>'catalogedDate' similar to '\d{4}-\d{2}-\d{2}'
-and (jsonb->>'discoverySuppress')::boolean is false)
+and ((jsonb->>'discoverySuppress')::boolean is false or (jsonb->>'discoverySuppress') is null))


### PR DESCRIPTION
Closes #1536 
We did this in materialized view but forgot the "regular" SQLs.