### PR TITLE
Ensure that Variable is an int

### DIFF
--- a/libsys_airflow/plugins/vendor/marc.py
+++ b/libsys_airflow/plugins/vendor/marc.py
@@ -171,8 +171,7 @@ def batch_task(download_path: str, filename: str) -> list[str]:
         logger.info(f"Skipping batching {filename}")
         return [filename]
     max_records = Variable.get("MAX_ENTITIES", 500)
-    if not isinstance(max_records, int):
-        max_records = int(max_records)
+    max_records = int(max_records)
     return batch(download_path, filename, max_records)
 
 

--- a/libsys_airflow/plugins/vendor/marc.py
+++ b/libsys_airflow/plugins/vendor/marc.py
@@ -171,6 +171,8 @@ def batch_task(download_path: str, filename: str) -> list[str]:
         logger.info(f"Skipping batching {filename}")
         return [filename]
     max_records = Variable.get("MAX_ENTITIES", 500)
+    if not isinstance(max_records, int):
+        max_records = int(max_records)
     return batch(download_path, filename, max_records)
 
 


### PR DESCRIPTION
When `MAX_ENTITIES` is set in the UI it is coming through as a string instead of a int causing the batch function to not batch correctly. 