### PR TITLE
Changes name of var for batching auth records

### DIFF
--- a/libsys_airflow/plugins/authority_control/helpers.py
+++ b/libsys_airflow/plugins/authority_control/helpers.py
@@ -32,7 +32,7 @@ def create_batches(marc21_file: str, airflow: str = '/opt/airflow/') -> list:
     batch_dir = pathlib.Path(airflow) / "authorities"
     batch_dir.mkdir(parents=True, exist_ok=True)
 
-    batch_size = int(Variable.get("MAX_ENTITIES", 20_000))
+    batch_size = int(Variable.get("AUTH_MAX_ENTITIES", 10_000))
     batches = []
     with open(marc21_file_path, "rb") as marc_file:
         reader = pymarc.MARCReader(marc_file)

--- a/tests/authority_control/test_authority_helpers.py
+++ b/tests/authority_control/test_authority_helpers.py
@@ -36,7 +36,7 @@ def test_create_batches(tmp_path):
 
     batches = create_batches(str(authority_marc_file), airflow=str(tmp_path))
 
-    assert len(batches) == 3
+    assert len(batches) == 6
     assert (tmp_path / "authorities/authority_1.mrc").exists()
     assert (tmp_path / "authorities/authority_2.mrc").exists()
 


### PR DESCRIPTION
Would help reduce problems remembering to change `MAX_ENTITIES` var back to 500 after running an authorities load. 