### PR TITLE
Reverts commit to use -up servers in deploy script

### DIFF
--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'sul-libsys-airflow-dev-up.stanford.edu', user: fetch(:user).to_s, roles: %w[app]
+server 'sul-libsys-airflow-dev.stanford.edu', user: fetch(:user).to_s, roles: %w[app]
 
 # allow ssh to host
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'sul-libsys-airflow-prod-up.stanford.edu', user: fetch(:user).to_s, roles: %w[app]
+server 'sul-libsys-airflow-prod.stanford.edu', user: fetch(:user).to_s, roles: %w[app]
 
 # allow ssh to host
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'sul-libsys-airflow-stage-up.stanford.edu', user: fetch(:user).to_s, roles: %w[app]
+server 'sul-libsys-airflow-stage.stanford.edu', user: fetch(:user).to_s, roles: %w[app]
 
 # allow ssh to host
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
For our migration to Airflow 3, we are going to rebuild the dev/stage/prod app server VMs using the -up server specifications in puppet. Per our [checklist](https://docs.google.com/spreadsheets/d/1PqirXM0wyvXse75fZJGgDdcGAGrVfetCSP2KS-8_DlA/edit?usp=sharing) we are going to merge this PR when we start the work tomorrow.