### PR TITLE
Refactors retry_failed_979 dag to use aiflow_client.

### DIFF
--- a/libsys_airflow/dags/digital_bookplates/retry_failed_979s.py
+++ b/libsys_airflow/dags/digital_bookplates/retry_failed_979s.py
@@ -1,13 +1,12 @@
 from datetime import datetime
 
-from airflow.sdk import dag, get_current_context, task
+from airflow.sdk import dag
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.timetables.trigger import CronTriggerTimetable
 
 from libsys_airflow.plugins.digital_bookplates.dag_979_retries import (
     failed_979_dags,
-    run_ids,
-    clear_failed_add_marc_tags_to_record,
+    clear_dag_runs,
     poll_for_979s_dags,
 )
 
@@ -33,19 +32,11 @@ def retry_failed_979s():
 
     end = EmptyOperator(task_id="end")
 
-    @task
-    def find_failed_979_dags():
-        context = get_current_context()
-        bash_operator = failed_979_dags()
-        return bash_operator.execute(context)
+    failed_dag_runs = failed_979_dags()
 
-    failed_dag_runs = find_failed_979_dags()
+    rerun_failed_979_dags = clear_dag_runs(dag_runs=failed_dag_runs)
 
-    dag_run_ids = run_ids(failed_dag_runs)
-
-    rerun_failed_979_dags = clear_failed_add_marc_tags_to_record()
-
-    start >> rerun_failed_979_dags >> poll_for_979s_dags(dag_run_ids) >> end
+    start >> rerun_failed_979_dags >> poll_for_979s_dags(rerun_failed_979_dags) >> end
 
 
 retry_failed_979s()

--- a/libsys_airflow/plugins/digital_bookplates/dag_979_retries.py
+++ b/libsys_airflow/plugins/digital_bookplates/dag_979_retries.py
@@ -1,59 +1,121 @@
 import logging
-
+import json
 from airflow.sdk import task, Variable
