### PR TITLE
Locations Reference Data View Bug Fix

### DIFF
--- a/libsys_airflow/plugins/folio/apps/circ_rules_tester_view.py
+++ b/libsys_airflow/plugins/folio/apps/circ_rules_tester_view.py
@@ -124,22 +124,22 @@ class CircRulesTester(AppBuilderBaseView):
             case "locations":
                 title = "Locations"
                 locations_df = pd.DataFrame(_folio_client.locations)
-                reference_df = locations_df.drop(
-                    columns=[
-                        'discoveryDisplayName',
-                        'isActive',
-                        'institutionId',
-                        'campusId',
-                        'libraryId',
-                        'details',
-                        'primaryServicePoint',
-                        'servicePointIds',
-                        'servicePoints',
-                        'isShadow',
-                        'metadata',
-                        'description',
-                    ]
-                ).rename(
+                drop_columns = [
+                    'discoveryDisplayName',
+                    'isActive',
+                    'institutionId',
+                    'campusId',
+                    'libraryId',
+                    'details',
+                    'primaryServicePoint',
+                    'servicePointIds',
+                    'servicePoints',
+                    'metadata',
+                    'description',
+                ]
+                if 'isShadow' in locations_df.columns:
+                    drop_columns.append('isShadow')
+                reference_df = locations_df.drop(columns=drop_columns).rename(
                     columns={"code": "FOLIO code", "name": "FOLIO name", "id": "UUID"}
                 )
 


### PR DESCRIPTION
Getting a 500 error on libsys-stage and libsys-prod when trying to access `/circ_rule_tester/reference/locations` (works on libsys-dev because that Airflow environment is pointed to folio-test with Sunflower). This is because there is a new property, `isShadow`. This PR provides a guard for that column and fixes the bug.