### PR TITLE
Sends email when data exports have no files to transmit.

### DIFF
--- a/libsys_airflow/dags/data_exports/backstage_transmission.py
+++ b/libsys_airflow/dags/data_exports/backstage_transmission.py
@@ -8,12 +8,14 @@ from airflow.timetables.interval import CronDataIntervalTimetable
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
     gather_files_task,
+    check_file_list_task,
     transmit_data_ftp_task,
     archive_transmitted_data_task,
 )
 
 from libsys_airflow.plugins.data_exports.email import (
     failed_transmission_email,
+    no_files_email,
 )
 
 logger = logging.getLogger(__name__)
@@ -45,13 +47,19 @@ def send_backstage_records():
 
     gather_files = gather_files_task(vendor="backstage")
 
+    check_file_list = check_file_list_task(gather_files["file_list"])
+
+    no_files_found_email = no_files_email()
+
     transmit_data = transmit_data_ftp_task("backstage", gather_files)
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 
     email_failures = failed_transmission_email(transmit_data["failures"])
 
-    start >> gather_files >> transmit_data >> [archive_data, email_failures] >> end
+    start >> gather_files >> check_file_list >> [transmit_data, no_files_found_email]
+    no_files_found_email >> end
+    transmit_data >> [archive_data, email_failures] >> end
 
 
 send_backstage_records()

--- a/libsys_airflow/dags/data_exports/gobi_transmission.py
+++ b/libsys_airflow/dags/data_exports/gobi_transmission.py
@@ -8,12 +8,14 @@ from airflow.timetables.interval import CronDataIntervalTimetable
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
     gather_files_task,
+    check_file_list_task,
     transmit_data_ftp_task,
     archive_transmitted_data_task,
 )
 
 from libsys_airflow.plugins.data_exports.email import (
     failed_transmission_email,
+    no_files_email,
 )
 
 logger = logging.getLogger(__name__)
@@ -45,13 +47,19 @@ def send_gobi_records():
 
     gather_files = gather_files_task(vendor="gobi")
 
+    check_file_list = check_file_list_task(gather_files["file_list"])
+
+    no_files_found_email = no_files_email()
+
     transmit_data = transmit_data_ftp_task("gobi", gather_files)
 
     archive_data = archive_transmitted_data_task(transmit_data['success'])
 
     email_failures = failed_transmission_email(transmit_data["failures"])
 
-    start >> gather_files >> transmit_data >> [archive_data, email_failures] >> end
+    start >> gather_files >> check_file_list >> [transmit_data, no_files_found_email]
+    no_files_found_email >> end
+    transmit_data >> [archive_data, email_failures] >> end
 
 
 send_gobi_records()

--- a/libsys_airflow/dags/data_exports/pod_transmission.py
+++ b/libsys_airflow/dags/data_exports/pod_transmission.py
@@ -8,12 +8,14 @@ from airflow.timetables.interval import CronDataIntervalTimetable
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
     gather_files_task,
+    check_file_list_task,
     transmit_data_http_task,
     archive_transmitted_data_task,
 )
 
 from libsys_airflow.plugins.data_exports.email import (
     failed_transmission_email,
+    no_files_email,
 )
 
 logger = logging.getLogger(__name__)
@@ -44,6 +46,10 @@ def send_pod_records():
 
     gather_files = gather_files_task(vendor="pod")
 
+    check_file_list = check_file_list_task(gather_files["file_list"])
+
+    no_files_found_email = no_files_email()
+
     transmit_data = transmit_data_http_task(
         gather_files,
         params={"vendor": "pod"},
@@ -54,7 +60,9 @@ def send_pod_records():
 
     email_failures = failed_transmission_email(transmit_data["failures"])
 
-    start >> gather_files >> transmit_data >> [archive_data, email_failures] >> end
+    start >> gather_files >> check_file_list >> [transmit_data, no_files_found_email]
+    no_files_found_email >> end
+    transmit_data >> [archive_data, email_failures] >> end
 
 
 send_pod_records()

--- a/libsys_airflow/plugins/data_exports/email.py
+++ b/libsys_airflow/plugins/data_exports/email.py
@@ -180,6 +180,48 @@ def generate_multiple_oclc_identifiers_email(**kwargs):
         )
 
 
