### PR TITLE
Full dump sql binding with psycopg2

### DIFF
--- a/libsys_airflow/dags/data_exports/full_dump_retrieval.py
+++ b/libsys_airflow/dags/data_exports/full_dump_retrieval.py
@@ -84,6 +84,11 @@ with DAG(
             type="string",
             description="Comma-seperated list of campus coded to include in full dump selection.",
         ),
+        "bucket": Param(
+            "marc-files",
+            type="string",
+            description="The S3 bucket to deposit the MARC records. CC0 or marc-files.",
+        ),
     },
 ) as dag:
 

--- a/libsys_airflow/dags/data_exports/full_dump_retrieval.py
+++ b/libsys_airflow/dags/data_exports/full_dump_retrieval.py
@@ -84,10 +84,10 @@ with DAG(
             type="string",
             description="Comma-seperated list of campus coded to include in full dump selection.",
         ),
-        "bucket": Param(
+        "marc_file_dir": Param(
             "marc-files",
             type="string",
-            description="The S3 bucket to deposit the MARC records. CC0 or marc-files.",
+            description="The S3 marc file path to deposit the MARC records. CC0 or marc-files.",
             enum=["marc-files", "CC0"],
         ),
     },

--- a/libsys_airflow/dags/data_exports/full_dump_retrieval.py
+++ b/libsys_airflow/dags/data_exports/full_dump_retrieval.py
@@ -63,7 +63,7 @@ with DAG(
             description="Remove excluded tags listed in marc/excluded_tags.pyfrom incoming record.",
         ),
         "from_date": Param(
-            Variable.get("EPOCH_DATE", "1885-11-11"),
+            Variable.get("FOLIO_EPOCH_DATE", "1885-11-11"),
             format="date",
             type="string",
             description="The earliest date to select record IDs from FOLIO.",

--- a/libsys_airflow/dags/data_exports/full_dump_retrieval.py
+++ b/libsys_airflow/dags/data_exports/full_dump_retrieval.py
@@ -88,6 +88,7 @@ with DAG(
             "marc-files",
             type="string",
             description="The S3 bucket to deposit the MARC records. CC0 or marc-files.",
+            enum=["marc-files", "CC0"],
         ),
     },
 ) as dag:

