### PR TITLE
Refactors FTPAdapter to use describe_directory FTPHook function.

### DIFF
--- a/libsys_airflow/plugins/vendor/download.py
+++ b/libsys_airflow/plugins/vendor/download.py
@@ -28,34 +28,71 @@ class FTPAdapter:
     def __init__(self, hook: FTPHook, remote_path: str):
         self.hook = hook
         self.remote_path = remote_path
-        self._filenames = hook.list_directory(remote_path)
+
+        try:
+            self._file_descriptions = hook.describe_directory(remote_path)
+            logger.info(f"Successfully used MLSD for {remote_path}")
+        except ftplib.error_perm as e:
+            logger.warning(f"MLSD not available for {remote_path}: {e}")
+            logger.info("Using fallback method (NLST + individual queries)")
+            self._file_descriptions = self._build_descriptions_from_list()
+
+    def _build_descriptions_from_list(self) -> dict:
+        """Fallback method when MLSD is not available."""
+        filenames = self.hook.list_directory(self.remote_path)
+        descriptions = {}
+
+        # Set binary mode once for all size queries
+        try:
+            self.hook.conn.sendcmd("TYPE I")  # type: ignore
+        except Exception as e:
+            logger.warning(f"Failed to set binary mode: {e}")
+
+        for filename in filenames:
+            # Normalize the path - handle both cases
+            if filename.startswith(self.remote_path):
+                full_path = filename
+                base_filename = filename.replace(f"{self.remote_path}/", "")
+            else:
+                full_path = f"{self.remote_path}/{filename}"
+                base_filename = filename
+            # Get modification time
+            try:
+                mod_time = self.hook.get_mod_time(full_path)
+                modify_str = mod_time.strftime("%Y%m%d%H%M%S")
+            except ftplib.error_perm as e:
+                logger.warning(f"Failed to get modification time for {full_path}: {e}")
+                modify_str = "19700101000000"
+
+            # Get size
+            try:
+                size = self.hook.get_size(full_path)
+                size_str = str(size) if size is not None else "0"
+            except ftplib.error_perm as e:
+                logger.warning(f"Failed to get size for {full_path}: {e}")
+                size_str = "0"
+
+            descriptions[base_filename] = {
+                "modify": modify_str,
+                "size": size_str,
+                "type": "file",
+            }
+
+        return descriptions
 
     def list_directory(self) -> list[str]:
-        return self._filenames
+        return list(self._file_descriptions.keys())
 
     def get_mod_time(self, filename: str) -> str:
-        try:
-            mod_time = self.hook.get_mod_time(filename)
-        except ftplib.error_perm as e:
-            logger.warning(f"Failed to retrieve modified time for {filename}, {e}.")
-            logger.info(f"Getting modified time for {self.remote_path}/{filename}")
-            mod_time = self.hook.get_mod_time(f"{self.remote_path}/{filename}")
-        return mod_time.isoformat()
+        mod_time_str = self._file_descriptions[filename]["modify"]
+        return datetime.strptime(mod_time_str, "%Y%m%d%H%M%S").isoformat()
 
     def get_size(self, filename: str) -> int:
-        try:
-            self.hook.conn.sendcmd("TYPE I")  # type: ignore
-            file_size = self.hook.get_size(filename)
-        except ftplib.error_perm as e:
-            logger.warning(f"Failed to retrieve size for {filename}, {e}")
-            logger.info(f"Getting size for {self.remote_path}/{filename}")
-            self.hook.conn.sendcmd("TYPE I")  # type: ignore
-            file_size = self.hook.get_size(f"{self.remote_path}/{filename}")
-
-        if file_size is None:
+        file_size = self._file_descriptions[filename]["size"]
+        if file_size is None or file_size == "":
             file_size = 0
 
-        return file_size
+        return int(file_size)
 
     def retrieve_file(self, filename: str, download_filepath: str):
         try:
@@ -79,12 +116,12 @@ class SFTPAdapter:
         mod_time_str = self._file_descriptions[filename]["modify"]
         return datetime.strptime(mod_time_str, "%Y%m%d%H%M%S").isoformat()
 
-    def get_size(self, filename: str) -> int | str:
+    def get_size(self, filename: str) -> int:
         file_size = self._file_descriptions[filename]["size"]
         if file_size is None:
             file_size = 0
 
-        return file_size
+        return int(file_size)
 
     def retrieve_file(self, filename: str, download_filepath: str):
         remote_filepath = str(pathlib.Path(self.remote_path) / filename)
