### PR TITLE
Use binary mode to calculate file size using FTP

### DIFF
--- a/libsys_airflow/plugins/vendor/download.py
+++ b/libsys_airflow/plugins/vendor/download.py
@@ -44,6 +44,7 @@ class FTPAdapter:
 
     def get_size(self, filename: str) -> int | None:
         try:
+            self.hook.conn.sendcmd("TYPE I")  # type: ignore
             file_size = self.hook.get_size(filename)
         except ftplib.error_perm as e:
             logger.error(f"Failed to retrieve size for {filename}, {e}")


### PR DESCRIPTION
Fixes #1614, FYI, "TYPE I" stands for images which are binary files.