### PR TITLE
Authority Loading DAG and Helper Fixes

### DIFF
--- a/tests/authority_control/test_authority_helpers.py
+++ b/tests/authority_control/test_authority_helpers.py
@@ -36,9 +36,9 @@ def test_create_batches(tmp_path):
 
     batches = create_batches(str(authority_marc_file), airflow=str(tmp_path))
 
-    assert len(batches) == 2
-    assert (tmp_path / "authorities/batch_1.mrc").exists()
-    assert (tmp_path / "authorities/batch_2.mrc").exists()
+    assert len(batches) == 3
+    assert (tmp_path / "authorities/authority_1.mrc").exists()
+    assert (tmp_path / "authorities/authority_2.mrc").exists()
 
 
 def test_trigger_load_record_dag(mocker):


### PR DESCRIPTION
Fixes bugs discovered during initial Authority file run. Batch size was hard-coded to 50k, now uses `MAX_ENTITIES` used for VMA loads with a default value 20k. Also, removed `clean_up_dag` task as the [folio_data_import](https://github.com/FOLIO-FSE/folio_data_import/blob/bbfd00e783a088b716629233b1df411e6783b9fa/src/folio_data_import/MARCDataImport.py#L499-L507) now does this as part of its processing.