@@ -282,7 +319,7 @@ def _filter_remote_path(filename: str, remote_path: str) -> str:
 
 def _record_vendor_file(
     filename: str,
-    filesize: int | str | None,
+    filesize: int | None,
     status: str,
     vendor_uuid: str,
     vendor_interface_uuid: str,

--- a/tests/vendor/test_download.py
+++ b/tests/vendor/test_download.py
@@ -82,72 +82,95 @@ def download_path(tmp_path):
     return str(tmp_path)
 
 
-@pytest.fixture(params=["ftp_error", "ftp_download", "sftp_download", "gobi"])
+@pytest.fixture(params=["ftp_download", "sftp_download", "gobi"])
 def mock_hook(mocker, request):
     test_type = request.param
 
-    def mock_get_mod_time(*args):
-        if args[0] == "0820240402_f.mrc" and test_type == "ftp_error":
-            raise ftplib.error_perm("550 The system cannot find the file specified.")
-        elif args[0].startswith("oclc") and test_type == "ftp_error":
-            return datetime.fromisoformat("2024-04-11T19:31:59")
-        elif args[0] == "3820230411.mrc" and test_type == "ftp_download":  # Downloaded
+    def mock_describe_directory(*args):
+        if test_type == "ftp_download":
             five_days_ago = (
                 datetime.now(timezone.utc) - timedelta(days=int(5))
-            ).isoformat(timespec="seconds")
-            return datetime.fromisoformat(five_days_ago)
-        elif (
-            args[0] == "3820230413.mrc" and test_type == "ftp_download"
-        ):  # Outside download window
-            return datetime.fromisoformat("2013-01-01T00:05:23")
-        elif test_type == "sftp_download":
-            return "blah"
-
-    def mock_get_size(*args):
-        if args[0] == "1120240402_f.mrc":
-            raise ftplib.error_perm("550 The system cannot find the file specified.")
-        elif args[0].startswith("oclc"):
-            return 563
-        elif args[0] == "3820230411.mrc":
-            return 123
-        elif args[0] == "3820230413.mrc":
-            return 678
-
-    def mock_list_directory(*args):
-        if test_type == "ftp_error":
-            return ['0820240402_f.mrc', '1120240402_f.mrc', '1220240402_f.mrc']
-        elif test_type == "ftp_download":
-            return [
-                "3820230411.mrc",  # Downloaded
-                "3820230412.mrc",  # Already fetched
-                "3820230413.mrc",  # Outside download window
-                "3820230412.xxx",  # Does not match regex
-            ]
+            ).replace(microsecond=0)
+            return {
+                "3820230411.mrc": {
+                    "size": "123",
+                    "modify": five_days_ago.strftime("%Y%m%d%H%M%S"),
+                    "type": "file",
+                },
+                "3820230412.mrc": {
+                    "size": "456",
+                    "modify": "20230101000523",
+                    "type": "file",
+                },
+                "3820230413.mrc": {
+                    "size": "678",
+                    "modify": "20130101000523",
+                    "type": "file",
+                },
+                "3820230412.xxx": {
+                    "size": "999",
+                    "modify": "20250101000523",
+                    "type": "file",
+                },
+            }
         elif test_type == "sftp_download":
             return {
-                "3820230411.mrc": {"size": 123, "modify": "20230101000523"},
-                "3820230412.mrc": {"size": 456, "modify": "20230101000523"},
-                "3820230413.mrc": {"size": 678, "modify": "20130101000523"},
-                "3820230412.xxx": {"size": None, "modify": "20250101000523"},
+                "3820230411.mrc": {
+                    "size": "123",
+                    "modify": "20230101000523",
+                    "type": "file",
+                },
+                "3820230412.mrc": {
+                    "size": "456",
+                    "modify": "20230101000523",
+                    "type": "file",
+                },
+                "3820230413.mrc": {
+                    "size": "678",
+                    "modify": "20130101000523",
+                    "type": "file",
+                },
+                "3820230412.xxx": {
+                    "size": None,
+                    "modify": "20250101000523",
+                    "type": "file",
+                },
             }
         elif test_type == "gobi":
-            return [
-                "3820230411.ord",
-                "3820230411.cnt",
-                "3820230412.ord",
-                "3820230412.cnt",
-                "3820230413.cnt",
-            ]
+            return {
+                "3820230411.ord": {
+                    "size": "100",
+                    "modify": "20230411120000",
+                    "type": "file",
+                },
+                "3820230411.cnt": {
+                    "size": "200",
+                    "modify": "20230411120000",
+                    "type": "file",
+                },
+                "3820230412.ord": {
+                    "size": "300",
+                    "modify": "20230412120000",
+                    "type": "file",
+                },
+                "3820230412.cnt": {
+                    "size": "400",
+                    "modify": "20230412120000",
+                    "type": "file",
+                },
+                "3820230413.cnt": {
+                    "size": "500",
+                    "modify": "20230413120000",
+                    "type": "file",
+                },
+            }
 
     def mock_retrieve_file(*args):
         if args[0] == "1220240402_f.mrc":
             raise ftplib.error_perm("550 The system cannot find the file specified.")
 
     mock_hook = mocker.MagicMock()
