### PR TITLE
The Boolean multiple attribute, if set, means the form control accepts more than one value

### DIFF
--- a/libsys_airflow/plugins/data_exports/templates/data-export-upload/index.html
+++ b/libsys_airflow/plugins/data_exports/templates/data-export-upload/index.html
@@ -89,7 +89,7 @@ function toggleRecordTypes() {
           <p class="help-block">
             Enter an email to receive upload confirmation:
           </p>
-          <input type="email" class="form-control" id="user_email" name="user_email">
+          <input type="email" class="form-control" id="user_email" name="user_email" multiple>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The form validation only allowed a single email. Added the `multiple` attribute.