### PR TITLE
Uses OKAPI_URL to figure _subject_with_server_name for email reports.

### DIFF
--- a/libsys_airflow/plugins/shared/utils.py
+++ b/libsys_airflow/plugins/shared/utils.py
@@ -81,11 +81,10 @@ def send_email_with_server_name(**kwargs):
 
 def _subject_with_server_name(**kwargs):
     subject = kwargs.get("subject")
-    folio_url = Variable.get("FOLIO_URL", "folio-test/stage")
+    folio_url = folio_name()
     if is_production():
         return subject
     else:
-        folio_url = re.sub('https?://', '', folio_url)
         return f"{folio_url} - {subject}"
 
 

--- a/tests/digital_bookplates/test_bookplates_emails.py
+++ b/tests/digital_bookplates/test_bookplates_emails.py
@@ -121,7 +121,7 @@ def test_bookplates_metadata_email(
 
     assert (
         mock_send_email.call_args[1]["subject"]
-        == "folio-test - Digital bookplates new and updated metadata"
+        == "Test - Digital bookplates new and updated metadata"
     )
 
     assert mock_send_email.call_args[1]["to"] == ["test@example.com"]

--- a/tests/encumbrances/test_fix_encumbrances_run.py
+++ b/tests/encumbrances/test_fix_encumbrances_run.py
@@ -79,7 +79,7 @@ def test_fix_encumbrances_email_subject(mock_folio_variables):
     from libsys_airflow.plugins.folio.encumbrances.email import subject
 
     subj = _subject_with_server_name(subject=subject(fy_code="SUL2024"))
-    assert subj == "okapi-test - Fix Encumbrances for SUL2024"
+    assert subj == "Test - Fix Encumbrances for SUL2024"
 
 
 def test_email_to(mocker, mock_folio_variables):

--- a/tests/shared/test_utils.py
+++ b/tests/shared/test_utils.py
@@ -286,3 +286,12 @@ def test_folio_name(mocker):
         return_value="https://okapi.edu/",
     )
     assert utils.folio_name() is None
+
+
+def test_subject_with_server_name(mocker):
+    mocker.patch(
+        "libsys_airflow.plugins.shared.utils.Variable.get",
+        return_value="https://folio-test-api.stanford.edu/",
+    )
+    email_subject = utils._subject_with_server_name(subject="Random email subject line")
+    assert email_subject == "Test - Random email subject line"


### PR DESCRIPTION
There was a bunch of confusion regarding which folio env the fix_encumbrances script ran against. (see [slack convo](https://stanfordlib.slack.com/archives/C02CWRMBMT8/p1782845674584149)). This updates the function `_subject_with_server_name` to use the OKAPI_URL to determine which folio env a dag run of whatever ran against. N.B. the subject lines will now be `"Test - <subject>"` instead of `"folio-test.stanford.edu - <subject>"` 