### PR TITLE
ap_payment_report dag patches

### DIFF
--- a/libsys_airflow/plugins/orafin/reports.py
+++ b/libsys_airflow/plugins/orafin/reports.py
@@ -236,7 +236,7 @@ def update_voucher(
     """
     row = task_instance.xcom_pull(
         task_ids="retrieve_invoice_task", key=voucher["invoiceId"]
-    )[0]
+    )
     voucher["status"] = "Paid"  # should already be Paid when update_invoice task ran
     voucher["disbursementAmount"] = row["AmountPaid"]
     voucher["disbursementNumber"] = row["PaymentNumber"]

--- a/libsys_airflow/plugins/orafin/tasks.py
+++ b/libsys_airflow/plugins/orafin/tasks.py
@@ -2,6 +2,7 @@ import logging
 import pathlib
 
 from airflow.sdk import get_current_context, task, Variable
+from airflow.sdk.exceptions import AirflowSkipException
 from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
 
 from folioclient import FolioClient
@@ -94,11 +95,15 @@ def email_summary_task(invoices: list):
 def email_invoice_errors_task(ti=None):
     folio_url = Variable.get("FOLIO_URL")
     # Pull from the mapped task using map_index
-    invoice_id = ti.xcom_pull(
+    update_result = ti.xcom_pull(
         task_ids="update-folio.update_invoices_task", map_indexes=ti.map_index
     )
-    generate_invoice_error_email(invoice_id, folio_url, ti)
-    return f"Emailed Error for Invoice {invoice_id}"
+    if update_result and update_result.get("invoice_id"):
+        invoice_id = update_result["invoice_id"]
+        generate_invoice_error_email(invoice_id, folio_url, ti)
+        return f"Emailed Error for Invoice {invoice_id}"
+
+    return "No error to report"
 
 
 @task
@@ -195,9 +200,15 @@ def retrieve_voucher_task(ti=None):
     """
     Retrieves voucher based on invoice id
     """
-    invoice_id: str = ti.xcom_pull(
+    update_result = ti.xcom_pull(
         task_ids="update-folio.update_invoices_task", map_indexes=ti.map_index
     )
+    # Check if update failed
+    if update_result is False or update_result.get("status") == "failed":
+        logger.info(f"Skipping voucher retrieval - update result: {update_result}")
+        raise AirflowSkipException("Update did not succeed")
+
+    invoice_id = update_result["invoice_id"]
     folio_client = _folio_client()
     return retrieve_voucher(invoice_id, folio_client)
 
@@ -229,16 +240,20 @@ def transform_folio_data_task(invoice_id: str):
 def update_invoices_task(invoice: dict):
     if invoice:
         folio_client = _folio_client()
-        logger.info(f"Updating Invoice {invoice['id']}")
-        update_invoice(invoice, folio_client)
-        return invoice['id']
+        invoice_id = invoice["id"]
+        logger.info(f"Updating Invoice {invoice_id}")
+        result = update_invoice(invoice, folio_client)
+        if result is False:
+            return {"status": "failed", "invoice_id": invoice_id}
+        return {"status": "success", "invoice_id": invoice_id}
     else:
         logger.error("Invoice is None")
+        return None
 
 
 @task.branch()
 def update_email_branch(update_result):
-    if update_result is False:
+    if update_result and update_result.get("status") == "failed":
         return "update-folio.email_invoice_errors_task"
     return "update-folio.retrieve_voucher_task"
 

--- a/tests/orafin/test_ap_reports.py
+++ b/tests/orafin/test_ap_reports.py
@@ -321,14 +321,12 @@ def test_update_invoice_failure(mock_folio_client, caplog):
 
 def test_update_voucher(mocker, mock_folio_client, caplog):
     def _xcom_pull(*args, **kwargs):
-        return [
-            {
-                "AmountPaid": "2499.01",
-                "PaymentAmount": "2498.63",
-                "PaymentDate": "10/24/2023",
-                "PaymentNumber": "2983835",
-            }
-        ]
+        return {
+            "AmountPaid": "2499.01",
+            "PaymentAmount": "2498.63",
+            "PaymentDate": "10/24/2023",
+            "PaymentNumber": "2983835",
+        }
 
     mock_task_instance = mocker.MagicMock()
     mock_task_instance.xcom_pull = _xcom_pull
@@ -351,14 +349,12 @@ def test_update_voucher(mocker, mock_folio_client, caplog):
 
 def test_update_voucher_failed(mocker, mock_folio_client, caplog):
     def _xcom_pull(*args, **kwargs):
-        return [
-            {
-                "AmountPaid": "2499.01",
-                "PaymentAmount": "2498.63",
-                "PaymentDate": "10/24/2023",
-                "PaymentNumber": "2983835",
-            }
-        ]
+        return {
+            "AmountPaid": "2499.01",
+            "PaymentAmount": "2498.63",
+            "PaymentDate": "10/24/2023",
+            "PaymentNumber": "2983835",
+        }
 
     mock_task_instance = mocker.MagicMock()
     mock_task_instance.xcom_pull = _xcom_pull


### PR DESCRIPTION
The ap_payment_report dag run in prod after the upgrade failed because the XCOM for retrieve_invoice_task returns a dictionary and not a list. See task instance https://sul-libsys-airflow-prod.stanford.edu/dags/ap_payment_report/runs/manual__2026-06-01T19:05:17.395270+00:00/tasks/update-folio.update_vouchers_task/mapped/0?try_number=2

I did a "hotfix" on the server to remove the `[0]` list index and reran the tasks and they succeeded.
Another issue was that it also emailed that it failed to update the invoices to status = paid, but it actually didn't fail to update. I think the change in [commit](https://github.com/sul-dlss/libsys-airflow/commit/6832409992090abfa9049d2cf92a7fbf8174e8f2) by returning a dictionar or None will help. Running locally against folio-test, I get:
 
<img width="1260" height="485" alt="Screenshot 2026-06-01 at 5 56 44 PM" src="https://github.com/user-attachments/assets/a5c6bcfd-0a59-4479-94cc-51b5decf6f7e" />

Here is the dag run that shows the one invoice that failed to update went to the email_invoice_errors_task (which I marked succeeded b/c it was failing on airflow.utils.email.send_email from localhost) and the other tasks got marked skipped:
<img width="1176" height="342" alt="Screenshot 2026-06-01 at 6 52 46 PM" src="https://github.com/user-attachments/assets/251800d7-7697-4ef2-bf1f-be1dbdcca353" />
