### PR TITLE
fix google view sql to remove duplicates

### DIFF
--- a/libsys_airflow/plugins/data_exports/sql/google_mat_view.sql
+++ b/libsys_airflow/plugins/data_exports/sql/google_mat_view.sql
@@ -24,7 +24,7 @@ filtered_items AS (
         )
     ORDER BY T.holdingsrecordid, T.id
 )
-SELECT
+SELECT DISTINCT ON (F.instanceid)
     F.instanceid,
     I.jsonb ->> 'hrid' AS hrid,
     M.content


### PR DESCRIPTION
Remove duplicate instance ids from base select for google view.