### PR TITLE
Fixes edge case errors when re-running ap_payment_report dag with already-processed report

### DIFF
--- a/libsys_airflow/plugins/orafin/emails.py
+++ b/libsys_airflow/plugins/orafin/emails.py
@@ -191,12 +191,15 @@ def _group_excluded_invoices(invoices_reasons: list):
     return grouped_acqunits
 
 
-def _group_invoices_by_acqunit(invoices: Union[list, None]) -> dict:
+def _group_invoices_by_acqunit(invoices: Union[dict, list, None]) -> dict:
     """
     Groups invoices by acq unit ID
     """
     grouped_acqunits: dict = {}
     if invoices:
+        if isinstance(invoices, dict):
+            invoices = [invoices]
+
         for row in invoices:
             acq_unit = row["acqUnitIds"][0]
             if acq_unit in grouped_acqunits:
@@ -391,10 +394,6 @@ def generate_ap_paid_report_email(folio_url: str, task_instance=None):
     """
     ap_report_path = task_instance.xcom_pull(task_ids="init_processing_task")
     invoices = task_instance.xcom_pull(task_ids="retrieve_invoice_task")
-    # Filter out None values - these are already-paid and reported in email_errors_task
-    if invoices:
-        invoices = [inv for inv in invoices if inv is not None]
-
     ap_report_name = pathlib.Path(ap_report_path).name
     grouped_invoices = _group_invoices_by_acqunit(invoices)
     devs_to_email_addr = Variable.get("EMAIL_DEVS")

--- a/libsys_airflow/plugins/orafin/emails.py
+++ b/libsys_airflow/plugins/orafin/emails.py
@@ -391,6 +391,10 @@ def generate_ap_paid_report_email(folio_url: str, task_instance=None):
     """
     ap_report_path = task_instance.xcom_pull(task_ids="init_processing_task")
     invoices = task_instance.xcom_pull(task_ids="retrieve_invoice_task")
+    # Filter out None values - these are already-paid and reported in email_errors_task
+    if invoices:
+        invoices = [inv for inv in invoices if inv is not None]
+
     ap_report_name = pathlib.Path(ap_report_path).name
     grouped_invoices = _group_invoices_by_acqunit(invoices)
     devs_to_email_addr = Variable.get("EMAIL_DEVS")

--- a/libsys_airflow/plugins/orafin/models.py
+++ b/libsys_airflow/plugins/orafin/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, UTC
 
 import numpy as np
 import pandas as pd
