### PR TITLE
Ignore encoding errors when opening edi files to email

### DIFF
--- a/libsys_airflow/plugins/vendor/edi.py
+++ b/libsys_airflow/plugins/vendor/edi.py
@@ -3,6 +3,6 @@ import re
 
 
 def invoice_count(edit_path: pathlib.Path) -> int:
-    with edit_path.open("r") as fo:
+    with edit_path.open("r", errors="ignore") as fo:
         text = fo.read()
         return len(re.findall(r"BGM\+380", text))


### PR DESCRIPTION
Fixes #1474 

Since the exact encoding of all of the characters in the files may not  be known or some characters might be unrepresentable in the encoding, we can use error handling during decoding.