-from airflow.providers.standard.operators.bash import BashOperator
+from airflow_client.client import DagRunApi, DAGRunClearBody
+from airflow_client.client.models import (
+    DAGRunCollectionResponse,
+    DAGRunResponse,
+    ResponseClearDagRun,
+)
+from airflow_client.client.rest import ApiException
 
 from libsys_airflow.plugins.digital_bookplates.bookplates import (
     launch_poll_for_979_dags_email,
+)
+from libsys_airflow.plugins.shared.airflow_api_client import (
+    api_client,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def failed_979_dags():
-    """
-    Find all of the failed digital_bookplate_979 DAG runs
-    """
-    dag_runs = BashOperator(
-        task_id="failed_dag_runs",
-        bash_command="airflow dags list-runs digital_bookplate_979s --state=failed --output=json",
-    )
-    return dag_runs
+def get_all_failed_dag_runs(
+    api_instance: DagRunApi, size: int, initial_limit: int, initial_offset: int
+) -> list[DAGRunResponse]:
+    all_dag_runs: list = []
+    limit = initial_limit
+    offset = initial_offset
+    while offset < size:
+        try:
+            api_response: DAGRunCollectionResponse = api_instance.get_dag_runs(
+                dag_id="digital_bookplate_979",
+                state=["failed"],
+                limit=limit,
+                offset=offset,
+            )
+            all_dag_runs.extend(api_response.dag_runs)
+        except ApiException as e:
+            logger.warning(f"Exception when calling DagRunApi: {e}")
+            continue
+
+        # Increment the limit and offset
+        limit = min(limit + 100, size - offset)
+        offset += limit
+
+    return all_dag_runs
+
+
+def total_failed_dag_runs(api_instance: DagRunApi) -> int | None:
+    try:
+        api_response: DAGRunCollectionResponse = api_instance.get_dag_runs(
+            dag_id="digital_bookplate_979", state=["failed"]
+        )
+        total_entries = api_response.total_entries
+        return total_entries
+    except ApiException as e:
+        logger.warning(f"Exception when calling DagRunApi: {e}")
+        return None
 
 
 @task
-def run_ids(failed_dag_runs: list) -> list:
+def failed_979_dags() -> list:
     """
-    Gets run_ids from list of failed dag runs
-    [{"dag_id": "course_reserves_data", "run_id": "scheduled__2025-11-06T00:40:00+00:00", "state": "failed", "run_after": "2025-11-06T09:40:00+00:00", "logical_date": "2025-11-06T00:40:00+00:00", "start_date": "2025-11-06T09:40:00.126471+00:00", "end_date": "2025-11-06T10:40:52.175757+00:00"},]
+    Find all of the failed digital_bookplate_979 DAG runs
+    Returns a list of DAGRunResponse as json
     """
-    run_ids = []
-    for _ in failed_dag_runs:
-        run_id = _["run_id"]
-        logger.info(f"Found: {run_id}")
-        run_ids.append(run_id)
+    client = api_client()
+    api_instance = DagRunApi(client)
+    total_dag_runs = total_failed_dag_runs(api_instance=api_instance)
+    all_dag_runs: list = []
+    if total_dag_runs is not None:
+        logger.info(f"Total number of failed dag runs: {total_dag_runs}")
+        all_dag_runs = get_all_failed_dag_runs(
+            api_instance=api_instance,
+            size=total_dag_runs,
+            initial_limit=100,
+            initial_offset=0,
+        )
+        logger.info(f"Total number of dag runs fetched: {len(all_dag_runs)}")
+    else:
+        logger.warning("Unable to get failed dag runs")
 
-    return run_ids
+    return [x.to_json() for x in all_dag_runs]
 
 
-@task.bash
-def clear_failed_add_marc_tags_to_record() -> str:
+@task
+def clear_dag_runs(dag_runs: list) -> list:
     """
-    Re-run the failed digital_bookplate_979 DAGs by clearing the add_marc_tags_to_record task
-    airflow tasks clear digital_bookplate_979 -t add_marc_tags_to_record --only-failed --downstream --yes
-    --yes = Do not prompt to confirm
+    Clears dag runs given a list of DAGRunResponses as json
+    Returns list of cleared dag_run_ids
     """
-    logger.info(
-        "Clearing failed add_marc_tags_to_record tasks for digital_bookplate_979 DAG runs."
-    )
-    return "airflow tasks clear digital_bookplate_979 -t add_marc_tags_to_record --only-failed --downstream --yes"
+    client = api_client()
+    api_instance = DagRunApi(client)
+    cleared_dag_runs: list = []
+    for dag_run in dag_runs:
+        dag_run = json.loads(dag_run)
+        dag_id = dag_run.get("dag_id", "digital_bookplate_979")
+        dag_run_id = dag_run.get("dag_run_id")
+        dag_run_clear_body = DAGRunClearBody(dry_run=False, only_failed=True)
+        try:
+            logger.info(f"Clearing dag run for {dag_id} {dag_run_id}")
+            api_response: ResponseClearDagRun = api_instance.clear_dag_run(
+                dag_id, dag_run_id, dag_run_clear_body
+            )
+            state = api_response.to_dict().get("state").name  # type: ignore
+            logger.info(f"Dag run ID: {dag_run_id}, state: {state}")
+            cleared_dag_runs.append(dag_run_id)
+        except ApiException as e:
+            logger.warning(f"Could not clear dag run for {dag_id} {dag_run_id}: {e}")
+
+    return cleared_dag_runs
 
 
 @task
 def poll_for_979s_dags(run_ids):
     devs_email_addr = Variable.get("EMAIL_DEVS")
 
-    logger.info(f"{len(run_ids)} failed 979 DAG runs queued: {run_ids}")
+    logger.info(f"{len(run_ids)} failed 979 DAG runs queued")
+    logger.info(run_ids)
 
     launch_poll_for_979_dags_email(dag_runs=run_ids, email=devs_email_addr)
 

--- a/tests/digital_bookplates/test_retry_failed_979s.py
+++ b/tests/digital_bookplates/test_retry_failed_979s.py
@@ -1,41 +1,74 @@
 import pytest
 
 from airflow.sdk import Variable
+from unittest.mock import MagicMock
+
+from mocks import (  # noqa
+    MockAirflowApiClientConfig,
+    MockAirflowApiClient,
+)
 
 from libsys_airflow.plugins.digital_bookplates.dag_979_retries import (
     failed_979_dags,
-    run_ids,
-    clear_failed_add_marc_tags_to_record,
+    clear_dag_runs,
     poll_for_979s_dags,
 )
 
 
 @pytest.fixture
-def mock_dag_list_runs():
+def mock_client_config():
+    return MockAirflowApiClientConfig()
+
+
+@pytest.fixture
+def mock_api_client():
+    return MockAirflowApiClient(configuration=MockAirflowApiClientConfig())
+
+
+@pytest.fixture(params=["get_dag_runs", "clear_dag_run"])
+def mock_api_instance(request):
+    api_request = request.param
+    api_instance = MagicMock()
+
+    if api_request == "get_dag_runs":
+        mock_response = MagicMock(
+            dag_runs=[
+                MagicMock(
+                    dag_id="digital_bookplate_979",
+                    dag_run_id="manual__2025-11-06T09:40:00+00:00",
+                ),
+                MagicMock(
+                    dag_id="digital_bookplate_979",
+                    dag_run_id="manual__2025-11-06T00:40:00+00:00",
+                ),
+            ],
+            total_entries=2,
+        )
+        api_instance.get_dag_runs.return_value = mock_response
+
+    elif api_request == "clear_dag_run":
+        mock_state = MagicMock()
+        mock_state.name = "QUEUED"
+
+        mock_response = MagicMock()
+        mock_response.to_dict.return_value = {"state": mock_state}
+
+        api_instance = MagicMock()
+        api_instance.clear_dag_run.return_value = mock_response
+
+    return api_instance
+
+
+@pytest.fixture
+def mock_clear_dag_runs_op_kwargs():
     return [
-        {
-            "dag_id": "digital_bookplate_979",
-            "run_id": "manual__2025-11-06T09:40:00+00:00",
-            "state": "failed",
-            "run_after": "2025-11-06T19:40:00+00:00",
-            "logical_date": "2025-11-06T09:40:00+00:00",
-            "start_date": "2025-11-06T21:47:50.247185+00:00",
-            "end_date": "2025-11-06T21:47:51.278468+00:00",
-        },
-        {
-            "dag_id": "digital_bookplate_979",
-            "run_id": "manual__2025-11-06T00:40:00+00:00",
-            "state": "failed",
-            "run_after": "2025-11-06T09:40:00+00:00",
-            "logical_date": "2025-11-06T00:40:00+00:00",
-            "start_date": "2025-11-06T21:47:48.169719+00:00",
-            "end_date": "2025-11-06T21:47:49.227595+00:00",
-        },
+        "{\"dag_id\": \"digital_bookplate_979\", \"dag_run_id\": \"manual__2025-11-06T09:40:00+00:00\"}",
+        "{\"dag_id\": \"digital_bookplate_979\", \"dag_run_id\": \"manual__2025-11-06T00:40:00+00:00\"}",
     ]
 
 
 @pytest.fixture
-def mock_run_ids():
+def mock_cleared_dag_runs():
     return ["manual__2025-11-06T09:40:00+00:00", "manual__2025-11-06T00:40:00+00:00"]
 
 
@@ -47,38 +80,50 @@ def mock_variable(monkeypatch):
     monkeypatch.setattr(Variable, "get", mock_get)
 
 
-def test_find_failed_979_dags(mocker, mock_dag_list_runs):
+@pytest.mark.parametrize("mock_api_instance", ["get_dag_runs"], indirect=True)
+def test_find_failed_979_dags(mocker, mock_api_client, mock_api_instance, caplog):
     mocker.patch(
-        "libsys_airflow.plugins.digital_bookplates.dag_979_retries.BashOperator",
-        return_value=mock_dag_list_runs,
+        "libsys_airflow.plugins.digital_bookplates.dag_979_retries.api_client",
+        return_value=mock_api_client,
+    )
+    mocker.patch(
+        "libsys_airflow.plugins.digital_bookplates.dag_979_retries.DagRunApi",
+        return_value=mock_api_instance,
     )
 
-    failed_dags = failed_979_dags()
+    failed_dags = failed_979_dags.function()
     assert len(failed_dags) == 2
+    assert "Total number of dag runs fetched: 2" in caplog.text
 
 
-def test_run_ids(mock_dag_list_runs, caplog):
-    failed_dag_run_ids = run_ids.function(mock_dag_list_runs)
-    assert isinstance(failed_dag_run_ids, list)
-    assert failed_dag_run_ids.pop() == "manual__2025-11-06T00:40:00+00:00"
-    assert "Found: manual__2025-11-06T09:40:00+00:00" in caplog.text
-
-
-def test_clear_failed_add_marc_tags_to_record(caplog):
-    clear_failed_add_marc_tags_to_record.function()
-    assert (
-        "Clearing failed add_marc_tags_to_record tasks for digital_bookplate_979 DAG runs."
-        in caplog.text
+@pytest.mark.parametrize("mock_api_instance", ["clear_dag_run"], indirect=True)
+def test_clear_dag_runs(
+    mocker, mock_api_client, mock_api_instance, mock_clear_dag_runs_op_kwargs, caplog
+):
+    mocker.patch(
+        "libsys_airflow.plugins.digital_bookplates.dag_979_retries.api_client",
+        return_value=mock_api_client,
+    )
+    mocker.patch(
+        "libsys_airflow.plugins.digital_bookplates.dag_979_retries.DagRunApi",
+        return_value=mock_api_instance,
     )
 
+    cleared_dag_runs = clear_dag_runs.function(dag_runs=mock_clear_dag_runs_op_kwargs)
+    assert (
+        "Clearing dag run for digital_bookplate_979 manual__2025-11-06T" in caplog.text
+    )
+    assert "state: QUEUED" in caplog.text
+    assert len(cleared_dag_runs) == 2
 
-def test_poll_for_979s_dags(mocker, mock_run_ids, mock_variable, caplog):
+
+def test_poll_for_979s_dags(mocker, mock_cleared_dag_runs, mock_variable, caplog):
     mock_email = mocker.patch(
         "libsys_airflow.plugins.digital_bookplates.dag_979_retries.launch_poll_for_979_dags_email"
     )
-    poll_for_979s_dags.function(mock_run_ids)
+    poll_for_979s_dags.function(mock_cleared_dag_runs)
 
-    assert (
-        f"{len(mock_run_ids)} failed 979 DAG runs queued: {mock_run_ids}" in caplog.text
+    assert f"{len(mock_cleared_dag_runs)} failed 979 DAG runs queued" in caplog.text
+    mock_email.assert_called_once_with(
+        dag_runs=mock_cleared_dag_runs, email="test@example.com"
     )
-    mock_email.assert_called_once_with(dag_runs=mock_run_ids, email="test@example.com")


### PR DESCRIPTION
Closes #1768 

Some screenshots and info when running locally in docker:
Log output of failed_979s_dags task:
<img width="1190" height="423" alt="Screenshot 2026-05-15 at 1 13 19 PM" src="https://github.com/user-attachments/assets/9ed3435e-f9c7-40b0-a5f5-730bea1e19ef" />

Logging of clear_dag_runs task:
```
[2026-05-15 13:12:55] WARNING - The `airflow.utils.operator_helpers.determine_kwargs` attribute is deprecated. Please use `'airflow.sdk.bases.decorator.determine_kwargs'`. category=DeprecatedImportWarning
[2026-05-15 13:12:55] INFO - DAG bundles loaded: dags-folder
[2026-05-15 13:12:55] INFO - Filling up the DagBag from /opt/airflow/libsys_airflow/dags/digital_bookplates/retry_failed_979s.py
[2026-05-15 13:12:55] INFO - Getting access token from http://airflow-apiserver:8080/auth/token
[2026-05-15 13:12:56] INFO - Clearing dag run for digital_bookplate_979 manual__2026-04-16T21:31:44.765161+00:00
[2026-05-15 13:12:56] INFO - Dag run ID: manual__2026-04-16T21:31:44.765161+00:00, state: QUEUED
[2026-05-15 13:12:56] INFO - Clearing dag run for digital_bookplate_979 manual__2026-05-05T21:20:18.380898+00:00
[2026-05-15 13:12:56] INFO - Dag run ID: manual__2026-05-05T21:20:18.380898+00:00, state: QUEUED
[2026-05-15 13:12:56] INFO - Clearing dag run for digital_bookplate_979 manual__2026-05-05T21:20:18.524375+00:00
[2026-05-15 13:12:56] INFO - Dag run ID: manual__2026-05-05T21:20:18.524375+00:00, state: QUEUED
[2026-05-15 13:12:56] INFO - Clearing dag run for digital_bookplate_979 manual__2026-05-05T21:20:18.616001+00:00
[2026-05-15 13:12:56] INFO - Dag run ID: manual__2026-05-05T21:20:18.616001+00:00, state: QUEUED
[2026-05-15 13:12:56] INFO - Clearing dag run for digital_bookplate_979 manual__2026-05-05T21:20:18.709150+00:00
[2026-05-15 13:12:56] INFO - Dag run ID: manual__2026-05-05T21:20:18.709150+00:00, state: QUEUED
<snip>
```

Screenshot of clear_dag_runs task XCOM:
<img width="1297" height="626" alt="Screenshot 2026-05-15 at 1 16 56 PM" src="https://github.com/user-attachments/assets/1c91e45e-3949-4539-95c3-f4e84732e7fc" />

Logs of poll_for_979s_dags task:
<img width="990" height="425" alt="Screenshot 2026-05-15 at 1 19 04 PM" src="https://github.com/user-attachments/assets/6cdb9ed8-1b39-4220-ae4d-635c70a316b0" />

poll_for_digital_bookplates_979_email dag retrieve_variables task:
<img width="983" height="368" alt="Screenshot 2026-05-15 at 1 20 50 PM" src="https://github.com/user-attachments/assets/7880cb8d-7b23-45e7-afc9-edba6d80c875" />
