### PR TITLE
Fixes dag_run.dag.dag_id which no longer works in Airflow 3

### DIFF
--- a/libsys_airflow/plugins/data_exports/email.py
+++ b/libsys_airflow/plugins/data_exports/email.py
@@ -201,7 +201,7 @@ def no_files_email(**kwargs):
     """
     dag_run = kwargs["dag_run"]
     dag_run_id = dag_run.run_id
-    dag_id = dag_run.dag.dag_id
+    dag_id = dag_run.dag_id
 
     run_url = dag_run_url(dag_run=dag_run)
     logger.info("Generating email of no files found to transmit")
@@ -260,7 +260,7 @@ def failed_transmission_email(files: list, **kwargs):
     """
     dag_run = kwargs["dag_run"]
     dag_run_id = dag_run.run_id
-    dag_id = dag_run.dag.dag_id
+    dag_id = dag_run.dag_id
 
     run_url = dag_run_url(dag_run=dag_run)
     params = kwargs.get("params", {})
@@ -332,7 +332,7 @@ def _missing_marc_for_instances(**kwargs) -> str:
     instance_uuids: list = kwargs["instance_uuids"]
     dag_run = kwargs["dag_run"]
     dag_run_id = dag_run.run_id
-    dag_id = dag_run.dag.dag_id
+    dag_id = dag_run.dag_id
 
     folio_url: str = kwargs["folio_url"]
 
@@ -432,6 +432,6 @@ def generate_missing_marc_email(**kwargs):
 
     send_email_with_server_name(
         to=email_addresses,
-        subject=f"Instances missing MARC Records for {dag_run.dag.dag_id}",
+        subject=f"Instances missing MARC Records for {dag_run.dag_id}",
         html_content=body,
     )

--- a/libsys_airflow/plugins/digital_bookplates/dag_979_sensor.py
+++ b/libsys_airflow/plugins/digital_bookplates/dag_979_sensor.py
@@ -5,7 +5,7 @@ from airflow_client.client.models.dag_run_response import DAGRunResponse
 from airflow_client.client.rest import ApiException
 from airflow.sdk import BaseSensorOperator
 
-from libsys_airflow.plugins.shared.utils import dag_run_response_url
+from libsys_airflow.plugins.shared.utils import dag_run_url
 from libsys_airflow.plugins.shared.airflow_api_client import (
     api_client,
 )
@@ -44,9 +44,7 @@ class DAG979Sensor(BaseSensorOperator):
             state = api_response.state.name.lower()
             if state in ['success', 'failed']:
                 self.dag_runs[dag_run_id]['state'] = state
