### PR TITLE
Fix TypeError Warning in logs

### DIFF
--- a/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances_master.py
+++ b/libsys_airflow/plugins/folio/encumbrances/fix_encumbrances_master.py
@@ -240,7 +240,7 @@ async def get_ids_of_orders_with_status(status: str) -> list:
     query = f'workflowStatus=="{status}"'
     orders_ids = await get_order_ids_by_query(query)
     print(f'  {status} orders:', len(orders_ids))
-    logger.info(f'  {status} orders:', len(orders_ids))
+    logger.info(f'  {status} orders: {len(orders_ids)}')
     return orders_ids
 
 


### PR DESCRIPTION
Fixes #1553

```
>>> status='Open'
>>> orders_ids=[1, 2, 3, 4]
>>> import logging
>>> logger = logging.getLogger(__name__)
>>> logging.basicConfig(level=logging.INFO)
>>> logger.info(f'  {status} orders:', len(orders_ids))

--- Logging error ---
Traceback (most recent call last):
...  
File "/opt/homebrew/Cellar/python@3.13/3.13.4/Frameworks/Python.framework/Versions/3.13/lib/python3.13/logging/__init__.py", line 400, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
...
Message: '  Open orders:'
Arguments: (4,)

>>> logger.info(f'  {status} orders: {len(orders_ids)}')
INFO:__main__:  Open orders: 4
```