@@ -402,7 +402,7 @@ class FeederFile:
         raw_file += "".join(
             [
                 self.trailer_number,
-                f"""TR{datetime.utcnow().strftime("%Y%m%d")}""",
+                f"""TR{datetime.now(UTC).strftime("%Y%m%d")}""",
                 str(self.number_of_invoices),
                 f"{self.batch_total_amount:015.2f}",
             ]

--- a/libsys_airflow/plugins/orafin/reports.py
+++ b/libsys_airflow/plugins/orafin/reports.py
@@ -222,9 +222,10 @@ def update_invoice(invoice: dict, folio_client: FolioClient) -> Union[dict, bool
     try:
         folio_client.folio_put(f"/invoice/invoices/{invoice['id']}", invoice)
         logger.info(f"Updated {invoice['id']} to status of Paid")
-    except httpx.HTTPError:
+        return invoice
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to update invoice {invoice['id']}: {e}")
         return False
-    return invoice
 
 
 def update_voucher(

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -93,7 +93,10 @@ def email_summary_task(invoices: list):
 @task
 def email_invoice_errors_task(ti=None):
     folio_url = Variable.get("FOLIO_URL")
-    invoice_id = ti.xcom_pull(task_ids="update_invoices_task")
+    # Pull from the mapped task using map_index
+    invoice_id = ti.xcom_pull(
+        task_ids="update-folio.update_invoices_task", map_indexes=ti.map_index
+    )
     generate_invoice_error_email(invoice_id, folio_url, ti)
     return f"Emailed Error for Invoice {invoice_id}"
 

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -236,7 +236,7 @@ def update_invoices_task(invoice: dict):
 @task.branch()
 def update_email_branch(update_result):
     if update_result is False:
-        return "update-folio.email_invoice_errors"
+        return "update-folio.email_invoice_errors_task"
     return "update-folio.retrieve_voucher_task"
 
 

--- a/tests/orafin/test_ap_reports.py
+++ b/tests/orafin/test_ap_reports.py
@@ -308,10 +308,14 @@ def test_update_invoice(mock_folio_client, caplog):
     assert invoice["status"] == "Paid"
 
 
-def test_update_invoice_failure(mock_folio_client):
+def test_update_invoice_failure(mock_folio_client, caplog):
     invoice = {"id": "b13c879f-7f5e-49e6-a522-abf04f66fa1b"}
     invoice_update_result = update_invoice(invoice, mock_folio_client)
 
+    assert (
+        "Failed to update invoice b13c879f-7f5e-49e6-a522-abf04f66fa1b: Internal Server Error"
+        in caplog.text
+    )
     assert invoice_update_result is False
 
 

--- a/tests/orafin/test_generated_emails.py
+++ b/tests/orafin/test_generated_emails.py
@@ -389,9 +389,9 @@ def test_generate_excluded_email(mocker):
 
     html_body = BeautifulSoup(sul_call[0][2]['html_content'], 'html.parser')
 
-    found_h2s = html_body.findAll("h2")
+    found_h2s = html_body.find_all("h2")
     assert found_h2s[0].text == "Amount split"
-    list_items = html_body.findAll("li")
+    list_items = html_body.find_all("li")
     assert "Vendor Invoice Number: 242428ZP1" in list_items[0].text
     anchor = html_body.find("a")
     assert anchor.text == "Invoice line number: 1"
@@ -480,9 +480,9 @@ def test_generate_invoice_error_email(mocker):
 
     assert html_body.find("a").text == invoice_uuid
 
-    table_rows = html_body.findAll("tr")
+    table_rows = html_body.find_all("tr")
 
-    ap_report_row_tds = table_rows[1].findAll("td")
+    ap_report_row_tds = table_rows[1].find_all("td")
 
     assert ap_report_row_tds[0].text == "3500"
     assert ap_report_row_tds[1].text == "2402586"
@@ -519,7 +519,7 @@ def test_generate_summary_email(mocker):
     )
 
     assert html_body.find("h2").text == "Approved Invoices Sent to AP"
-    list_items = html_body.findAll("li")
+    list_items = html_body.find_all("li")
     assert "Vendor Invoice Number: 242428ZP1" in list_items[0].text
     anchor = html_body.find("a")
     assert anchor.text == "Vendor Invoice Number: 242428ZP1"

--- a/tests/orafin/test_generated_emails.py
+++ b/tests/orafin/test_generated_emails.py
@@ -251,12 +251,15 @@ def test_generate_ap_paid_report_email(mocker):
             return "/opt/airflow/orafin-data/reports/xxdl_ap_payment_09282023161640.csv"
         if task_ids.startswith("retrieve_invoice_task"):
             return [
+                None,  # already-paid invoices will return None in retrieve_invoice_task
                 {
                     "id": "9cf2899a-c7a6-4101-bf8e-c5996ded5fd1",
                     "vendorInvoiceNo": "23-24364",
                     "acqUnitIds": ["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
                     "accountingCode": "031134FEEDER",
                 },
+                None,
+                None,
                 {
                     "id": "de3eabab-94c8-4616-9192-7f7b1483e157",
                     "vendorInvoiceNo": "56-23478",

--- a/tests/orafin/test_generated_emails.py
+++ b/tests/orafin/test_generated_emails.py
@@ -10,6 +10,7 @@ from libsys_airflow.plugins.orafin.emails import (
     generate_failed_dag_email,
     generate_invoice_error_email,
     generate_summary_email,
+    _group_invoices_by_acqunit,
 )
 
 from test_payments import invoice_dict, invoice_lines, vendor
@@ -251,15 +252,12 @@ def test_generate_ap_paid_report_email(mocker):
             return "/opt/airflow/orafin-data/reports/xxdl_ap_payment_09282023161640.csv"
         if task_ids.startswith("retrieve_invoice_task"):
             return [
-                None,  # already-paid invoices will return None in retrieve_invoice_task
                 {
                     "id": "9cf2899a-c7a6-4101-bf8e-c5996ded5fd1",
                     "vendorInvoiceNo": "23-24364",
                     "acqUnitIds": ["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
                     "accountingCode": "031134FEEDER",
                 },
-                None,
-                None,
                 {
                     "id": "de3eabab-94c8-4616-9192-7f7b1483e157",
                     "vendorInvoiceNo": "56-23478",
@@ -297,6 +295,35 @@ def test_generate_ap_paid_report_email(mocker):
     li = html_body.find("li")
     assert li.find("a").text == "Vendor Invoice Number: 23-24364"
     assert "031134FEEDER" not in li.find("a").text
+
+
+def test_group_invoices_by_acqunit():
+    invoice = {
+        "id": "9cf2899a-c7a6-4101-bf8e-c5996ded5fd1",
+        "vendorInvoiceNo": "23-24364",
+        "acqUnitIds": ["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
+        "accountingCode": "031134FEEDER",
+    }
+
+    grouped_acqunits = _group_invoices_by_acqunit(invoice)
+    assert isinstance(grouped_acqunits["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"], list)
+
+    invoices = [
+        {
+            "id": "9cf2899a-c7a6-4101-bf8e-c5996ded5fd1",
+            "vendorInvoiceNo": "23-24364",
+            "acqUnitIds": ["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
+            "accountingCode": "031134FEEDER",
+        },
+        {
+            "id": "de3eabab-94c8-4616-9192-7f7b1483e157",
+            "vendorInvoiceNo": "56-23478",
+            "acqUnitIds": ["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
+            "accountingCode": "071724FEEDER",
+        },
+    ]
+    grouped_acqunits = _group_invoices_by_acqunit(invoices)
+    assert len(grouped_acqunits["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"]) == 2
 
 
 def test_generate_ap_paid_report_email_no_invoices(mocker):

--- a/tests/orafin/test_models.py
+++ b/tests/orafin/test_models.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, UTC
 import uuid
 
 import pytest  # noqa
@@ -110,7 +110,7 @@ def mock_invoice():
         acqUnitIds=["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
         fiscalYearId="e9c45170-2eb3-4207-a1c8-39a51e8b9dd0",
         folioInvoiceNo="10592",
-        invoiceDate=datetime.datetime(2023, 7, 12),
+        invoiceDate=datetime(2023, 7, 12),
         lines=[
             InvoiceLine(
                 id="b26f45bd-aa92-471d-9aa9-a27d5f520a78",
@@ -238,7 +238,7 @@ def test_expense_codes(mock_folio_client):
 
     invoice = Invoice(
         id="abcdefa",
-        invoiceDate=datetime.datetime(2023, 6, 28),
+        invoiceDate=datetime(2023, 6, 28),
         fiscalYearId="e9c45170-2eb3-4207-a1c8-39a51e8b9dd0",
         folioInvoiceNo="12356",
         accountingCode="4567",
@@ -412,7 +412,7 @@ def test_invoice_header_reconcile_amount():
         accountingCode='011033FEEDER',
         id='b88cc4cf-ba1e-4355-9f28-94ef624e7d14',
         acqUnitIds=["bd6c5f05-9ab3-41f7-8361-1c1e847196d3"],
-        invoiceDate=datetime.datetime(2023, 9, 22),
+        invoiceDate=datetime(2023, 9, 22),
         fiscalYearId="e9c45170-2eb3-4207-a1c8-39a51e8b9dd0",
         folioInvoiceNo='12265',
         subTotal=53790.0,
@@ -675,7 +675,7 @@ def test_attachment_flag(mock_invoice):
 
 def test_terms_name(mock_invoice):
     assert mock_invoice.terms_name == "N30"
-    mock_invoice.paymentDue = datetime.datetime(2023, 7, 13)
+    mock_invoice.paymentDue = datetime(2023, 7, 13)
     assert mock_invoice.terms_name == "IMMEDIATE"
 
 
@@ -833,7 +833,7 @@ def test_feeder_file(mock_invoice, mock_folio_client):
 
     raw_feeder_file = feeder_file.generate()
 
-    current_date_str = datetime.datetime.utcnow().strftime("%Y%m%d")
+    current_date_str = datetime.now(UTC).strftime("%Y%m%d")
     last_line = f"LIB9999999999TR{current_date_str}2000000001516.83"
 
     assert raw_feeder_file.splitlines()[-1] == last_line
@@ -950,7 +950,7 @@ yen_invoice = Invoice(
     currency='JPY',
     exchangeRate=0.006678211586901763,
     fiscalYearId="e9c45170-2eb3-4207-a1c8-39a51e8b9dd0",
-    invoiceDate=datetime.datetime(2023, 10, 2),
+    invoiceDate=datetime(2023, 10, 2),
     subTotal=11200.0,
     total=12085.0,
     folioInvoiceNo='11110',

--- a/tests/orafin/test_payments.py
+++ b/tests/orafin/test_payments.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import pytest  # noqa
 
 from unittest.mock import MagicMock
@@ -269,7 +269,7 @@ def test_get_invoice(mock_folio_client):
     assert invoice.amount == invoice.total
     invoice.total = -100.00
     assert invoice.invoice_type == "CR"
-    invoice.paymentDue = datetime.utcnow()
+    invoice.paymentDue = datetime.now(UTC)
     assert invoice.terms_name == "IMMEDIATE"
     assert invoice.lines[0].tax_code(True) == "SALES_STANDARD"
     invoice.lines[0].adjustmentsTotal = 0.0


### PR DESCRIPTION
Fixes #1777 

Re-running the ap_payment_report dag in folio-test, where stuff was already marked paid, revealed some edge cases to account for. Namely, when there are invoices already marked as paid in folio and one that needs to update (but the update actually fails), some tasks ended up failing. In [this dag run](https://sul-libsys-airflow-dev-up.stanford.edu/dags/ap_payment_report/runs/manual__2026-05-20T00:39:52.812953+00:00/tasks/email-group.email_paid_task?try_number=9), attempt 9 for email_paid_task, revealed that when there is only one invoice that gets sent through the dag, the xcom ends up being a dict and not a list, so that grouping invoices by acq unit fails with this error:
```
[2026-05-19 19:36:24] ERROR - Task failed with exception
TypeError: string indices must be integers, not 'str'
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1263 in run
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1678 in _execute_task
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/bases/operator.py", line 443 in wrapper
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/bases/decorator.py", line 398 in execute
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/bases/operator.py", line 443 in wrapper
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/standard/operators/python.py", line 227 in execute
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/standard/operators/python.py", line 250 in execute_callable
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/execution_time/callback_runner.py", line 97 in run
File "/opt/airflow/libsys_airflow/plugins/orafin/tasks.py", line 82 in email_paid_task
File "/opt/airflow/libsys_airflow/plugins/orafin/emails.py", line 396 in generate_ap_paid_report_email
File "/opt/airflow/libsys_airflow/plugins/orafin/emails.py", line 201 in _group_invoices_by_acqunit
```
I deployed this branch to dev-up and ran it again, end-to-end. Here is the link to the dag run: https://sul-libsys-airflow-dev-up.stanford.edu/dags/ap_payment_report/runs/manual__2026-05-20T02:41:11.132741+00:00/