-                self.dag_runs[dag_run_id]['url'] = dag_run_response_url(
-                    dag_run=api_response
-                )
+                self.dag_runs[dag_run_id]['url'] = dag_run_url(dag_run=api_response)
                 instances = []
                 dag_run_config: dict = (
                     api_response.conf['druids_for_instance_id']

--- a/libsys_airflow/plugins/shared/utils.py
+++ b/libsys_airflow/plugins/shared/utils.py
@@ -4,14 +4,14 @@ import logging
 import pymarc
 import re
 import time
-import urllib
 
 from typing import Union
 from datetime import datetime, timezone
+from urllib.parse import quote
 
+from airflow_client.client import DAGRunResponse
 from airflow.configuration import conf
 from airflow.sdk import Variable
-from airflow_client.client.models.dag_run_response import DAGRunResponse
 from airflow.utils.email import send_email
 
 from libsys_airflow.plugins.shared.folio_client import folio_client
@@ -23,7 +23,7 @@ def execution_date() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def dag_run_response_url(**kwargs) -> str:
+def dag_run_url(**kwargs) -> str:
     dag_run: DAGRunResponse = kwargs["dag_run"]
     airflow_url = kwargs.get("airflow_url")
 
@@ -32,20 +32,8 @@ def dag_run_response_url(**kwargs) -> str:
         if not airflow_url.endswith("/"):
             airflow_url = f"{airflow_url}/"
 
-    return f"{airflow_url}dags/{dag_run.dag_id}/runs/{dag_run.dag_run_id}"
-
-
-def dag_run_url(**kwargs) -> str:
-    dag_run = kwargs["dag_run"]
-    airflow_url = kwargs.get("airflow_url")
-
-    if not airflow_url:
-        airflow_url = conf.get('api', 'base_url')
-        if not airflow_url.endswith("/"):
-            airflow_url = f"{airflow_url}/"
-
-    params = urllib.parse.urlencode({"dag_run_id": dag_run.run_id})
-    return f"{airflow_url}dags/{dag_run.dag.dag_id}/grid?{params}"
+    run_id = getattr(dag_run, 'run_id', '') or getattr(dag_run, 'dag_run_id', '')
+    return f"{airflow_url}dags/{dag_run.dag_id}/runs/{quote(run_id)}"
 
 
 def is_production():

--- a/tests/authority_control/test_authority_email.py
+++ b/tests/authority_control/test_authority_email.py
@@ -31,13 +31,9 @@ def mock_folio_variables(monkeypatch):
     monkeypatch.setattr(Variable, "get", mock_get)
 
 
-class MockDag(BaseModel):
-    dag_id: str = "load_marc_file"
-
-
 class MockDagRun(BaseModel):
     run_id: str = "marc-import-2025-02-12T00:00:00+00:00"
-    dag: MockDag = MockDag()
+    dag_id: str = "load_marc_file"
 
 
 def test_email_deletes_report(mocker, mock_folio_variables):
@@ -56,7 +52,7 @@ def test_email_deletes_report(mocker, mock_folio_variables):
 
     dag_run = MockDagRun()
     dag_run.run_id = "manual__2025-12-16T20:35:13"
-    dag_run.dag.dag_id = "delete_authority_records"
+    dag_run.dag_id = "delete_authority_records"
 
     email_deletes_report(
         deleted=10,

--- a/tests/data_exports/test_data_exports_emails.py
+++ b/tests/data_exports/test_data_exports_emails.py
@@ -54,8 +54,7 @@ def mock_folio_variables(monkeypatch):
 def mock_dag_run(mocker):
     dag_run = mocker.stub(name="dag_run")
     dag_run.run_id = "manual_2022-03-05"
-    dag_run.dag = mocker.stub(name="dag")
-    dag_run.dag.dag_id = "send_vendor_records"
+    dag_run.dag_id = "send_vendor_records"
 
     return dag_run
 
@@ -196,7 +195,7 @@ def test_no_files_email(mocker, mock_dag_run, mock_folio_variables, caplog):
     assert html_body.find("a").text == "manual_2022-03-05"
     assert (
         html_body.find("a").attrs["href"]
-        == "http://localhost:8080/dags/send_vendor_records/grid?dag_run_id=manual_2022-03-05"
+        == "http://localhost:8080/dags/send_vendor_records/runs/manual_2022-03-05"
     )
 
 
@@ -238,7 +237,7 @@ def test_failed_transmission_email(mocker, mock_dag_run, mock_folio_variables, c
 
     assert (
         html_body.find("a").attrs["href"]
-        == "http://localhost:8080/dags/send_vendor_records/grid?dag_run_id=manual_2022-03-05"
+        == "http://localhost:8080/dags/send_vendor_records/runs/manual_2022-03-05"
     )
 
     list_items = html_body.findAll("li")
@@ -278,7 +277,7 @@ def test_generate_oclc_new_marc_errors_email(
 def test_failed_full_dump_transmission_email(
     mocker, mock_dag_run, mock_folio_variables
 ):
-    mock_dag_run.dag.dag_id = "send_all_records"
+    mock_dag_run.dag_id = "send_all_records"
 
     mock_send_email = mocker.patch(
         "libsys_airflow.plugins.data_exports.email.send_email_with_server_name"
@@ -311,7 +310,7 @@ def test_failed_full_dump_transmission_email(
 
     assert (
         html_body.find("a").attrs["href"]
-        == "http://localhost:8080/dags/send_all_records/grid?dag_run_id=manual_2022-03-05"
+        == "http://localhost:8080/dags/send_all_records/runs/manual_2022-03-05"
     )
 
 
@@ -320,7 +319,7 @@ def test_generate_missing_marc_email(mocker, mock_dag_run, mock_folio_variables)
         "libsys_airflow.plugins.data_exports.email.send_email_with_server_name"
     )
 
-    mock_dag_run.dag.dag_id = "select_vendor_records"
+    mock_dag_run.dag_id = "select_vendor_records"
 
     generate_missing_marc_email.function(
         dag_run=mock_dag_run,
@@ -371,7 +370,7 @@ def test_generate_missing_marc_email_oclc(mocker, mock_dag_run, mock_folio_varia
         return_value=True,
     )
 
-    mock_dag_run.dag.dag_id = "select_vendor_records"
+    mock_dag_run.dag_id = "select_vendor_records"
 
     generate_missing_marc_email.function(
         dag_run=mock_dag_run,

--- a/tests/data_exports/test_oclc_reports.py
+++ b/tests/data_exports/test_oclc_reports.py
@@ -19,8 +19,7 @@ from libsys_airflow.plugins.data_exports.oclc_reports import (
 def mock_dag_run(mocker):
     dag_run = mocker.stub(name="dag_run")
     dag_run.run_id = "scheduled__2024-07-29T19:00:00:00:00"
-    dag_run.dag = mocker.stub(name="dag")
-    dag_run.dag.dag_id = "send_oclc_records"
+    dag_run.dag_id = "send_oclc_records"
 
     return dag_run
 
@@ -313,7 +312,7 @@ def test_holdings_set_errors_match_task(tmp_path, mocker, mock_dag_run):
     assert dag_a[0].text == "DAG Run"
     assert (
         dag_a[0].attrs["href"]
-        == "http://localhost:8080/dags/send_oclc_records/grid?dag_run_id=scheduled__2024-07-29T19%3A00%3A00%3A00%3A00"
+        == "http://localhost:8080/dags/send_oclc_records/runs/scheduled__2024-07-29T19%3A00%3A00%3A00%3A00"
     )
 
     hoover_report = pathlib.Path(reports['HIN'])

--- a/tests/digital_bookplates/test_bookplates_emails.py
+++ b/tests/digital_bookplates/test_bookplates_emails.py
@@ -82,7 +82,7 @@ def mock_DAG979Sensor():
     return {
         "manual__2024-10-20T02:00:00+00:00": {
             "state": "success",
-            "url": "https://sul-libsys-airflow.stanford.edu/dags/digital_bookplate_979/grid?dag_run_id=manual__2024-10-20T02:00:00+00:00",
+            "url": "https://sul-libsys-airflow.stanford.edu/dags/digital_bookplate_979/runs/manual__2024-10-20T02:00:00+00:00",
             "instances": [
                 {
                     "uuid": "fddf7e4c-161e-4ae8-baad-058288f63e17",

--- a/tests/digital_bookplates/test_dag_979_sensor.py
+++ b/tests/digital_bookplates/test_dag_979_sensor.py
@@ -18,7 +18,7 @@ def mock_api_instance(request):
     if test_type == "success":
         mock_response = MagicMock()
         mock_response.dag_id = "digital_bookplate_979"
-        mock_response.dag_run_id = "manual__2024-10-17"
+        mock_response.run_id = "manual__2024-10-17"
         mock_response.conf = {
             "druids_for_instance_id": {"d55f7f1b-9512-452c-98ff-5e2be9dcdb16": {}}
         }
@@ -34,7 +34,7 @@ def mock_api_instance(request):
         # For mixed, create a success response and a 500 exception
         mock_success_response = MagicMock()
         mock_success_response.dag_id = "digital_bookplate_979"
-        mock_success_response.dag_run_id = "manual__2024-10-17"
+        mock_success_response.run_id = "manual__2024-10-17"
         mock_success_response.conf = {
             "druids_for_instance_id": {"d55f7f1b-9512-452c-98ff-5e2be9dcdb16": {}}
         }

--- a/tests/encumbrances/test_fix_encumbrances_run.py
+++ b/tests/encumbrances/test_fix_encumbrances_run.py
@@ -50,13 +50,8 @@ def mock_folio_variables(monkeypatch):
 
 
 def test_fix_encumbrances_log_file_params(
-    mocker, tmp_path, mock_task_instance, mock_folio_variables, monkeypatch
+    mocker, tmp_path, mock_task_instance, mock_folio_variables
 ):
-    mocker.patch(
-        'libsys_airflow.plugins.folio.encumbrances.fix_encumbrances_master.Variable.get',
-        return_value=mock_folio_variables,
-    )
-
     async_mock = AsyncMock()
     mocker.patch(
         'libsys_airflow.plugins.folio.encumbrances.fix_encumbrances_master.run_operation',
@@ -79,7 +74,7 @@ def test_fix_encumbrances_log_file_params(
     assert log_path.endswith("foo-scheduled__2024-07-29T19:00:00:00:00.log")
 
 
-def test_fix_encumbrances_email_subject():
+def test_fix_encumbrances_email_subject(mock_folio_variables):
     from libsys_airflow.plugins.shared.utils import _subject_with_server_name
     from libsys_airflow.plugins.folio.encumbrances.email import subject
 
@@ -87,7 +82,7 @@ def test_fix_encumbrances_email_subject():
     assert subj == "okapi-test - Fix Encumbrances for SUL2024"
 
 
-def test_email_to(mocker):
+def test_email_to(mocker, mock_folio_variables):
     mocker.patch(
         'libsys_airflow.plugins.shared.utils.send_email_with_server_name',
         return_value=None,

--- a/tests/orafin/test_generated_emails.py
+++ b/tests/orafin/test_generated_emails.py
@@ -416,7 +416,8 @@ def test_generate_failed_dag_email(mocker):
     mock_context = mocker.MagicMock()
     mock_dag_run = mocker.MagicMock()
     mock_dag_run.run_id = "mock_instance_run_id"
-    mock_context.dag_run = mock_dag_run
+    mock_dag_run.dag_id = "ap_payment_report"
+    mock_context.get.return_value = mock_dag_run
 
     generate_failed_dag_email(mock_context, "http://airflow-stanford.edu")
 

--- a/tests/orafin/test_payments.py
+++ b/tests/orafin/test_payments.py
@@ -370,7 +370,10 @@ def mock_sftp_hook(mocker):
     return mock_hook
 
 
-def test_transfer_to_orafin(mock_sftp_hook, tmp_path, caplog):
+def test_transfer_to_orafin(mock_sftp_hook, mocker, tmp_path, caplog):
+    mocker.patch(
+        "libsys_airflow.plugins.orafin.payments.is_production", return_value=False
+    )
     feeder_file_path = tmp_path / "feeder20210823_202309240000"
     feeder_file_path.write_text(
         """LIB376992    HD006169FEEDER         23-13094 376992                         20230503000000000385.52DR                              N30

--- a/tests/shared/test_utils.py
+++ b/tests/shared/test_utils.py
@@ -149,7 +149,7 @@ def mock_folio_add_marc_tags(mocker):
 def mock_dag_run_response():
     mock_response = MagicMock()
     mock_response.dag_id = "digital_bookplate_979"
-    mock_response.dag_run_id = "manual__2026-04-16T21:31:44.765161+00:00"
+    mock_response.run_id = "manual__2026-04-16T21:31:44.765161+00:00"
 
     return mock_response
 
@@ -176,12 +176,12 @@ def mock_folio_client(mocker):
 
 
 def test_dag_run_response_url(mock_dag_run_response):
-    url = utils.dag_run_response_url(
+    url = utils.dag_run_url(
         dag_run=mock_dag_run_response, airflow_url="http://localhost/"
     )
     assert (
         url
-        == "http://localhost/dags/digital_bookplate_979/runs/manual__2026-04-16T21:31:44.765161+00:00"
+        == "http://localhost/dags/digital_bookplate_979/runs/manual__2026-04-16T21%3A31%3A44.765161%2B00%3A00"
     )
 
 


### PR DESCRIPTION
Fixes #1775 

See : https://sul-libsys-airflow-stage-up.stanford.edu/dags/select_backstage_records/runs/manual__2026-05-13T14:19:16.396100+00:00/tasks/email_missing_marc

The Airflow 3 Task SDK replaced the DagRun model with a plain Pydantic model that exposes dag_id as a direct field, so dag_run.dag.dag_id no longer works.

Also fixes email links to the new url pattern and fixes tests and mocks to match the new patterns.