### PR TITLE
Enables ssh agent and keys when running cap tasks

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,6 +6,7 @@ set :user, 'libsys'
 set :venv, '/home/libsys/virtual-env/bin/activate'
 set :migration, 'https://github.com/sul-dlss/folio_migration.git'
 set :alembic_dbs, ['vma', 'digital_bookplates']
+set :ssh_options, { :forward_agent => true }
 
 def alembic_dbs
   ENV['ALEMBIC_DBS']&.gsub(/\s/, '')&.split(',') || fetch(:alembic_dbs)


### PR DESCRIPTION
Once the auth_key is added to the target server this change will allow the deploy tasks to use ssh to run the (non-github) deploy tasks.

in puppet for the target server:
```
profile::app::user:
  libsys:
    auth_keys:
      libsys@sul-libsys-deploy:
        type:
          'ssh-rsa'
        key:
          'AAAAB3N...'
```