### PR TITLE
Skips task when no missing barcodes and adjust trigger rule to account for skipped task.

### DIFF
--- a/libsys_airflow/dags/sdr/item_stat_codes.py
+++ b/libsys_airflow/dags/sdr/item_stat_codes.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import folioclient
 
 from airflow.sdk import dag, get_current_context, task, TriggerRule, Variable
+from airflow.sdk.exceptions import AirflowSkipException
 from airflow.providers.standard.operators.empty import EmptyOperator
 
 
@@ -110,9 +111,12 @@ def manage_sdr_stat_codes(**kwargs):
             map_indexes=None,
         )
 
+        if missing_barcode_files is None:
+            raise AirflowSkipException("No missing barcodes file - skipping task")
+
         concat_missing_barcodes(missing_barcode_files)
 
-    @task(trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
+    @task(trigger_rule=TriggerRule.NONE_FAILED)
     def remove_csv_file(**kwargs):
         task_instance = kwargs["ti"]
         csv_file = task_instance.xcom_pull(


### PR DESCRIPTION
Fixes #1793 

I did a hot fix on stage-up and ran the dag: https://sul-libsys-airflow-stage-up.stanford.edu/dags/manage_sdr_stat_codes/runs/manual__2026-05-21T19:15:19.204542+00:00/