--- a/libsys_airflow/dags/data_exports/full_dump_retrieval.py
+++ b/libsys_airflow/dags/data_exports/full_dump_retrieval.py
@@ -63,7 +63,7 @@ with DAG(
             description="Remove excluded tags listed in marc/excluded_tags.pyfrom incoming record.",
         ),
         "from_date": Param(
-            Variable.get("FOLIO_EPOCH_DATE", "2023-08-23"),
+            Variable.get("EPOCH_DATE", "1885-11-11"),
             format="date",
             type="string",
             description="The earliest date to select record IDs from FOLIO.",

--- a/libsys_airflow/plugins/data_exports/full_dump_marc.py
+++ b/libsys_airflow/plugins/data_exports/full_dump_marc.py
@@ -134,11 +134,11 @@ def reset_s3(**kwargs) -> None:
     context = get_current_context()
     params = context.get("params", {})  # type: ignore
     reset = params.get("reset_s3", True)
-    bucket = params.get("bucket", "marc-files")
+    marc_file_dir = params.get("marc_file_dir", "marc-files")
 
     if reset:
         bucket = Variable.get("FOLIO_AWS_BUCKET", "folio-data-export-prod")
-        s3_dir = s3_bucket_path(bucket)
+        s3_dir = S3Path(f"/{bucket}/data-export-files/full-dump/{marc_file_dir}/")
         s3_files = s3_dir.glob("*.*")
         for file in s3_files:
             file.unlink()
@@ -153,10 +153,3 @@ def add_quotes(csv_string) -> str:
     values = csv_string.split(',')
     quoted_values = ["'{}'".format(v.strip()) for v in values]
     return ','.join(quoted_values)
-
-
-def s3_bucket_path(bucket) -> S3Path:
-    if bucket == "CC0":
-        return S3Path(f"/{bucket}/data-export-files/full-dump/CC0/")
-
-    return S3Path(f"/{bucket}/data-export-files/full-dump/marc-files/")

--- a/libsys_airflow/plugins/data_exports/full_dump_marc.py
+++ b/libsys_airflow/plugins/data_exports/full_dump_marc.py
@@ -148,7 +148,7 @@ def reset_s3(**kwargs) -> None:
     return None
 
 
-def add_quotes(csv_string):
+def add_quotes(csv_string) -> str:
     """Adds single quotes around each comma-separated value in a string."""
     values = csv_string.split(',')
     quoted_values = ["'{}'".format(v.strip()) for v in values]

--- a/libsys_airflow/plugins/data_exports/full_dump_marc.py
+++ b/libsys_airflow/plugins/data_exports/full_dump_marc.py
@@ -1,11 +1,12 @@
 import logging
+import psycopg2
 
 from datetime import datetime, timedelta
 from pathlib import Path
 from s3path import S3Path
 from typing import Union
 
-from airflow.models import Variable
+from airflow.models import Variable, Connection
 from airflow.operators.python import get_current_context
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from libsys_airflow.plugins.data_exports.marc.exporter import Exporter
@@ -19,41 +20,20 @@ def create_campus_filter_view(**kwargs) -> Union[str, None]:
     recreate = params.get("recreate_view", False)
     include_campus = params.get("include_campus", "SUL, LAW, GSB, HOOVER, MED")
 
-    campuses = add_quotes(include_campus)
-    # TODO: Use SQL param biding instead of inline query.
-    # query = None
-
-    query = (
-        "DROP MATERIALIZED VIEW IF EXISTS filter_campus_ids CASCADE; "  # noqa
-        "create materialized view filter_campus_ids as "
-        "select distinct(instanceid) from sul_mod_inventory_storage.holdings_record "
-        "where  permanentlocationid in ( "
-        "    select id from sul_mod_inventory_storage.location "
-        "    where campusid in ( "
-        "        select id from sul_mod_inventory_storage.loccampus "
-        f"        where jsonb->>'code' in ({campuses}) "
-        "    )"
-        ");"
-        "DROP INDEX IF EXISTS filter_full_dump_campus_idx; "
-        "CREATE UNIQUE INDEX filter_full_dump_campus_idx ON filter_campus_ids (instanceid);"
-    )
+    query = None
 
     if recreate:
+        campuses = psycopg2.extensions.AsIs(f"({add_quotes(include_campus)})")
+
         logger.info(f"Refreshing view filter with campus codes {campuses}")
+        with open(filter_campus_sql_file()) as sqv:
+            query = sqv.read()
 
-        # TODO: Use SQL param biding instead of inline query.
-        # with open(filter_campus_sql_file()) as sqv:
-        #     query = sqv.read()
-
-        SQLExecuteQueryOperator(
-            task_id="postgres_full_count_query",
-            conn_id="postgres_folio",
-            database=kwargs.get("database", "okapi"),
-            sql=query,
-            # param={
-            #     "campuses": campuses
-            # },
-        ).execute(context)
+        connection = Connection.get_connection_from_secrets("postgres_folio")
+        conn_string = f"dbname=okapi user=okapi host={connection.host} port={connection.port} password={connection.password}"
+        conn = psycopg2.connect(conn_string)
+        cur = conn.cursor()
+        cur.execute(query, {"campuses": campuses})
     else:
         logger.info("Skipping refresh of campus filter view")
 
@@ -117,7 +97,7 @@ def fetch_full_dump_marc(**kwargs) -> str:
     batch_size = kwargs.get("batch_size", 1000)
     connection = kwargs.get("connection")
     cursor = connection.cursor()  # type: ignore
-    sql = "SELECT id, hrid, content FROM public.data_export_marc ORDER BY hrid LIMIT (%s) OFFSET (%s)"
+    sql = "SELECT instanceid, hrid, content FROM public.data_export_marc ORDER BY hrid LIMIT (%s) OFFSET (%s)"
     params = (batch_size, offset)
     cursor.execute(sql, params)
     tuples = cursor.fetchall()
@@ -134,7 +114,7 @@ def fetch_full_dump_marc(**kwargs) -> str:
 def fetch_number_of_records(**kwargs) -> int:
     context = get_current_context()
 
-    query = "SELECT count(id) from public.data_export_marc"
+    query = "SELECT count(instanceid) from public.data_export_marc"
 
     result = SQLExecuteQueryOperator(
         task_id="postgres_full_count_query",
@@ -154,10 +134,11 @@ def reset_s3(**kwargs) -> None:
     context = get_current_context()
     params = context.get("params", {})  # type: ignore
     reset = params.get("reset_s3", True)
+    bucket = params.get("bucket", "marc-files")
 
     if reset:
         bucket = Variable.get("FOLIO_AWS_BUCKET", "folio-data-export-prod")
-        s3_dir = S3Path(f"/{bucket}/data-export-files/full-dump/marc-files/")
+        s3_dir = s3_bucket_path(bucket)
         s3_files = s3_dir.glob("*.*")
         for file in s3_files:
             file.unlink()
@@ -172,3 +153,10 @@ def add_quotes(csv_string):
     values = csv_string.split(',')
     quoted_values = ["'{}'".format(v.strip()) for v in values]
     return ','.join(quoted_values)
+
+
+def s3_bucket_path(bucket) -> S3Path:
+    if bucket == "CC0":
+        return S3Path(f"/{bucket}/data-export-files/full-dump/CC0/")
+
+    return S3Path(f"/{bucket}/data-export-files/full-dump/marc-files/")

--- a/libsys_airflow/plugins/data_exports/marc/exporter.py
+++ b/libsys_airflow/plugins/data_exports/marc/exporter.py
@@ -9,6 +9,7 @@ from pymarc import (
 
 from libsys_airflow.plugins.shared.folio_client import folio_client
 from airflow.models import Variable
+from airflow.operators.python import get_current_context
 from s3path import S3Path
 from typing import Union
 
@@ -183,8 +184,11 @@ class Exporter(object):
         """
         Writes marc record to a file system (local or S3)
         """
+        context = get_current_context()
+        params = context.get("params", {})  # type: ignore
+        bucket_path = params.get("bucket", "marc-files")
         marc_file_name = instance_file.stem
-        directory = marc_directory / "marc-files"
+        directory = marc_directory / bucket_path
         mode = "wb"
 
         if type(marc_directory).__name__ == 'PosixPath':

--- a/libsys_airflow/plugins/data_exports/marc/exporter.py
+++ b/libsys_airflow/plugins/data_exports/marc/exporter.py
@@ -96,9 +96,8 @@ class Exporter(object):
         self, instance_file: pathlib.Path, kind: str
     ) -> str:
         """
-        Called for each instanceid file in vendor or full-dump directory
-        For each ID row, writes and returns converted MARC from SRS
-        Writes to file system, or in case of full-dump to AWS bucket
+        Called for each instanceid file in vendor directory.
+        For each ID row, writes and returns converted MARC from SRS to file system
         """
         if not instance_file.exists():
             raise ValueError(
@@ -130,6 +129,10 @@ class Exporter(object):
         return marc_file
 
     def retrieve_marc_for_full_dump(self, marc_filename: str, instance_ids: str) -> str:
+        """
+        Called for each instanceid file in the full-dump directory
+        For each ID row, writes and returns converted MARC from SRS and writes to AWS bucket
+        """
         marc_file = ""
         bucket = Variable.get("FOLIO_AWS_BUCKET", "folio-data-export-prod")
         full_dump_files = f"/{bucket}/data-export-files/full-dump"

--- a/libsys_airflow/plugins/data_exports/marc/exporter.py
+++ b/libsys_airflow/plugins/data_exports/marc/exporter.py
@@ -186,9 +186,9 @@ class Exporter(object):
         """
         context = get_current_context()
         params = context.get("params", {})  # type: ignore
-        bucket_path = params.get("bucket", "marc-files")
+        marc_file_dir = params.get("marc_file_dir", "marc-files")
         marc_file_name = instance_file.stem
-        directory = marc_directory / bucket_path
+        directory = marc_directory / marc_file_dir
         mode = "wb"
 
         if type(marc_directory).__name__ == 'PosixPath':

--- a/libsys_airflow/plugins/data_exports/sql/materialized_view.sql
+++ b/libsys_airflow/plugins/data_exports/sql/materialized_view.sql
@@ -1,29 +1,29 @@
-DROP MATERIALIZED VIEW IF EXISTS data_export_marc
-;
+DROP MATERIALIZED VIEW IF EXISTS data_export_marc;
 create materialized view data_export_marc as
-select I.id, I.jsonb->'hrid' as hrid, M.content
-from sul_mod_inventory_storage.instance I
-inner join(
+select F.instanceid,
+I.jsonb->'hrid' as hrid,
+M.content
+from filter_campus_ids F
+inner join sul_mod_inventory_storage.instance I
+on F.instanceid = I.id
+  and I.jsonb->>'catalogedDate' between %(from_date)s and %(to_date)s
+  and I.jsonb->>'source' = 'MARC'
+  and (I.jsonb->>'statusId')::uuid in (
+    select id
+    from sul_mod_inventory_storage.instance_status
+    where jsonb->>'name' = 'Cataloged'
+  )
+  and ((I.jsonb->>'discoverySuppress')::boolean is false or (I.jsonb->>'discoverySuppress') is null)
+left join (
   select distinct on (external_id) external_id, id, generation
   from sul_mod_source_record_storage.records_lb
   order by external_id, generation desc
 ) R
 on R.external_id = I.id
-and (I.jsonb->>'statusId')::uuid in (
-    select id
-    from sul_mod_inventory_storage.instance_status
-    where jsonb->>'name' = 'Cataloged'
-  )
-  and I.jsonb->>'catalogedDate' between %(from_date)s and %(to_date)s
-  and ((I.jsonb->>'discoverySuppress')::boolean is false or (I.jsonb->>'discoverySuppress') is null)
-  and I.jsonb->>'source' = 'MARC'
-join sul_mod_source_record_storage.marc_records_lb M
+left join sul_mod_source_record_storage.marc_records_lb M
   on M.id = R.id
-right join filter_campus_ids F
-  on  I.id = F.instanceid
-order by I.jsonb->'hrid'
-;
+order by I.jsonb->'hrid';
 DROP INDEX IF EXISTS data_export_marc_ids;
 DROP INDEX IF EXISTS data_export_marc_hrids;
-CREATE UNIQUE INDEX data_export_marc_ids ON data_export_marc (id);
+CREATE UNIQUE INDEX data_export_marc_ids ON data_export_marc (instanceid);
 CREATE UNIQUE INDEX data_export_marc_hrids ON data_export_marc (hrid);

--- a/tests/data_exports/test_full_dump_selections.py
+++ b/tests/data_exports/test_full_dump_selections.py
@@ -170,11 +170,16 @@ def mock_get_current_context_no_recreate(monkeypatch, mocker):
             "recreate_view": False,
             "from_date": "2023-09-01",
             "to_date": "2025-02-01",
+            "bucket": "marc-files",
         }
         return context
 
     monkeypatch.setattr(
         'libsys_airflow.plugins.data_exports.full_dump_marc.get_current_context',
+        _context,
+    )
+    monkeypatch.setattr(
+        'libsys_airflow.plugins.data_exports.marc.exporter.get_current_context',
         _context,
     )
 
@@ -220,7 +225,7 @@ def setup_recreate_tests(mocker, mock_airflow_connection):
     )
 
 
-def test_fetch_full_dump(tmp_path, mocker, mock_airflow_connection, caplog):
+def test_fetch_full_dump(tmp_path, mocker, mock_get_current_context_no_recreate, mock_airflow_connection, caplog):
     mocker.patch.object(exporter, "S3Path")
     mocker.patch('libsys_airflow.plugins.data_exports.marc.exporter.folio_client')
     mocker.patch(

--- a/tests/data_exports/test_full_dump_selections.py
+++ b/tests/data_exports/test_full_dump_selections.py
@@ -170,7 +170,7 @@ def mock_get_current_context_no_recreate(monkeypatch, mocker):
             "recreate_view": False,
             "from_date": "2023-09-01",
             "to_date": "2025-02-01",
-            "bucket": "marc-files",
+            "marc_file_dir": "marc-files",
         }
         return context
 

--- a/tests/data_exports/test_full_dump_selections.py
+++ b/tests/data_exports/test_full_dump_selections.py
@@ -16,6 +16,20 @@ class MockSQLExecuteQueryOperator(pydantic.BaseModel):
         return None
 
 
+class MockPsycopg2Cursor(pydantic.BaseModel):
+    def fetchall(self):
+        return [()]
+
+    def execute(self, sql_stmt, params):
+        self
+
+
+class MockPsycopg2Connection(pydantic.BaseModel):
+
+    def cursor(self):
+        return MockPsycopg2Cursor()
+
+
 class MockCursor(pydantic.BaseModel):
     batch_size: int = 0
     offset: int = 0
@@ -32,19 +46,6 @@ class MockConnection(pydantic.BaseModel):
 
     def cursor(self):
         return MockCursor()
-
-
-class MockPool(pydantic.BaseModel):
-    connection: MockConnection = MockConnection()
-
-    def pool(self):
-        return self
-
-    def getconn(self):
-        return self.connection
-
-    def putconn(self, connection):
-        return None
 
 
 def mock_number_of_records(mock_result_set):
@@ -206,6 +207,10 @@ def setup_recreate_tests(mocker, mock_airflow_connection):
         return_value=MockSQLExecuteQueryOperator(),
     )
     mocker.patch(
+        'libsys_airflow.plugins.data_exports.full_dump_marc.psycopg2.connect',
+        return_value=MockPsycopg2Connection(),
+    )
+    mocker.patch(
         'libsys_airflow.plugins.data_exports.full_dump_marc.materialized_view_sql_file',
         return_value='libsys_airflow/plugins/data_exports/sql/materialized_view.sql',
     )
@@ -239,7 +244,9 @@ def test_no_recreate_filter_campus_ids(
 ):
     setup_recreate_tests(mocker, mock_airflow_connection)
 
-    query = full_dump_marc.create_campus_filter_view()
+    query = full_dump_marc.create_campus_filter_view(
+        connection=MockPsycopg2Connection()
+    )
 
     if query is None:
         assert True
@@ -279,9 +286,11 @@ def test_recreate_campus_filter_view(
 ):
     setup_recreate_tests(mocker, mock_airflow_connection)
 
-    query = full_dump_marc.create_campus_filter_view()
+    query = full_dump_marc.create_campus_filter_view(
+        connection=MockPsycopg2Connection()
+    )
 
     assert query.startswith("DROP MATERIALIZED VIEW IF EXISTS filter_campus_ids")
     assert (
-        "Refreshing view filter with campus codes 'SUL','LAW','HOOVER'" in caplog.text
+        "Refreshing view filter with campus codes ('SUL','LAW','HOOVER')" in caplog.text
     )

--- a/tests/data_exports/test_full_dump_selections.py
+++ b/tests/data_exports/test_full_dump_selections.py
@@ -225,7 +225,13 @@ def setup_recreate_tests(mocker, mock_airflow_connection):
     )
 
 
-def test_fetch_full_dump(tmp_path, mocker, mock_get_current_context_no_recreate, mock_airflow_connection, caplog):
+def test_fetch_full_dump(
+    tmp_path,
+    mocker,
+    mock_get_current_context_no_recreate,
+    mock_airflow_connection,
+    caplog,
+):
     mocker.patch.object(exporter, "S3Path")
     mocker.patch('libsys_airflow.plugins.data_exports.marc.exporter.folio_client')
     mocker.patch(

--- a/tests/data_exports/test_marc_exports.py
+++ b/tests/data_exports/test_marc_exports.py
@@ -113,6 +113,21 @@ def mock_folio_404():
     return mock_404_client
 
 
+@pytest.fixture
+def mock_get_current_context(monkeypatch, mocker):
+    def _context():
+        context = mocker.stub(name="context")
+        context.get = lambda *args: {
+            "bucket": "marc-files",
+        }
+        return context
+
+    monkeypatch.setattr(
+        'libsys_airflow.plugins.data_exports.marc.exporter.get_current_context',
+        _context,
+    )
+
+
 def setup_test_file_updates(tmp_path):
     instance_file = (
         tmp_path / "data-export-files/pod/instanceids/updates/202402271159.csv"
@@ -147,7 +162,9 @@ def setup_test_file_deletes(tmp_path):
     return instance_file
 
 
-def test_retrieve_marc_for_instances(mocker, mock_folio_client, tmp_path):
+def test_retrieve_marc_for_instances(
+    mocker, mock_folio_client, mock_get_current_context, tmp_path
+):
     mocker.patch(
         'libsys_airflow.plugins.data_exports.marc.exporter.folio_client',
         return_value=mock_folio_client,
@@ -184,7 +201,9 @@ def test_retrieve_marc_for_instance_404(mocker, mock_folio_404, tmp_path, caplog
     assert "response code 404" in caplog.text
 
 
-def test_marc_for_instances(mocker, tmp_path, mock_folio_client):
+def test_marc_for_instances(
+    mocker, tmp_path, mock_folio_client, mock_get_current_context
+):
     update_file_path = setup_test_file_updates(tmp_path)
     delete_file_path = setup_test_file_deletes(tmp_path)
 


### PR DESCRIPTION
- Adds param for s3 bucket path (Marc-files or CC0)
- Use psycopg2 connection to create materialized view of campus ids in order to correctly bind params
- Adjust sql and subsequent queries for materialized views
- remove unnecessary test class