### PR TITLE
Reverts commit that broke vendor_loads db:create.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cap alembic:migrate  # Run Alembic database migrations
 
 In `config/deploy.rb` at the top, add new default database set to the list of alembic_dbs:
 ```
-set :alembic_dbs, ['vma', 'digital_bookplates', 'new_database', '...']
+set :alembic_dbs, ['vendor_loads', 'digital_bookplates', 'new_database', '...']
 ```
 
 Or alternately, run any alembic task with the ALEMBIC_DBS environment variable set, e.g.
@@ -135,7 +135,7 @@ to see changes in the running Airflow environment.
 We are supporting multiple databases, Vendor Management App and Digital Bookplates, using alembic following
 these [directions](https://alembic.sqlalchemy.org/en/latest/cookbook.html#run-multiple-alembic-environments-from-one-ini-file).
 
-To run any `alembic` commands you need add the `--name` parameter followed by `vma` for the Vendor Management database
+To run any `alembic` commands you need add the `--name` parameter followed by `vendor_loads` for the Vendor Management database
 and `digital_bookplates` for the Digital Bookplates database.
 
 ### Local Database Creation and Migrations
@@ -196,12 +196,12 @@ To generate a migration script, first make the changes in the `models.py`
 module and then run the following steps:
 
 1. Set your shell to use the local poetry virtual environment: `poetry shell`
-2. Run `dotenv run alembic --name vma revision --autogenerate -m "{short message describing change}"` (**NOTE**: not all changes to the model are detected, see this [note](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) in the documentation)
+2. Run `dotenv run alembic --name vendor_loads revision --autogenerate -m "{short message describing change}"` (**NOTE**: not all changes to the model are detected, see this [note](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) in the documentation)
 3. After the migration script is created, run `dotenv run alembic upgrade head` to apply your latest changes to the database.
 
-If you prefer not to use `poetry shell` you can use `poetry run` along with `dotenv` instead: e.g. `poetry run dotenv run alembic --name vma upgrade head`. Or you can simply put the `DATABASE_*` environment variables into your shell via another means.
+If you prefer not to use `poetry shell` you can use `poetry run` along with `dotenv` instead: e.g. `poetry run dotenv run alembic --name vendor_loads upgrade head`. Or you can simply put the `DATABASE_*` environment variables into your shell via another means.
 
-To fix multiple heads: `poetry run alembic --name vma merge heads -m "merge <revision 1> and <revision 2>"`
+To fix multiple heads: `poetry run alembic --name vendor_loads merge heads -m "merge <revision 1> and <revision 2>"`
 
 #### Clearing out VendorFiles for Development
 Assuming you have populated VendorFiles table and want to re-fetch vendor files, clear out the database table with:

--- a/alembic.ini
+++ b/alembic.ini
@@ -60,7 +60,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 
 sqlalchemy.url = driver://user:pass@localhost/dbname
 
-[vma]
+[vendor_loads]
 script_location = vendor_loads_migration
 
 [digital_bookplates]

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ set :repo_url, 'https://github.com/sul-dlss/libsys-airflow.git'
 set :user, 'libsys'
 set :venv, '/home/libsys/virtual-env/bin/activate'
 set :migration, 'https://github.com/sul-dlss/folio_migration.git'
-set :alembic_dbs, ['vma', 'digital_bookplates']
+set :alembic_dbs, ['vendor_loads', 'digital_bookplates']
 set :ssh_options, { :forward_agent => true }
 
 def alembic_dbs

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -6,11 +6,11 @@ from alembic.script import ScriptDirectory
 
 def test_only_single_head_revision_in_migrations():
     config = Config('alembic.ini')
-    vma_script = ScriptDirectory(dir=config.get_section('vma')['script_location'])
+    vendor_loads_script = ScriptDirectory(dir=config.get_section('vendor_loads')['script_location'])
     digital_bookplate_script = ScriptDirectory(
         dir=config.get_section('digital_bookplates')['script_location']
     )
 
     # This will raise if there are multiple heads
-    vma_script.get_current_head()
+    vendor_loads_script.get_current_head()
     digital_bookplate_script.get_current_head()


### PR DESCRIPTION
The db:create cap task was changed to create a database called "vma" but all the alembic migration scripts are for a database called "vendor_loads". I don't believe this will be an issue for our stage and prod upgrades because the database "vendor_loads" already exists, but it is problematic for dev because we started with an empty database.

The db:create cap task created a "vma" database:
```
db:create
      01 psql         -v ON_ERROR_STOP=1 postgresql://$DATABASE_USERNAME:$DATABASE_PASSWORD@$DATABASE_HOSTNAME <<-SQL
        SELECT 'CREATE DATABASE air…
      01 CREATE DATABASE
      01 GRANT
    ✔ 01 libsys@sul-libsys-airflow-dev-up.stanford.edu 0.413s
      02 psql         -v ON_ERROR_STOP=1 postgresql://$DATABASE_USERNAME:$DATABASE_PASSWORD@$DATABASE_HOSTNAME <<-SQL
        SELECT 'CREATE DATABASE vma…
      02 CREATE DATABASE
      02 GRANT
    ✔ 02 libsys@sul-libsys-airflow-dev-up.stanford.edu 0.188s
      03 psql         -v ON_ERROR_STOP=1 postgresql://$DATABASE_USERNAME:$DATABASE_PASSWORD@$DATABASE_HOSTNAME <<-SQL
        SELECT 'CREATE DATABASE dig…
      03 CREATE DATABASE
      03 GRANT
    ✔ 03 libsys@sul-libsys-airflow-dev-up.stanford.edu 0.180s
```
But the alembic:migrate cap tasks fail because it is trying to run "vendor_loads" migrations for "vma":
```
02:18 alembic:migrate
      01 cd /home/libsys/libsys-airflow/releases/20260428181114 && source /home/libsys/virtual-env/bin/activate && poetry run alembic --name vma upgrade …
<snip>
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at "sul-libsys-airflow-db-dev-01.stanford.edu" (10.111.7.183), port 5432 failed: FATAL:  database "vendor_loads" does not exist
```
The commit where this broke is https://github.com/sul-dlss/libsys-airflow/commit/c747997c4c7ca80044ad6bd9fd0548bab2a50d4d#diff-3d066bc83eaf220ed7d8276202a78415dfe66ddf285f3382273b86d5845ab94c