### PR TITLE
Add Google Drive uploader plugin task for scanning shipments (#1843)

### DIFF
--- a/libsys_airflow/plugins/google_scanning/drive.py
+++ b/libsys_airflow/plugins/google_scanning/drive.py
@@ -1,0 +1,54 @@
+import logging
+
+from pathlib import Path
+
+from airflow.sdk import task, Variable
+from airflow.providers.google.suite.hooks.drive import GoogleDriveHook
+
+from libsys_airflow.plugins.shared.utils import is_production
+
+logger = logging.getLogger(__name__)
+
+DRIVE_CONN_ID = "libsys_drive"
+
+# Default "Metadata & Manifests" folder shared with the libsys service account.
+# https://drive.google.com/drive/u/1/folders/1Mov-oJfN6yJmgMY6h93RrqtevbSS_Kt6
+DEFAULT_DRIVE_FOLDER_ID = "1Mov-oJfN6yJmgMY6h93RrqtevbSS_Kt6"
+
+
+def drive_folder_id() -> str:
+    return Variable.get("GOOGLE_SCANNING_DRIVE_FOLDER_ID", DEFAULT_DRIVE_FOLDER_ID)
+
+
+@task
+def upload_to_drive_task(file_list: list) -> dict:
+    """
+    Uploads files to the Google Drive folder shared with Google for scanning
+    shipments, via the libsys_drive Connection.
+    Returns lists of files successfully uploaded and failures, following the
+    transmit-data task shape in plugins/data_exports/transmission_tasks.py.
+    """
+    if not is_production():
+        logger.info("SKIPPING GOOGLE DRIVE UPLOAD")
+        return {"success": file_list, "failures": []}
+
+    success = []
+    failures = []
+    folder_id = drive_folder_id()
+    hook = GoogleDriveHook(gcp_conn_id=DRIVE_CONN_ID)
+    for f in file_list:
+        remote_location = Path(f).name
+        try:
+            logger.info(f"Start upload of file {f} to Google Drive")
+            hook.upload_file(
+                local_location=f,
+                remote_location=remote_location,
+                folder_id=folder_id,
+            )
+            success.append(f)
+            logger.info(f"Uploaded {f} to Google Drive")
+        except Exception as e:
+            logger.error(f"Error uploading {f} to Google Drive: {e}")
+            failures.append(f)
+
+    return {"success": success, "failures": failures}

--- a/tests/google_scanning/test_drive.py
+++ b/tests/google_scanning/test_drive.py
@@ -1,0 +1,88 @@
+import pytest  # noqa
+
+from libsys_airflow.plugins.google_scanning.drive import (
+    upload_to_drive_task,
+    drive_folder_id,
+    DEFAULT_DRIVE_FOLDER_ID,
+)
+
+
+@pytest.fixture
+def mock_files(tmp_path):
+    files = []
+    for name in ["stanford_20260101-campus.xml", "stanford_20260101-campus.txt"]:
+        file_path = tmp_path / name
+        file_path.write_text("hello world")
+        files.append(str(file_path))
+    return files
+
+
+def test_drive_folder_id_default(mocker):
+    mocker.patch(
+        "libsys_airflow.plugins.google_scanning.drive.Variable.get",
+        side_effect=lambda key, default: default,
+    )
+    assert drive_folder_id() == DEFAULT_DRIVE_FOLDER_ID
+
+
+def test_drive_folder_id_from_variable(mocker):
+    mocker.patch(
+        "libsys_airflow.plugins.google_scanning.drive.Variable.get",
+        return_value="abc123",
+    )
+    assert drive_folder_id() == "abc123"
+
+
+def test_upload_to_drive_task_skips_when_not_production(mocker, mock_files, caplog):
+    mocker.patch(
+        "libsys_airflow.plugins.google_scanning.drive.is_production",
+        return_value=False,
+    )
+
+    result = upload_to_drive_task.function(mock_files)
+
+    assert result == {"success": mock_files, "failures": []}
+    assert "SKIPPING GOOGLE DRIVE UPLOAD" in caplog.text
+
+
+def test_upload_to_drive_task_success(mocker, mock_files, caplog):
+    mocker.patch(
+        "libsys_airflow.plugins.google_scanning.drive.is_production",
+        return_value=True,
+    )
+    mock_upload_file = mocker.patch(
+        "airflow.providers.google.suite.hooks.drive.GoogleDriveHook.upload_file",
+        return_value="file-id",
+    )
+    mocker.patch(
+        "airflow.providers.google.suite.hooks.drive.GoogleDriveHook.__init__",
+        return_value=None,
+    )
+
+    result = upload_to_drive_task.function(mock_files)
+
+    assert result["success"] == mock_files
+    assert result["failures"] == []
+    assert mock_upload_file.call_count == 2
+    assert "Uploaded" in caplog.text
+
+
+def test_upload_to_drive_task_failure(mocker, mock_files, caplog):
+    mocker.patch(
+        "libsys_airflow.plugins.google_scanning.drive.is_production",
+        return_value=True,
+    )
+    mocker.patch(
+        "airflow.providers.google.suite.hooks.drive.GoogleDriveHook.__init__",
+        return_value=None,
+    )
+    mocker.patch(
+        "airflow.providers.google.suite.hooks.drive.GoogleDriveHook.upload_file",
+        side_effect=Exception("boom"),
+    )
+
+    result = upload_to_drive_task.function(mock_files)
+
+    assert result["success"] == []
+    assert result["failures"] == mock_files
+    assert "Error uploading" in caplog.text


### PR DESCRIPTION
Fixes #1843 

Creates a plugin to handle the upload of files to the Google Drive folder shared with Google for scanning shipments, via the libsys_drive Connection. Returns lists of files successfully uploaded and failures, following the `transmit-data` task shape in `plugins/data_exports/transmission_tasks.py`. Uses an airflow Variable for GOOGLE_SCANNING_DRIVE_FOLDER_ID with the current folder_id as the default.