### PR TITLE
Changes default value for remote_path param.

### DIFF
--- a/libsys_airflow/dags/vendor/data_fetcher.py
+++ b/libsys_airflow/dags/vendor/data_fetcher.py
@@ -56,7 +56,7 @@ with DAG(
         "dataload_profile_uuid": Param(
             None, type=["null", "string"]
         ),  # f4144dbd-def7-4b77-842a-954c62faf319
-        "remote_path": Param(None, type=["null", "string"]),  # 'oclc'
+        "remote_path": Param("", type="string"),  # 'oclc'
         "filename_regex": Param(
             None, type=["null", "string"]
         ),  # '^\d+\.mrc$' or CNT-ORD for special Gobi file filtering.


### PR DESCRIPTION
Closes #1684 
When a vendor sync occurs, the vendor interface is created with remote_path None:
https://github.com/sul-dlss/libsys-airflow/blob/13e05ec4094c0eebcb0b7de99ba9ca49fb0f294a/libsys_airflow/plugins/vendor/sync.py#L139-L141
The VendorInterface model has remote_path as nullable, so remote_path ends up as None:
https://github.com/sul-dlss/libsys-airflow/blob/13e05ec4094c0eebcb0b7de99ba9ca49fb0f294a/libsys_airflow/plugins/vendor/models.py#L88
The remote_path is added to VMA when a user edits the vendor interface. At that point, it goes from None to "" or some string:
https://github.com/sul-dlss/libsys-airflow/blob/13e05ec4094c0eebcb0b7de99ba9ca49fb0f294a/libsys_airflow/plugins/vendor_app/vendor_management.py#L194-L195
If you don't edit the vendor interface and just run the data fetcher dag, it'll pass None as remote_path and fail. To prevent this scenario, we set the default value for remote_path in the params to an empty string. This will keep the dag from failing with the error `TypeError: can only concatenate str (not "NoneType") to str`