+def _no_files_email_body(dag_id: str, dag_run_id: str, dag_run_url: str):
+    template = Template(
+        """
+        <h2>No Files Found to Transmit for {{ dag_id }}</h2>
+        <p><a href="{{ dag_run_url }}">{{ dag_run_id }}</a>
+    """
+    )
+
+    return template.render(
+        dag_id=dag_id,
+        dag_run_id=dag_run_id,
+        dag_run_url=dag_run_url,
+    )
+
+
+@task
+def no_files_email(**kwargs):
+    """
+    Generates email for failing to find vendor files to export
+    """
+    dag_run = kwargs["dag_run"]
+    dag_run_id = dag_run.run_id
+    dag_id = dag_run.dag.dag_id
+
+    run_url = dag_run_url(dag_run=dag_run)
+    logger.info("Generating email of no files found to transmit")
+    devs_to_email_addr = Variable.get("EMAIL_DEVS")
+    html_content = _no_files_email_body(
+        dag_id,
+        dag_run_id,
+        run_url,
+    )
+
+    send_email_with_server_name(
+        to=[
+            devs_to_email_addr,
+        ],
+        subject=f"No Files Found to Transmit for {dag_id}",
+        html_content=html_content,
+    )
+
+
 def _failed_transmission_email_body(
     files: list, vendor: str, dag_id: str, dag_run_id: str, dag_run_url: str
 ):

--- a/libsys_airflow/plugins/data_exports/transmission_tasks.py
+++ b/libsys_airflow/plugins/data_exports/transmission_tasks.py
@@ -53,6 +53,14 @@ def gather_files_task(**kwargs) -> dict:
     }
 
 
+@task.branch(task_id="check_file_list")
+def check_file_list_task(file_list: list):
+    if len(file_list) < 1:
+        return "no_files_email"
+    else:
+        return "transmit_data_ftp_task"
+
+
 @task
 def retry_failed_files_task(**kwargs) -> dict:
     """

--- a/tests/data_exports/test_data_exports_emails.py
+++ b/tests/data_exports/test_data_exports_emails.py
@@ -8,6 +8,7 @@ from libsys_airflow.plugins.data_exports.email import (
     generate_multiple_oclc_identifiers_email,
     generate_oclc_new_marc_errors_email,
     generate_missing_marc_email,
+    no_files_email,
     failed_transmission_email,
     send_confirmation_email,
 )
@@ -170,6 +171,33 @@ def test_prod_oclc_email(mocker, mock_folio_variables):
         "hoover@example.com",
         "test@stanford.edu",
     ]
+
+
+def test_no_files_email(mocker, mock_dag_run, mock_folio_variables, caplog):
+    mock_send_email = mocker.patch(
+        "libsys_airflow.plugins.data_exports.email.send_email_with_server_name"
+    )
+
+    no_files_email.function(dag_run=mock_dag_run)
+    assert "Generating email of no files found to transmit" in caplog.text
+    assert mock_send_email.called
+    assert (
+        mock_send_email.call_args[1]["subject"]
+        == "No Files Found to Transmit for send_vendor_records"
+    )
+
+    html_body = BeautifulSoup(
+        mock_send_email.call_args[1]["html_content"], "html.parser"
+    )
+    assert (
+        html_body.find("h2").text
+        == "No Files Found to Transmit for send_vendor_records"
+    )
+    assert html_body.find("a").text == "manual_2022-03-05"
+    assert (
+        html_body.find("a").attrs["href"]
+        == "http://localhost:8080/dags/send_vendor_records/grid?dag_run_id=manual_2022-03-05"
+    )
 
 
 def test_no_failed_transmission_email(mock_dag_run, caplog):

--- a/tests/data_exports/test_transmission_tasks.py
+++ b/tests/data_exports/test_transmission_tasks.py
@@ -13,6 +13,7 @@ import libsys_airflow.plugins.data_exports.transmission_tasks as transmission_ta
 
 from libsys_airflow.plugins.data_exports.transmission_tasks import (
     gather_files_task,
+    check_file_list_task,
     retry_failed_files_task,
     transmit_data_http_task,
     transmit_data_ftp_task,
@@ -174,6 +175,18 @@ def test_gather_gobi_files(tmp_path, mock_vendor_marc_files):
     marc_files = gather_files_task.function(airflow=airflow, vendor="gobi")
     assert marc_files["file_list"][0] == mock_vendor_marc_files["file_list"][-1]
     assert len(marc_files["file_list"]) == 1
+
+
+def test_check_no_file_list_task():
+    marcfile_list = []
+    branch = check_file_list_task.function(marcfile_list)
+    assert branch == "no_files_email"
+
+
+def test_check_file_list_task():
+    marcfile_list = ["airflow/data-export-files/some-vendor/updates/123.mrc"]
+    branch = check_file_list_task.function(marcfile_list)
+    assert branch == "transmit_data_ftp_task"
 
 
 def test_retry_failed_files_task(mock_marc_files, caplog):


### PR DESCRIPTION
Closes #1167 

The OCLC exports is more complex and I'm not sure of the kind of reporting we would want for it. @ahafele maybe add a new, detailed ticket if there is some reporting you want for OCLC when there are no files to send.

Example dag run when no files found:
<img width="1041" height="355" alt="Screenshot 2025-12-02 at 11 39 40 AM" src="https://github.com/user-attachments/assets/33d93d36-fa1b-4d7b-9698-68355e65e2c4" />
N.B. the send email task fails b/c this screenshot is from running on localhost.