### PR TITLE
Avoids pydantic error if invoice_id is None.

### DIFF
--- a/libsys_airflow/dags/orafin/report_processing.py
+++ b/libsys_airflow/dags/orafin/report_processing.py
@@ -65,4 +65,8 @@ with DAG(
 
     invoices = retrieve_invoice_task.expand(row=report_rows)
 
-    update_folio.expand(record=invoices) >> email_group() >> finish_updates
+    # Prevents creating task group instances for already-paid invoices
+    folio_updates = update_folio.expand(record=invoices)
+    emails = email_group()
+
+    folio_updates >> emails >> finish_updates

--- a/libsys_airflow/dags/orafin/report_processing.py
+++ b/libsys_airflow/dags/orafin/report_processing.py
@@ -32,7 +32,10 @@ default_args = {
 def update_folio(record):
     invoice_id = update_invoices_task(invoice=record)
     voucher_result = retrieve_voucher_task()
-    update_email_branch(invoice_id) >> [voucher_result, email_invoice_errors_task()]
+    update_email_branch(invoice_id) >> [
+        voucher_result,
+        email_invoice_errors_task(invoice=record),
+    ]
 
     voucher_result >> update_vouchers_task()
 

--- a/libsys_airflow/plugins/orafin/emails.py
+++ b/libsys_airflow/plugins/orafin/emails.py
@@ -391,10 +391,6 @@ def generate_ap_paid_report_email(folio_url: str, task_instance=None):
     """
     ap_report_path = task_instance.xcom_pull(task_ids="init_processing_task")
     invoices = task_instance.xcom_pull(task_ids="retrieve_invoice_task")
-    # Filter out None values from the mapped task results
-    if invoices:
-        invoices = [inv for inv in invoices if inv is not None]
-
     ap_report_name = pathlib.Path(ap_report_path).name
     grouped_invoices = _group_invoices_by_acqunit(invoices)
     devs_to_email_addr = Variable.get("EMAIL_DEVS")

--- a/libsys_airflow/plugins/orafin/emails.py
+++ b/libsys_airflow/plugins/orafin/emails.py
@@ -282,6 +282,10 @@ def generate_invoice_error_email(invoice_id: str, folio_url: str, ti=None):
     Retrieves AP report information for invoice that failed to update and
     emails report
     """
+    # Avoids pydantic error if invoice_id is None (for already paid invoices)
+    if invoice_id is None:
+        return
+
     devs_to_email_addr = Variable.get("EMAIL_DEVS")
     sul_to_email_addr = Variable.get("ORAFIN_TO_EMAIL_SUL")
     law_to_email_addr = Variable.get("ORAFIN_TO_EMAIL_LAW")

--- a/libsys_airflow/plugins/orafin/emails.py
+++ b/libsys_airflow/plugins/orafin/emails.py
@@ -391,6 +391,10 @@ def generate_ap_paid_report_email(folio_url: str, task_instance=None):
     """
     ap_report_path = task_instance.xcom_pull(task_ids="init_processing_task")
     invoices = task_instance.xcom_pull(task_ids="retrieve_invoice_task")
+    # Filter out None values from the mapped task results
+    if invoices:
+        invoices = [inv for inv in invoices if inv is not None]
+
     ap_report_name = pathlib.Path(ap_report_path).name
     grouped_invoices = _group_invoices_by_acqunit(invoices)
     devs_to_email_addr = Variable.get("EMAIL_DEVS")

--- a/libsys_airflow/plugins/orafin/emails.py
+++ b/libsys_airflow/plugins/orafin/emails.py
@@ -391,6 +391,10 @@ def generate_ap_paid_report_email(folio_url: str, task_instance=None):
     """
     ap_report_path = task_instance.xcom_pull(task_ids="init_processing_task")
     invoices = task_instance.xcom_pull(task_ids="retrieve_invoice_task")
+    # Filter out None values - these are already-paid and reported in email_errors_task
+    if invoices:
+        invoices = [inv for inv in invoices if inv is not None]
+
     ap_report_name = pathlib.Path(ap_report_path).name
     grouped_invoices = _group_invoices_by_acqunit(invoices)
     devs_to_email_addr = Variable.get("EMAIL_DEVS")

--- a/libsys_airflow/plugins/orafin/emails.py
+++ b/libsys_airflow/plugins/orafin/emails.py
@@ -282,10 +282,6 @@ def generate_invoice_error_email(invoice_id: str, folio_url: str, ti=None):
     Retrieves AP report information for invoice that failed to update and
     emails report
     """
-    # Avoids pydantic error if invoice_id is None (for already paid invoices)
-    if invoice_id is None:
-        return
-
     devs_to_email_addr = Variable.get("EMAIL_DEVS")
     sul_to_email_addr = Variable.get("ORAFIN_TO_EMAIL_SUL")
     law_to_email_addr = Variable.get("ORAFIN_TO_EMAIL_LAW")

--- a/libsys_airflow/plugins/orafin/models.py
+++ b/libsys_airflow/plugins/orafin/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, UTC
 
 import numpy as np
 import pandas as pd
@@ -402,7 +402,7 @@ class FeederFile:
         raw_file += "".join(
             [
                 self.trailer_number,
-                f"""TR{datetime.utcnow().strftime("%Y%m%d")}""",
+                f"""TR{datetime.now(UTC).strftime("%Y%m%d")}""",
                 str(self.number_of_invoices),
                 f"{self.batch_total_amount:015.2f}",
             ]

--- a/libsys_airflow/plugins/orafin/reports.py
+++ b/libsys_airflow/plugins/orafin/reports.py
@@ -222,9 +222,10 @@ def update_invoice(invoice: dict, folio_client: FolioClient) -> Union[dict, bool
     try:
         folio_client.folio_put(f"/invoice/invoices/{invoice['id']}", invoice)
         logger.info(f"Updated {invoice['id']} to status of Paid")
-    except httpx.HTTPError:
+        return invoice
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to update invoice {invoice['id']}: {e}")
         return False
-    return invoice
 
 
 def update_voucher(

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -94,6 +94,9 @@ def email_summary_task(invoices: list):
 def email_invoice_errors_task(ti=None):
     folio_url = Variable.get("FOLIO_URL")
     invoice_id = ti.xcom_pull(task_ids="update_invoices_task")
+    if invoice_id is None:
+        return "No invoice ID to email about"
+
     generate_invoice_error_email(invoice_id, folio_url, ti)
     return f"Emailed Error for Invoice {invoice_id}"
 

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -61,7 +61,7 @@ def consolidate_reports_task(ti=None):
     return all_files
 
 
-@task(trigger_rule='none_failed')
+@task(trigger_rule="none_failed_min_one_success")
 def email_errors_task(ti=None):
     folio_url = Variable.get("FOLIO_URL")
     total_errors = generate_ap_error_report_email(folio_url, ti)
@@ -76,7 +76,7 @@ def email_excluded_task(invoices_exclusion_reasons: list):
     return f"Emailed report for {len(invoices_exclusion_reasons):,} invoices"
 
 
-@task(trigger_rule='none_failed')
+@task(trigger_rule="none_failed_min_one_success")
 def email_paid_task(ti=None):
     folio_url = Variable.get("FOLIO_URL")
     total_invoices = generate_ap_paid_report_email(folio_url, ti)

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -93,10 +93,17 @@ def email_summary_task(invoices: list):
 @task
 def email_invoice_errors_task(ti=None):
     folio_url = Variable.get("FOLIO_URL")
-    invoice_id = ti.xcom_pull(task_ids="update_invoices_task")
-    if invoice_id is None:
-        return "No invoice ID to email about"
+    # Pull from the mapped task using map_index
+    update_result = ti.xcom_pull(
+        task_ids="update-folio.update_invoices_task", map_indexes=ti.map_index
+    )
+    if update_result is None or update_result is False:
+        logger.warning(
+            f"No valid invoice to email about, update_result: {update_result}"
+        )
+        return "Skipped - no invoice to email about"
 
+    invoice_id = update_result
     generate_invoice_error_email(invoice_id, folio_url, ti)
     return f"Emailed Error for Invoice {invoice_id}"
 
@@ -236,6 +243,7 @@ def update_invoices_task(invoice: dict):
         return invoice['id']  # Update succeeded
     else:
         logger.error("Invoice is None")
+        return None
 
 
 @task.branch()

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -230,8 +230,10 @@ def update_invoices_task(invoice: dict):
     if invoice:
         folio_client = _folio_client()
         logger.info(f"Updating Invoice {invoice['id']}")
-        update_invoice(invoice, folio_client)
-        return invoice['id']
+        result = update_invoice(invoice, folio_client)
+        if result is False:
+            return False  # Update failed
+        return invoice['id']  # Update succeeded
     else:
         logger.error("Invoice is None")
 

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -91,21 +91,21 @@ def email_summary_task(invoices: list):
 
 
 @task
-def email_invoice_errors_task(ti=None):
+def email_invoice_errors_task(invoice=None, ti=None):
     folio_url = Variable.get("FOLIO_URL")
     # Pull from the mapped task using map_index
     update_result = ti.xcom_pull(
         task_ids="update-folio.update_invoices_task", map_indexes=ti.map_index
     )
-    if update_result is None or update_result is False:
-        logger.warning(
-            f"No valid invoice to email about, update_result: {update_result}"
-        )
-        return "Skipped - no invoice to email about"
+    # Send error email if update_result is False
+    if update_result is False:
+        if invoice and invoice.get("id"):
+            invoice_id = invoice["id"]
+            generate_invoice_error_email(invoice_id, folio_url, ti)
+            return f"Emailed Error for Invoice {invoice_id}"
 
-    invoice_id = update_result
-    generate_invoice_error_email(invoice_id, folio_url, ti)
-    return f"Emailed Error for Invoice {invoice_id}"
+    logger.info(f"No error to email - update_result: {update_result}")
+    return "Skipped - no error to report"
 
 
 @task

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -241,7 +241,7 @@ def update_invoices_task(invoice: dict):
 @task.branch()
 def update_email_branch(update_result):
     if update_result is False:
-        return "update-folio.email_invoice_errors"
+        return "update-folio.email_invoice_errors_task"
     return "update-folio.retrieve_voucher_task"
 
 

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -245,7 +245,7 @@ def update_email_branch(update_result):
     return "update-folio.retrieve_voucher_task"
 
 
-@task
+@task(trigger_rule="none_failed_min_one_success")
 def update_vouchers_task(ti=None):
     voucher = ti.xcom_pull(
         task_ids="update-folio.retrieve_voucher_task", map_indexes=ti.map_index

--- a/tests/orafin/test_ap_reports.py
+++ b/tests/orafin/test_ap_reports.py
@@ -308,10 +308,14 @@ def test_update_invoice(mock_folio_client, caplog):
     assert invoice["status"] == "Paid"
 
 
-def test_update_invoice_failure(mock_folio_client):
+def test_update_invoice_failure(mock_folio_client, caplog):
     invoice = {"id": "b13c879f-7f5e-49e6-a522-abf04f66fa1b"}
     invoice_update_result = update_invoice(invoice, mock_folio_client)
 
+    assert (
+        "Failed to update invoice b13c879f-7f5e-49e6-a522-abf04f66fa1b: Internal Server Error"
+        in caplog.text
+    )
     assert invoice_update_result is False
 
 

--- a/tests/orafin/test_generated_emails.py
+++ b/tests/orafin/test_generated_emails.py
@@ -296,98 +296,17 @@ def test_generate_ap_paid_report_email(mocker):
     assert "031134FEEDER" not in li.find("a").text
 
 
-def test_generate_ap_paid_report_email_with_none_values(mocker):
-    """Test that None values from paid invoices are filtered out"""
-
-    def _paid_xcom_pull(**kwargs):
-        task_ids = kwargs["task_ids"]
-        if task_ids.startswith("init_processing_task"):
-            return "/opt/airflow/orafin-data/reports/xxdl_ap_payment_09282023161640.csv"
-        if task_ids.startswith("retrieve_invoice_task"):
-            # Simulates mapped tasks where some returned None (paid invoices)
-            return [
-                None,  # Paid invoice
-                None,  # Paid invoice
-                {
-                    "id": "9cf2899a-c7a6-4101-bf8e-c5996ded5fd1",
-                    "vendorInvoiceNo": "23-24364",
-                    "acqUnitIds": ["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
-                    "accountingCode": "031134FEEDER",
-                },
-                None,  # Paid invoice
-                {
-                    "id": "de3eabab-94c8-4616-9192-7f7b1483e157",
-                    "vendorInvoiceNo": "56-23478",
-                    "acqUnitIds": ["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
-                    "accountingCode": "071724FEEDER",
-                },
-                None,  # Paid invoice
-            ]
-
-    mock_send_email = mocker.patch(
-        "libsys_airflow.plugins.orafin.emails.send_email_with_server_name"
-    )
-
-    mocker.patch(
-        "libsys_airflow.plugins.orafin.emails.Variable.get",
-        return_value="test@stanford.edu",
-    )
-
-    task_instance = mocker.MagicMock()
-    task_instance.xcom_pull = _paid_xcom_pull
-
-    total_invoices = generate_ap_paid_report_email(
-        "http://folio.stanford.edu", task_instance
-    )
-
-    assert total_invoices == 2
-    assert mock_send_email.called
-
-    html_body = BeautifulSoup(
-        mock_send_email.call_args[1]['html_content'], 'html.parser'
-    )
-
-    paragraph = html_body.find("p")
-    assert paragraph.text == "From ap report xxdl_ap_payment_09282023161640.csv"
-
-    li = html_body.find("li")
-    assert li.find("a").text == "Vendor Invoice Number: 23-24364"
-
-
-def test_generate_ap_paid_report_email_all_none(mocker):
-    """Test when all mapped tasks return None (all invoices were paid)"""
-
-    def _mock_xcom_pull(**kwargs):
-        task_ids = kwargs["task_ids"]
-        if task_ids.startswith("init_processing_task"):
-            return "/opt/airflow/orafin-data/reports/xxdl_ap_payment.csv"
-        if task_ids.startswith("retrieve_invoice_task"):
-            return [None, None, None, None]  # All paid invoices
-
-    mocker.patch(
-        "libsys_airflow.plugins.orafin.emails.Variable.get",
-        return_value="test@stanford.edu",
-    )
-
-    task_instance = mocker.MagicMock()
-    task_instance.xcom_pull = _mock_xcom_pull
-
-    total_invoices = generate_ap_paid_report_email(
-        "http://folio.stanford.edu", task_instance
-    )
-
-    assert total_invoices == 0
-
-
 def test_generate_ap_paid_report_email_no_invoices(mocker):
-    """Test when retrieve_invoice_task returns None (no mapped tasks)"""
-
     def _mock_xcom_pull(**kwargs):
         task_ids = kwargs["task_ids"]
-        if task_ids.startswith("init_processing_task"):
-            return "/opt/airflow/orafin-data/reports/xxdl_ap_payment.csv"
-        if task_ids.startswith("retrieve_invoice_task"):
-            return None
+        match task_ids:
+            case "init_processing_task":
+                return "/opt/airflow/orafin-data/reports/xxdl_ap_payment.csv"
+
+            case _:
+                return None
+
+    mocker.patch("libsys_airflow.plugins.orafin.emails.send_email_with_server_name")
 
     mocker.patch(
         "libsys_airflow.plugins.orafin.emails.Variable.get",
@@ -470,9 +389,9 @@ def test_generate_excluded_email(mocker):
 
     html_body = BeautifulSoup(sul_call[0][2]['html_content'], 'html.parser')
 
-    found_h2s = html_body.find_all("h2")
+    found_h2s = html_body.findAll("h2")
     assert found_h2s[0].text == "Amount split"
-    list_items = html_body.find_all("li")
+    list_items = html_body.findAll("li")
     assert "Vendor Invoice Number: 242428ZP1" in list_items[0].text
     anchor = html_body.find("a")
     assert anchor.text == "Invoice line number: 1"
@@ -560,9 +479,9 @@ def test_generate_invoice_error_email(mocker):
 
     assert html_body.find("a").text == invoice_uuid
 
-    table_rows = html_body.find_all("tr")
+    table_rows = html_body.findAll("tr")
 
-    ap_report_row_tds = table_rows[1].find_all("td")
+    ap_report_row_tds = table_rows[1].findAll("td")
 
     assert ap_report_row_tds[0].text == "3500"
     assert ap_report_row_tds[1].text == "2402586"
@@ -599,7 +518,7 @@ def test_generate_summary_email(mocker):
     )
 
     assert html_body.find("h2").text == "Approved Invoices Sent to AP"
-    list_items = html_body.find_all("li")
+    list_items = html_body.findAll("li")
     assert "Vendor Invoice Number: 242428ZP1" in list_items[0].text
     anchor = html_body.find("a")
     assert anchor.text == "Vendor Invoice Number: 242428ZP1"

--- a/tests/orafin/test_generated_emails.py
+++ b/tests/orafin/test_generated_emails.py
@@ -389,9 +389,9 @@ def test_generate_excluded_email(mocker):
 
     html_body = BeautifulSoup(sul_call[0][2]['html_content'], 'html.parser')
 
-    found_h2s = html_body.findAll("h2")
+    found_h2s = html_body.find_all("h2")
     assert found_h2s[0].text == "Amount split"
-    list_items = html_body.findAll("li")
+    list_items = html_body.find_all("li")
     assert "Vendor Invoice Number: 242428ZP1" in list_items[0].text
     anchor = html_body.find("a")
     assert anchor.text == "Invoice line number: 1"
@@ -479,9 +479,9 @@ def test_generate_invoice_error_email(mocker):
 
     assert html_body.find("a").text == invoice_uuid
 
-    table_rows = html_body.findAll("tr")
+    table_rows = html_body.find_all("tr")
 
-    ap_report_row_tds = table_rows[1].findAll("td")
+    ap_report_row_tds = table_rows[1].find_all("td")
 
     assert ap_report_row_tds[0].text == "3500"
     assert ap_report_row_tds[1].text == "2402586"
@@ -518,7 +518,7 @@ def test_generate_summary_email(mocker):
     )
 
     assert html_body.find("h2").text == "Approved Invoices Sent to AP"
-    list_items = html_body.findAll("li")
+    list_items = html_body.find_all("li")
     assert "Vendor Invoice Number: 242428ZP1" in list_items[0].text
     anchor = html_body.find("a")
     assert anchor.text == "Vendor Invoice Number: 242428ZP1"

--- a/tests/orafin/test_generated_emails.py
+++ b/tests/orafin/test_generated_emails.py
@@ -251,12 +251,14 @@ def test_generate_ap_paid_report_email(mocker):
             return "/opt/airflow/orafin-data/reports/xxdl_ap_payment_09282023161640.csv"
         if task_ids.startswith("retrieve_invoice_task"):
             return [
+                None,  # mapped tasks where some returned None (paid invoices)
                 {
                     "id": "9cf2899a-c7a6-4101-bf8e-c5996ded5fd1",
                     "vendorInvoiceNo": "23-24364",
                     "acqUnitIds": ["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
                     "accountingCode": "031134FEEDER",
                 },
+                None,
                 {
                     "id": "de3eabab-94c8-4616-9192-7f7b1483e157",
                     "vendorInvoiceNo": "56-23478",

--- a/tests/orafin/test_generated_emails.py
+++ b/tests/orafin/test_generated_emails.py
@@ -296,17 +296,98 @@ def test_generate_ap_paid_report_email(mocker):
     assert "031134FEEDER" not in li.find("a").text
 
 
-def test_generate_ap_paid_report_email_no_invoices(mocker):
+def test_generate_ap_paid_report_email_with_none_values(mocker):
+    """Test that None values from paid invoices are filtered out"""
+
+    def _paid_xcom_pull(**kwargs):
+        task_ids = kwargs["task_ids"]
+        if task_ids.startswith("init_processing_task"):
+            return "/opt/airflow/orafin-data/reports/xxdl_ap_payment_09282023161640.csv"
+        if task_ids.startswith("retrieve_invoice_task"):
+            # Simulates mapped tasks where some returned None (paid invoices)
+            return [
+                None,  # Paid invoice
+                None,  # Paid invoice
+                {
+                    "id": "9cf2899a-c7a6-4101-bf8e-c5996ded5fd1",
+                    "vendorInvoiceNo": "23-24364",
+                    "acqUnitIds": ["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
+                    "accountingCode": "031134FEEDER",
+                },
+                None,  # Paid invoice
+                {
+                    "id": "de3eabab-94c8-4616-9192-7f7b1483e157",
+                    "vendorInvoiceNo": "56-23478",
+                    "acqUnitIds": ["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
+                    "accountingCode": "071724FEEDER",
+                },
+                None,  # Paid invoice
+            ]
+
+    mock_send_email = mocker.patch(
+        "libsys_airflow.plugins.orafin.emails.send_email_with_server_name"
+    )
+
+    mocker.patch(
+        "libsys_airflow.plugins.orafin.emails.Variable.get",
+        return_value="test@stanford.edu",
+    )
+
+    task_instance = mocker.MagicMock()
+    task_instance.xcom_pull = _paid_xcom_pull
+
+    total_invoices = generate_ap_paid_report_email(
+        "http://folio.stanford.edu", task_instance
+    )
+
+    assert total_invoices == 2
+    assert mock_send_email.called
+
+    html_body = BeautifulSoup(
+        mock_send_email.call_args[1]['html_content'], 'html.parser'
+    )
+
+    paragraph = html_body.find("p")
+    assert paragraph.text == "From ap report xxdl_ap_payment_09282023161640.csv"
+
+    li = html_body.find("li")
+    assert li.find("a").text == "Vendor Invoice Number: 23-24364"
+
+
+def test_generate_ap_paid_report_email_all_none(mocker):
+    """Test when all mapped tasks return None (all invoices were paid)"""
+
     def _mock_xcom_pull(**kwargs):
         task_ids = kwargs["task_ids"]
-        match task_ids:
-            case "init_processing_task":
-                return "/opt/airflow/orafin-data/reports/xxdl_ap_payment.csv"
+        if task_ids.startswith("init_processing_task"):
+            return "/opt/airflow/orafin-data/reports/xxdl_ap_payment.csv"
+        if task_ids.startswith("retrieve_invoice_task"):
+            return [None, None, None, None]  # All paid invoices
 
-            case _:
-                return None
+    mocker.patch(
+        "libsys_airflow.plugins.orafin.emails.Variable.get",
+        return_value="test@stanford.edu",
+    )
 
-    mocker.patch("libsys_airflow.plugins.orafin.emails.send_email_with_server_name")
+    task_instance = mocker.MagicMock()
+    task_instance.xcom_pull = _mock_xcom_pull
+
+    total_invoices = generate_ap_paid_report_email(
+        "http://folio.stanford.edu", task_instance
+    )
+
+    assert total_invoices == 0
+
+
+def test_generate_ap_paid_report_email_no_invoices(mocker):
+    """Test when retrieve_invoice_task returns None (no mapped tasks)"""
+
+    def _mock_xcom_pull(**kwargs):
+        task_ids = kwargs["task_ids"]
+        if task_ids.startswith("init_processing_task"):
+            return "/opt/airflow/orafin-data/reports/xxdl_ap_payment.csv"
+        if task_ids.startswith("retrieve_invoice_task"):
+            return None
 
     mocker.patch(
         "libsys_airflow.plugins.orafin.emails.Variable.get",
@@ -389,9 +470,9 @@ def test_generate_excluded_email(mocker):
 
     html_body = BeautifulSoup(sul_call[0][2]['html_content'], 'html.parser')
 
-    found_h2s = html_body.findAll("h2")
+    found_h2s = html_body.find_all("h2")
     assert found_h2s[0].text == "Amount split"
-    list_items = html_body.findAll("li")
+    list_items = html_body.find_all("li")
     assert "Vendor Invoice Number: 242428ZP1" in list_items[0].text
     anchor = html_body.find("a")
     assert anchor.text == "Invoice line number: 1"
@@ -479,9 +560,9 @@ def test_generate_invoice_error_email(mocker):
 
     assert html_body.find("a").text == invoice_uuid
 
-    table_rows = html_body.findAll("tr")
+    table_rows = html_body.find_all("tr")
 
-    ap_report_row_tds = table_rows[1].findAll("td")
+    ap_report_row_tds = table_rows[1].find_all("td")
 
     assert ap_report_row_tds[0].text == "3500"
     assert ap_report_row_tds[1].text == "2402586"
@@ -518,7 +599,7 @@ def test_generate_summary_email(mocker):
     )
 
     assert html_body.find("h2").text == "Approved Invoices Sent to AP"
-    list_items = html_body.findAll("li")
+    list_items = html_body.find_all("li")
     assert "Vendor Invoice Number: 242428ZP1" in list_items[0].text
     anchor = html_body.find("a")
     assert anchor.text == "Vendor Invoice Number: 242428ZP1"

--- a/tests/orafin/test_models.py
+++ b/tests/orafin/test_models.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, UTC
 import uuid
 
 import pytest  # noqa
@@ -110,7 +110,7 @@ def mock_invoice():
         acqUnitIds=["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
         fiscalYearId="e9c45170-2eb3-4207-a1c8-39a51e8b9dd0",
         folioInvoiceNo="10592",
-        invoiceDate=datetime.datetime(2023, 7, 12),
+        invoiceDate=datetime(2023, 7, 12),
         lines=[
             InvoiceLine(
                 id="b26f45bd-aa92-471d-9aa9-a27d5f520a78",
@@ -238,7 +238,7 @@ def test_expense_codes(mock_folio_client):
 
     invoice = Invoice(
         id="abcdefa",
-        invoiceDate=datetime.datetime(2023, 6, 28),
+        invoiceDate=datetime(2023, 6, 28),
         fiscalYearId="e9c45170-2eb3-4207-a1c8-39a51e8b9dd0",
         folioInvoiceNo="12356",
         accountingCode="4567",
@@ -412,7 +412,7 @@ def test_invoice_header_reconcile_amount():
         accountingCode='011033FEEDER',
         id='b88cc4cf-ba1e-4355-9f28-94ef624e7d14',
         acqUnitIds=["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
-        invoiceDate=datetime.datetime(2023, 9, 22),
+        invoiceDate=datetime(2023, 9, 22),
         fiscalYearId="e9c45170-2eb3-4207-a1c8-39a51e8b9dd0",
         folioInvoiceNo='12265',
         subTotal=53790.0,
@@ -675,7 +675,7 @@ def test_attachment_flag(mock_invoice):
 
 def test_terms_name(mock_invoice):
     assert mock_invoice.terms_name == "N30"
-    mock_invoice.paymentDue = datetime.datetime(2023, 7, 13)
+    mock_invoice.paymentDue = datetime(2023, 7, 13)
     assert mock_invoice.terms_name == "IMMEDIATE"
 
 
@@ -833,7 +833,7 @@ def test_feeder_file(mock_invoice, mock_folio_client):
 
     raw_feeder_file = feeder_file.generate()
 
-    current_date_str = datetime.datetime.utcnow().strftime("%Y%m%d")
+    current_date_str = datetime.now(UTC).strftime("%Y%m%d")
     last_line = f"LIB9999999999TR{current_date_str}2000000001516.83"
 
     assert raw_feeder_file.splitlines()[-1] == last_line
@@ -950,7 +950,7 @@ yen_invoice = Invoice(
     currency='JPY',
     exchangeRate=0.006678211586901763,
     fiscalYearId="e9c45170-2eb3-4207-a1c8-39a51e8b9dd0",
-    invoiceDate=datetime.datetime(2023, 10, 2),
+    invoiceDate=datetime(2023, 10, 2),
     subTotal=11200.0,
     total=12085.0,
     folioInvoiceNo='11110',

--- a/tests/orafin/test_payments.py
+++ b/tests/orafin/test_payments.py
@@ -370,12 +370,16 @@ def mock_sftp_hook(mocker):
     return mock_hook
 
 
-def test_transfer_to_orafin(mock_sftp_hook, tmp_path, caplog):
+def test_transfer_to_orafin(mock_sftp_hook, mocker, tmp_path, caplog):
     feeder_file_path = tmp_path / "feeder20210823_202309240000"
     feeder_file_path.write_text(
         """LIB376992    HD006169FEEDER         23-13094 376992                         20230503000000000385.52DR                              N30
 LIB376992    DR000000000023.95USE_CA              1065087-101-AALIB-53245
 LIB376992    TX000000000002.19USE_CA              1065087-101-AALIB-53245"""
+    )
+    mocker.patch(
+        "libsys_airflow.plugins.orafin.payments.is_production",
+        return_value=0
     )
     transfer_to_orafin(str(feeder_file_path))
 

--- a/tests/orafin/test_payments.py
+++ b/tests/orafin/test_payments.py
@@ -377,10 +377,7 @@ def test_transfer_to_orafin(mock_sftp_hook, mocker, tmp_path, caplog):
 LIB376992    DR000000000023.95USE_CA              1065087-101-AALIB-53245
 LIB376992    TX000000000002.19USE_CA              1065087-101-AALIB-53245"""
     )
-    mocker.patch(
-        "libsys_airflow.plugins.orafin.payments.is_production",
-        return_value=0
-    )
+    mocker.patch("libsys_airflow.plugins.orafin.payments.is_production", return_value=0)
     transfer_to_orafin(str(feeder_file_path))
 
     assert feeder_file_path.exists()

--- a/tests/orafin/test_payments.py
+++ b/tests/orafin/test_payments.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import pytest  # noqa
 
 from unittest.mock import MagicMock
@@ -269,7 +269,7 @@ def test_get_invoice(mock_folio_client):
     assert invoice.amount == invoice.total
     invoice.total = -100.00
     assert invoice.invoice_type == "CR"
-    invoice.paymentDue = datetime.utcnow()
+    invoice.paymentDue = datetime.now(UTC)
     assert invoice.terms_name == "IMMEDIATE"
     assert invoice.lines[0].tax_code(True) == "SALES_STANDARD"
     invoice.lines[0].adjustmentsTotal = 0.0


### PR DESCRIPTION
Fixes #1777 

The problem here is that the generate_invoice_error_email is using the XCOM from the retrieve_invoice_task. When the invoice is already paid, the retrieve_invoice_task's return_value is None (invoice_id), and a key "paid" with value a row from the report. So for the test dag run in dev-up, all but one of the retrieve_invoice_task mapped tasks returned None for invoice_id b/c they were paid, and one returned the invoice_id. Since the branching is in a task group, the email_invoice_errors_tasks is getting triggered for the 8 invoices that were already paid and returned None for invoice_id. It gets skipped for the one mapped task that has an unpaid invoice but errors for the 8 where generate_invoice_error_email expects invoice_id to be a string and not None.