-    mock_hook.get_mod_time = mock_get_mod_time
-    mock_hook.get_size = mock_get_size
-    mock_hook.list_directory = mock_list_directory
-    mock_hook.describe_directory = mock_list_directory
+    mock_hook.describe_directory = mock_describe_directory
     mock_hook.retrieve_file = mock_retrieve_file
     return mock_hook
 
@@ -245,8 +268,10 @@ def test_download_task(mock_hook, download_path, mocker, caplog):
         "Gobi - Full bibs",
         ["3820230411.mrc"],
     )
-    mod_time = (datetime.now(timezone.utc) - timedelta(days=int(5))).isoformat(
-        timespec="seconds"
+    mod_time = (
+        (datetime.now(timezone.utc) - timedelta(days=int(5)))
+        .replace(tzinfo=None)
+        .isoformat(timespec="seconds")
     )
     assert (
         "Downloading for interface Gobi - Full bibs from oclc with ftp-example.com-user"
@@ -329,24 +354,62 @@ def test_update_vendor_files_table(pg_hook, caplog):
         assert empty_vendor_file.filesize == 0
 
 
-@pytest.mark.parametrize("mock_hook", ["ftp_error"], indirect=True)
-def test_ftp_download_error_handling(mock_hook, mocker, caplog):
+def test_ftp_adapter_fallback_to_list_directory(mocker):
+    mock_hook = mocker.MagicMock()
+    mock_hook.describe_directory.side_effect = ftplib.error_perm(
+        "502 MLSD not implemented"
+    )
+    mock_hook.list_directory.return_value = ["file1.mrc", "file2.mrc"]
+    mock_hook.conn.sendcmd.return_value = None
 
-    adapter = FTPAdapter(hook=mock_hook, remote_path="oclc")
+    # Mock get_mod_time to return datetime objects
+    def mock_get_mod_time(path):
+        return datetime(2024, 1, 15, 10, 30, 0)
 
-    mod_time = adapter.get_mod_time('0820240402_f.mrc')
+    mock_hook.get_mod_time.side_effect = mock_get_mod_time
 
-    assert "Failed to retrieve modified time" in caplog.text
-    assert mod_time == "2024-04-11T19:31:59"
+    # Mock get_size to return integers
+    mock_hook.get_size.return_value = 1234
 
-    file_size = adapter.get_size('1120240402_f.mrc')
+    adapter = FTPAdapter(mock_hook, "/remote/path")
 
-    assert "Failed to retrieve size" in caplog.text
-    assert file_size == 563
+    assert mock_hook.list_directory.called
+    assert adapter.list_directory() == ["file1.mrc", "file2.mrc"]
+    assert adapter.get_size("file1.mrc") == 1234
+    assert adapter.get_mod_time("file1.mrc") == "2024-01-15T10:30:00"
 
-    adapter.retrieve_file("1220240402_f.mrc", "/home/airflow/vendor-files/abded-abcd")
 
-    assert "Failed to retrieve 1220240402_f.mrc" in caplog.text
+def test_build_descriptions_handles_errors(mocker):
+    mock_hook = mocker.MagicMock()
+    mock_hook.describe_directory.side_effect = ftplib.error_perm(
+        "502 MLSD not implemented"
+    )
+    mock_hook.list_directory.return_value = ["good_file.mrc", "bad_file.mrc"]
+    mock_hook.conn.sendcmd.return_value = None
+
+    # First file succeeds, second fails
+    def mock_get_mod_time(path):
+        if "bad_file" in path:
+            raise ftplib.error_perm("550 File not found")
+        return datetime(2024, 1, 15, 10, 30, 0)
+
+    def mock_get_size(path):
+        if "bad_file" in path:
+            raise ftplib.error_perm("550 File not found")
+        return 1234
+
+    mock_hook.get_mod_time.side_effect = mock_get_mod_time
+    mock_hook.get_size.side_effect = mock_get_size
+
+    adapter = FTPAdapter(mock_hook, "/remote/path")
+
+    # Good file has real data
+    assert adapter.get_size("good_file.mrc") == 1234
+    assert adapter.get_mod_time("good_file.mrc") == "2024-01-15T10:30:00"
+
+    # Bad file has defaults
+    assert adapter.get_size("bad_file.mrc") == 0
+    assert adapter.get_mod_time("bad_file.mrc") == "1970-01-01T00:00:00"
 
 
 @pytest.mark.parametrize("mock_hook", ["sftp_download"], indirect=True)


### PR DESCRIPTION
Fixes #1769 

I'm not sure why we never used the describe_directory function for the FTPHook. I refactored FTPAdapter to use that function and if MLSD is not available on the FTP server (which is possible), we still use the old functions. Maybe this will work better. 🤷 