### PR TITLE
Shows form on page after submitting boundwith file.

### DIFF
--- a/libsys_airflow/plugins/boundwith/templates/boundwith/index.html
+++ b/libsys_airflow/plugins/boundwith/templates/boundwith/index.html
@@ -2,20 +2,20 @@
 
 {% block content %}
 <div>
-    <h2>Boundwith CSV Creator</h2>
     {% if run_id %}
     <div>
-        <p>
+        <h3>
             DAG add_bw_relationships triggered with
             <a href="/dags/add_bw_relationships/runs/{{ run_id }}">Run ID {{ run_id }}</a>
-        </p>
+        </h3>
         {% if user_email %}
         <p>
             Summary report will be emailed to {{ user_email }}.
         </p>
         {% endif %}
     </div>
-    {% else %}
+    {% endif %}
+    <h2>Boundwith CSV Creator</h2>
     <p>Create boundwith relationships for parts and principle.</p>
     <p class="help-block">CSV should include a row for the principle's barcode and holdings HRID (use part_holdings_hrid column for principle's holdings HRID).</p>
     <form enctype="multipart/form-data" method="POST" action="{{ url_for('BoundWithView.run_bw_creation') }}">
@@ -56,6 +56,5 @@
             </div>
         </div>
     </form>
-    {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #828 

After submitting a boundwith file, the page renders the form for another submission. This way, the user doesn't have to click on the back button to upload a new file.
<img width="1172" height="625" alt="Screenshot 2026-07-21 at 1 04 30 PM" src="https://github.com/user-attachments/assets/5456bc84-03cb-4435-be50-87942ea8eb3a" />
