### PR TITLE
Adjust time range for Backstage selection DAG

### DIFF
--- a/libsys_airflow/dags/data_exports/backstage_selections.py
+++ b/libsys_airflow/dags/data_exports/backstage_selections.py
@@ -41,7 +41,7 @@ with DAG(
     tags=["data export", "backstage"],
     params={
         "from_date": Param(
-            f"{(datetime.now() - timedelta(8)).strftime('%Y-%m-%d')}",
+            f"{(datetime.now() - timedelta(6)).strftime('%Y-%m-%d')}",
             format="date",
             type="string",
             description="The earliest date to select record IDs from FOLIO.",


### PR DESCRIPTION
From testing on stage, desired time frame for the selection is 10/24/2025 to 10/30/2025 which works out to be six.