### PR TITLE
Puts back binary mode for get_size

### DIFF
--- a/libsys_airflow/plugins/vendor/download.py
+++ b/libsys_airflow/plugins/vendor/download.py
@@ -193,7 +193,7 @@ def filter_by_mod_date(
             result["filtered_files"].append(filename)
         else:
             file_size = adapter.get_size(filename)
-            result["skipped"].append((filename, file_size, mod_time))
+            result["skipped"].append((filename, file_size, mod_time.isoformat()))
 
     return result
 

--- a/tests/vendor/test_download.py
+++ b/tests/vendor/test_download.py
@@ -229,7 +229,7 @@ def test_filter_by_mod_date(mock_hook, pg_hook, mocker, caplog):
     assert filtered_by_timestamp["skipped"].pop() == (
         "3820230413.mrc",
         678,
-        datetime.fromisoformat("2013-01-01T00:05:23"),
+        "2013-01-01T00:05:23",
     )
 
 


### PR DESCRIPTION
Closes #1680 

As part of the download tasks refactoring, I had moved the sendcmd TYPE I to when the adapter is instantiated. This didn't work.

The underlying python library ftplib is used by the airflow FTPHook. When we instantiate a FTPHook with our FTPAdapter class, we create a FTP object. When we do a get_size on the FTPAdapter -> FTPHook -> ftplib.FTP.size it is doing: https://github.com/python/cpython/blob/378b24b54e2d0690c165b1ae52af366419dadb4d/Lib/ftplib.py#L621C3-L627C26 . According to [RFC-3659](https://www.rfc-editor.org/rfc/rfc3659.html#section-4.1) an error response of 550 could mean:

> Where the command is correctly parsed but the size is not available,
   perhaps because the pathname identifies no existing entity or because
   the entity named cannot be transferred in the current MODE and TYPE
   (or at all), then a 550 reply should be sent.  Where the command
   cannot be correctly parsed, a 500 or 501 reply should be sent, as
   specified in [[3](https://www.rfc-editor.org/rfc/rfc3659.html#ref-3)].  The presence of the 550 error response to a SIZE
   command MUST NOT be taken by the client as an indication that the
   file cannot be transferred in the current MODE and TYPE.  A server
   may generate this error for other reasons -- for instance if the
   processing overhead is considered too great.  Various 4xy replies are
   also possible in appropriate circumstances.

The fact that we got a 550 response when trying to get size for `out/out/BIB20251206.MRC` (does not exist) AND trying to get size for `out/BIB20251206.MRC` (does exist) to me means that we need to send TYPE I command every time before we get the size and doing it when instantiating the adapter is not enough. [According to the RFC](https://www.rfc-editor.org/rfc/rfc3659.html#section-7.5.7), we could use the MLST command instead if we do not need precise size. Looking at the airflow hook source code, it doesn't look like MLST command is used in any of the hook's functions https://airflow.apache.org/docs/apache-airflow-providers-ftp/stable/_modules/airflow/providers/ftp/hooks/ftp.html. Alternatively, we could use ftplib's [mlsd function](https://github.com/python/cpython/blob/378b24b54e2d0690c165b1ae52af366419dadb4d/Lib/ftplib.py#L565C9-L591) but we probably don't want to refactor FTPAdapter to be a subclass of FTP and not airflow's FTPHook. It's just easier to do a sendcmd before trying hook.get_size.
