### PR TITLE
Make full-dump vendor exclusion configurable

### DIFF
--- a/libsys_airflow/plugins/data_exports/marc/exporter.py
+++ b/libsys_airflow/plugins/data_exports/marc/exporter.py
@@ -155,14 +155,14 @@ class Exporter(object):
                 logger.warning(e)
                 continue
 
-            if self.exclude_marc_by_vendor(marc21, "full-dump"):
+            if self.exclude_marc_by_vendor(
+                marc21, Variable.get("FULL_DUMP_VENDOR", "full-dump")
+            ):
                 continue
 
             marc.append(marc21)
 
-        logger.info(
-            f"Saving {len(instance_ids)} marc records to {marc_filename} in bucket."
-        )
+        logger.info(f"Saving {len(marc)} marc records to {marc_filename} in bucket.")
         marc_file = self.write_marc(
             pathlib.Path(marc_filename), S3Path(full_dump_files), marc, "."
         )

--- a/tests/data_exports/test_full_dump_selections.py
+++ b/tests/data_exports/test_full_dump_selections.py
@@ -82,6 +82,7 @@ def mock_result_set():
     return [
         (
             'e53ba957-8a95-5a5d-a0b6-4e712b3cb9cc',
+            '"a1"',
             {
                 "fields": [
                     {
@@ -97,6 +98,7 @@ def mock_result_set():
         ),
         (
             'e53bac58-0efa-5a2a-bffb-fa44e1dd9ded',
+            '"a2"',
             {
                 "fields": [
                     {
@@ -112,6 +114,7 @@ def mock_result_set():
         ),
         (
             'e53bad8c-2a0c-58ce-b082-6a66f93ca238',
+            '"a3"',
             {
                 "fields": [
                     {
@@ -122,11 +125,12 @@ def mock_result_set():
                         }
                     }
                 ],
-                "leader": "01229cas a2200373 a 450",
+                "leader": "01229cas a2200373 a 4500",
             },
         ),
         (
             'c32aeaa2-4740-5a91-a839-38894720a8df',
+            '"a4"',
             {
                 "fields": [
                     {
@@ -137,11 +141,12 @@ def mock_result_set():
                         }
                     }
                 ],
-                "leader": "00760cam a2200241 i 450",
+                "leader": "00760cam a2200241 i 4500",
             },
         ),
         (
             'd3f5f06a-f5cc-5606-b30e-aa75b1fbbf8s',
+            '"a5"',
             {
                 "fields": [
                     {
@@ -157,6 +162,7 @@ def mock_result_set():
         ),
         (
             'd3f5f2b9-be10-5680-bf86-23abc0eb55fe',
+            '"a6"',
             {
                 "fields": [
                     {
@@ -263,6 +269,12 @@ def test_fetch_full_dump(
     mocker.patch(
         'libsys_airflow.plugins.data_exports.sql_pool.Connection.get',
         return_value=mock_airflow_connection,
+    )
+    mock_variable = mocker.patch(
+        "libsys_airflow.plugins.data_exports.marc.exporter.Variable"
+    )
+    mock_variable.get = lambda key, default=None: (
+        "full-dump" if key == "FULL_DUMP_VENDOR" else "test-bucket"
     )
 
     full_dump_marc.fetch_full_dump_marc(

--- a/tests/data_exports/test_marc_exports.py
+++ b/tests/data_exports/test_marc_exports.py
@@ -331,3 +331,37 @@ def test_exclude_marc_by_vendor_sharevde(mocker):
     marc_record.add_field(field_590, field_915)
 
     assert exporter.exclude_marc_by_vendor(marc_record, 'sharevde')
+
+
+def test_retrieve_marc_for_full_dump_vendor_none(mocker):
+    mocker.patch('libsys_airflow.plugins.data_exports.marc.exporter.folio_client')
+    mock_variable = mocker.patch(
+        'libsys_airflow.plugins.data_exports.marc.exporter.Variable'
+    )
+    mock_variable.get = lambda key, _: (
+        "none" if key == "FULL_DUMP_VENDOR" else "test-bucket"
+    )
+    mock_write = mocker.patch.object(
+        Exporter, 'write_marc', return_value='/test/0_1.mrc'
+    )
+
+    marc_json = {
+        "leader": "01509nam a2200361 a 4500",
+        "fields": [
+            {"001": "a123"},
+            {
+                "915": {
+                    "ind1": "1",
+                    "ind2": "0",
+                    "subfields": [{"a": "NO EXPORT"}, {"b": "FOR SU ONLY"}],
+                }
+            },
+        ],
+    }
+    instance_ids = [('uuid-1', '"hrid-1"', marc_json)]
+
+    exporter_instance = Exporter()
+    exporter_instance.retrieve_marc_for_full_dump("0_1.mrc", instance_ids)
+
+    _, _, written_records, _ = mock_write.call_args[0]
+    assert len(written_records) == 1


### PR DESCRIPTION
This will allow the full dump to exclude records as specified as any vendor (or no vendor) or "full-dump."  It would be possible to do skip the excludes by using a param, but this change touches fewer files and does not need to pass around any params.

- exporter.py line 158: Variable.get("FULL_DUMP_VENDOR", "full-dump") makes the vendor configurable — set to any unrecognized value to skip all exclusions
- exporter.py line 164: len(marc) instead of len(instance_ids) so the log reflects records actually written, not input count
- test_marc_exports.py: New test_retrieve_marc_for_full_dump_vendor_none exercises the full retrieve_marc_for_full_dump path with Variable mocked to return "none", confirming a 915-flagged record is not excluded
- test_full_dump_selections.py: Mock result set updated to 3-tuples (adding the hrid column[ the SQL now returns](https://github.com/sul-dlss/libsys-airflow/commit/5b2dd00a50965f59e1c12ca355a4d0726f7e9d32)), two invalid 23-char leaders fixed to 24, and Variable mock added to test_fetch_full_dump