### PR TITLE
Hardcodes max_active_tis_per_dag in VMA workflows.

### DIFF
--- a/libsys_airflow/plugins/folio/data_import.py
+++ b/libsys_airflow/plugins/folio/data_import.py
@@ -44,7 +44,7 @@ def data_import_branch_task(dataload_profile_uuid: Optional[str]):
     on_execute_callback=record_loading,
     on_success_callback=record_loaded,
     on_failure_callback=record_loading_error,
-    max_active_tis_per_dag=Variable.get("max_active_data_import_tis", 1),
+    max_active_tis_per_dag=1,
     multiple_outputs=True,
 )
 def data_import_task(

--- a/libsys_airflow/plugins/vendor/download.py
+++ b/libsys_airflow/plugins/vendor/download.py
@@ -197,7 +197,7 @@ def filter_by_mod_date(
     return result
 
 
-@task(max_active_tis_per_dag=Variable.get("max_active_download_tis", 2))
+@task(max_active_tis_per_dag=2)
 def download_task(
     conn_id: str,
     remote_path: str,


### PR DESCRIPTION
Closes #1734 
Fixes log message that this variable is not found. Follows the pattern we've established for settings this parameter, e.g. https://github.com/sul-dlss/libsys-airflow/blob/a21bde813437687464ba87c4747c03ca62ae7a1e/libsys_airflow/plugins/folio/invoices.py#L132