### PR TITLE
VendorFile status field to the Sent to Data Import HTML table

### DIFF
--- a/libsys_airflow/plugins/vendor_app/templates/vendors/interface.html
+++ b/libsys_airflow/plugins/vendor_app/templates/vendors/interface.html
@@ -164,8 +164,8 @@
         <th>Filename</th>
         <th>File Size</th>
         <th>File Timestamp</th>
-        <th>Status</th>
         <th>Loaded</th>
+        <th>Status</th>
         <th data-sortable="false">Actions</th>
       </thead>
       <tbody>
@@ -177,8 +177,8 @@
           <td>{{ file.vendor_filename }} {{ _macros.fileDownload(file) }}</td>
           <td>{{ file.filesize }}</td>
           <td>{{ file.vendor_timestamp }}</td>
-          <td>{{ file.status.value }}</td>
           <td>{{ file.loaded_timestamp }}</td>
+          <td>{{ file.status.value }}</td>
           <td>
             {% if interface.assigned_in_folio or interface.upload_only %}
             <form action="{{ url_for('VendorManagementView.load_file', file_id=file.id, redirect_url=request.url) }}" method="POST">


### PR DESCRIPTION
fixes #1482 

From comment on ticket, moved *Status* to second to last like this:
<img width="1608" height="964" alt="Screenshot 2025-11-17 at 8 22 43 AM" src="https://github.com/user-attachments/assets/91fcf02c-f486-40e3-8cad-7461328b8d1b" />
