### PR TITLE
Fixes API base url settings

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -65,7 +65,7 @@ x-airflow-common:
     AIRFLOW__API_AUTH__JWT_SECRET: ${AIRFLOW__API_AUTH__JWT_SECRET:-airflow_jwt_secret}
     AIRFLOW__API_AUTH__JWT_ISSUER: ${AIRFLOW__API__BASE_URL:-airflow}
     AIRFLOW__API__SECRET_KEY: ${AIRFLOW__API__SECRET_KEY}
-    AIRFLOW__API__BASE_URL: ${AIRFLOW__API__BASE_URL}
+    AIRFLOW__API__BASE_URL: 'http://airflow-apiserver:8080'
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -65,7 +65,7 @@ x-airflow-common:
     AIRFLOW__API_AUTH__JWT_SECRET: ${AIRFLOW__API_AUTH__JWT_SECRET:-airflow_jwt_secret}
     AIRFLOW__API_AUTH__JWT_ISSUER: ${AIRFLOW__API__BASE_URL:-airflow}
     AIRFLOW__API__SECRET_KEY: ${AIRFLOW__API__SECRET_KEY}
-    AIRFLOW__API__BASE_URL: 'http://airflow-apiserver:8080'
+    AIRFLOW__API__BASE_URL: ${AIRFLOW__API__BASE_URL}
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -149,7 +149,7 @@ services:
     <<: *airflow-common
     command: api-server
     ports:
-      - "8080:8080"
+      - "3000:8080"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/version"]
       interval: 30s

--- a/libsys_airflow/plugins/shared/airflow_api_client.py
+++ b/libsys_airflow/plugins/shared/airflow_api_client.py
@@ -39,7 +39,7 @@ def get_access_token(
 
 def api_client() -> airflow_client.client.ApiClient:
     configuration = airflow_client.client.Configuration(
-        host=os.getenv("AIRFLOW__API__BASE_URL", "http://airflow-apiserver:8080"),
+        host="http://airflow-apiserver:8080",
         username=os.getenv("AIRFLOW_VAR_API_USER", "nausername"),
         password=os.getenv("AIRFLOW_VAR_API_PASSWORD", "napassword"),
     )

--- a/libsys_airflow/plugins/shared/airflow_api_client.py
+++ b/libsys_airflow/plugins/shared/airflow_api_client.py
@@ -2,7 +2,9 @@ import os
 import airflow_client.client
 from pydantic import BaseModel
 import httpx
+import logging
 
+logger = logging.getLogger(__name__)
 
 class AirflowAccessToken(BaseModel):
     access_token: str
@@ -14,17 +16,24 @@ def get_access_token(
     password: str | None,
 ) -> str:
     url = f"{host}/auth/token"
+    logger.info(f"Getting access token from {url}")
     payload = {
         "username": username,
         "password": password,
     }
     headers = {"Content-Type": "application/json"}
-    response = httpx.post(url, json=payload, headers=headers)
-    if response.status_code != 201:
-        raise RuntimeError(
+    try:
+        response = httpx.post(url, json=payload, headers=headers)
+        if response.status_code == 201:
+            response_success = AirflowAccessToken(**response.json())
+        else:
+            raise RuntimeError(
             f"Failed to get access token: {response.status_code} {response.text}"
         )
-    response_success = AirflowAccessToken(**response.json())
+    except httpx.ConnectError as e:
+        print(f"Connection error: {e}")
+        raise
+
     return response_success.access_token
 
 


### PR DESCRIPTION
Related to this puppet PR: https://github.com/sul-dlss/puppet/pull/13650

Sets the `AIRFLOW__API__BASE_URL` to the airflow-apiserver docker container service, which the other airflow containers use when interacting with the Airflow 3 API. Having airflow-apiserver service running on ports `3000:8080` aligns with the server's proxy_pass settings:
https://github.com/sul-dlss/puppet/blob/9a7b049371e128e3a355db47fa81a92d4d8fa4ce/hieradata/node/sul-libsys-airflow-dev-up.stanford.edu.yaml#L182