### PR TITLE
Download csv for shipped items and add refresh button

### DIFF
--- a/libsys_airflow/plugins/google_scanning/apps/google_scanning_upload_view.py
+++ b/libsys_airflow/plugins/google_scanning/apps/google_scanning_upload_view.py
@@ -10,6 +10,7 @@ from fastapi.templating import Jinja2Templates
 
 from libsys_airflow.plugins.google_scanning.staging import (
     archived_file_path,
+    download_filename,
     list_shipped_carts,
     list_staged_carts,
     save_staged_file,
@@ -123,4 +124,4 @@ async def download_shipped_file(cart_name: str, filename: str):
     if not file_path.is_file():
         raise HTTPException(status_code=404, detail="File not found")
 
-    return FileResponse(file_path, filename=filename)
+    return FileResponse(file_path, filename=download_filename(filename))

--- a/libsys_airflow/plugins/google_scanning/apps/google_scanning_upload_view.py
+++ b/libsys_airflow/plugins/google_scanning/apps/google_scanning_upload_view.py
@@ -4,11 +4,12 @@ from datetime import date
 from pathlib import Path
 from urllib.parse import urlencode
 
-from fastapi import FastAPI, File, Form, Request, UploadFile
-from fastapi.responses import RedirectResponse
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi.responses import FileResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from libsys_airflow.plugins.google_scanning.staging import (
+    archived_file_path,
     list_shipped_carts,
     list_staged_carts,
     save_staged_file,
@@ -110,3 +111,16 @@ async def trigger_shipment(
         return _redirect_home(warning=f"Failed to start shipment: {e}")
 
     return _redirect_home(success=f"Started shipment DAG run {dag_run_id}.")
+
+
+@app.get("/download/{cart_name}/{filename}")
+async def download_shipped_file(cart_name: str, filename: str):
+    try:
+        file_path = archived_file_path(cart_name, filename)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    if not file_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    return FileResponse(file_path, filename=filename)

--- a/libsys_airflow/plugins/google_scanning/staging.py
+++ b/libsys_airflow/plugins/google_scanning/staging.py
@@ -86,6 +86,16 @@ def archived_file_path(cart_name: str, filename: str) -> Path:
     return file_path
 
 
+def download_filename(filename: str) -> str:
+    """
+    Returns the filename to present for download, always with a .csv
+    extension. The staged/archived file is a single column of barcodes --
+    effectively a one-column CSV -- regardless of the extension it was
+    originally uploaded with.
+    """
+    return str(Path(filename).with_suffix(".csv"))
+
+
 def list_staged_carts() -> list[dict]:
     """
     Lists all currently staged carts for the review/shipment page.
@@ -139,6 +149,7 @@ def list_shipped_carts() -> list[dict]:
                 {
                     "cart_name": cart_name,
                     "filename": archived_file.name,
+                    "download_filename": download_filename(archived_file.name),
                     "shipped_at": status.get("shipped_at"),
                     "status": status,
                 }

--- a/libsys_airflow/plugins/google_scanning/staging.py
+++ b/libsys_airflow/plugins/google_scanning/staging.py
@@ -73,6 +73,19 @@ def shipped_cart_status(cart_name: str) -> dict:
     return _cart_status(ARCHIVED_FILES_BASE, cart_name)
 
 
+def archived_file_path(cart_name: str, filename: str) -> Path:
+    """
+    Resolves a shipped cart's archived file for download, rejecting any
+    cart_name/filename (e.g. "..") that would resolve outside
+    ARCHIVED_FILES_BASE.
+    """
+    base = ARCHIVED_FILES_BASE.resolve()
+    file_path = (base / cart_name / filename).resolve()
+    if base not in file_path.parents:
+        raise ValueError(f"Invalid archived file path: {cart_name}/{filename}")
+    return file_path
+
+
 def list_staged_carts() -> list[dict]:
     """
     Lists all currently staged carts for the review/shipment page.

--- a/libsys_airflow/plugins/google_scanning/templates/google_scanning_upload/index.html
+++ b/libsys_airflow/plugins/google_scanning/templates/google_scanning_upload/index.html
@@ -14,7 +14,8 @@
     th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
     .form-row { margin-bottom: 1rem; }
     label { display: block; font-weight: bold; margin-bottom: 0.25rem; }
-    .search-row { max-width: 24rem; margin-left: auto; margin-bottom: 1rem; }
+    .search-row { max-width: 28rem; margin-left: auto; margin-bottom: 1rem; display: flex; align-items: flex-end; gap: 0.5rem; }
+    .search-row > div { flex: 1; }
     #table-search { width: 100%; }
     .tables-panel { border: 1px solid #ccc; border-radius: 4px; padding: 0 1rem 1rem; }
     .tables-panel > h2:first-child { margin-top: 1rem; }
@@ -45,8 +46,11 @@
   </form>
 
   <div class="search-row">
-    <label for="table-search">Search Staged &amp; Shipped Carts</label>
-    <input type="text" id="table-search" placeholder="Filter by cart name, filename, date, status...">
+    <button type="button" id="refresh-tables">Refresh</button>
+    <div>
+      <label for="table-search">Search Staged &amp; Shipped Carts</label>
+      <input type="text" id="table-search" placeholder="Filter by cart name, filename, date, status...">
+    </div>
   </div>
 
   <div class="tables-panel">
@@ -103,7 +107,7 @@
       {% for cart in shipped_carts %}
       <tr class="filterable-row">
         <td>{{ cart.cart_name }}</td>
-        <td>{{ cart.filename }}</td>
+        <td><a href="download/{{ cart.cart_name | urlencode }}/{{ cart.filename | urlencode }}">{{ cart.filename }}</a></td>
         <td>{{ cart.shipped_at | default("Unknown", true) }}</td>
         <td>{{ cart.status.status | default("unknown", true) | capitalize }}</td>
       </tr>
@@ -122,6 +126,10 @@
       document.querySelectorAll(".filterable-row").forEach(function (row) {
         row.style.display = row.textContent.toLowerCase().includes(query) ? "" : "none";
       });
+    });
+
+    document.getElementById("refresh-tables").addEventListener("click", function () {
+      window.location.reload();
     });
   </script>
 </body>

--- a/libsys_airflow/plugins/google_scanning/templates/google_scanning_upload/index.html
+++ b/libsys_airflow/plugins/google_scanning/templates/google_scanning_upload/index.html
@@ -107,7 +107,7 @@
       {% for cart in shipped_carts %}
       <tr class="filterable-row">
         <td>{{ cart.cart_name }}</td>
-        <td><a href="download/{{ cart.cart_name | urlencode }}/{{ cart.filename | urlencode }}">{{ cart.filename }}</a></td>
+        <td><a href="download/{{ cart.cart_name | urlencode }}/{{ cart.filename | urlencode }}">{{ cart.download_filename }}</a></td>
         <td>{{ cart.shipped_at | default("Unknown", true) }}</td>
         <td>{{ cart.status.status | default("unknown", true) | capitalize }}</td>
       </tr>

--- a/tests/apps/google_scanning/test_google_scanning_upload_view.py
+++ b/tests/apps/google_scanning/test_google_scanning_upload_view.py
@@ -113,6 +113,7 @@ def test_home_renders_shipped_carts(mocker):
     assert "20260807" in response.text
     assert "Shipped" in response.text
     assert 'href="download/cart-3/barcodes.txt"' in response.text
+    assert ">barcodes.csv</a>" in response.text
 
 
 def test_home_renders_unknown_status_for_shipped_cart_missing_status(mocker):
@@ -309,7 +310,7 @@ def test_download_shipped_file(mocker, tmp_path):
 
     assert response.status_code == 200
     assert response.content == b"12345\n67890\n"
-    assert 'filename="barcodes.txt"' in response.headers["content-disposition"]
+    assert 'filename="barcodes.csv"' in response.headers["content-disposition"]
 
 
 def test_download_shipped_file_invalid_path(mocker):

--- a/tests/apps/google_scanning/test_google_scanning_upload_view.py
+++ b/tests/apps/google_scanning/test_google_scanning_upload_view.py
@@ -43,6 +43,14 @@ def test_home_renders_staged_carts():
     assert "Staged" in response.text
 
 
+def test_home_renders_refresh_button():
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert 'id="refresh-tables"' in response.text
+    assert "window.location.reload()" in response.text
+
+
 def test_home_renders_shared_table_search(mocker):
     mocker.patch(
         "libsys_airflow.plugins.google_scanning.apps.google_scanning_upload_view.list_shipped_carts",
@@ -102,6 +110,7 @@ def test_home_renders_shipped_carts(mocker):
     assert "cart-3" in response.text
     assert "20260807" in response.text
     assert "Shipped" in response.text
+    assert 'href="download/cart-3/barcodes.txt"' in response.text
 
 
 def test_home_renders_unknown_status_for_shipped_cart_missing_status(mocker):
@@ -283,3 +292,40 @@ def test_ship_dag_trigger_failure(mocker):
 
     followed = client.get(response.headers["location"])
     assert "alert-warning" in followed.text
+
+
+def test_download_shipped_file(mocker, tmp_path):
+    file_path = tmp_path / "barcodes.txt"
+    file_path.write_bytes(b"12345\n67890\n")
+    mocker.patch(
+        "libsys_airflow.plugins.google_scanning.apps.google_scanning_upload_view.archived_file_path",
+        return_value=file_path,
+    )
+
+    response = client.get("/download/cart-1/barcodes.txt")
+
+    assert response.status_code == 200
+    assert response.content == b"12345\n67890\n"
+    assert 'filename="barcodes.txt"' in response.headers["content-disposition"]
+
+
+def test_download_shipped_file_invalid_path(mocker):
+    mocker.patch(
+        "libsys_airflow.plugins.google_scanning.apps.google_scanning_upload_view.archived_file_path",
+        side_effect=ValueError("Invalid archived file path"),
+    )
+
+    response = client.get("/download/cart-1/barcodes.txt")
+
+    assert response.status_code == 404
+
+
+def test_download_shipped_file_missing(mocker, tmp_path):
+    mocker.patch(
+        "libsys_airflow.plugins.google_scanning.apps.google_scanning_upload_view.archived_file_path",
+        return_value=tmp_path / "does-not-exist.txt",
+    )
+
+    response = client.get("/download/cart-1/does-not-exist.txt")
+
+    assert response.status_code == 404

--- a/tests/apps/google_scanning/test_google_scanning_upload_view.py
+++ b/tests/apps/google_scanning/test_google_scanning_upload_view.py
@@ -58,6 +58,7 @@ def test_home_renders_shared_table_search(mocker):
             {
                 "cart_name": "cart-3",
                 "filename": "barcodes.txt",
+                "download_filename": "barcodes.csv",
                 "shipped_at": "20260807",
                 "status": {"status": "shipped"},
             }
@@ -98,6 +99,7 @@ def test_home_renders_shipped_carts(mocker):
             {
                 "cart_name": "cart-3",
                 "filename": "barcodes.txt",
+                "download_filename": "barcodes.csv",
                 "shipped_at": "20260807",
                 "status": {"status": "shipped"},
             }
@@ -120,6 +122,7 @@ def test_home_renders_unknown_status_for_shipped_cart_missing_status(mocker):
             {
                 "cart_name": "cart-3",
                 "filename": "barcodes.txt",
+                "download_filename": "barcodes.csv",
                 "shipped_at": None,
                 "status": {},
             }

--- a/tests/google_scanning/test_staging.py
+++ b/tests/google_scanning/test_staging.py
@@ -151,7 +151,10 @@ def test_list_shipped_carts_unknown_status(mock_archived_files_base):
 
 
 def test_download_filename_renames_extension_to_csv():
-    assert download_filename("cart-Stanford001-barcodes.txt") == "cart-Stanford001-barcodes.csv"
+    assert (
+        download_filename("cart-Stanford001-barcodes.txt")
+        == "cart-Stanford001-barcodes.csv"
+    )
 
 
 def test_download_filename_replaces_existing_csv_extension():

--- a/tests/google_scanning/test_staging.py
+++ b/tests/google_scanning/test_staging.py
@@ -6,6 +6,7 @@ from libsys_airflow.plugins.google_scanning.staging import (
     STATUS_SHIPPED,
     STATUS_STAGED,
     STATUS_UNKNOWN,
+    archived_file_path,
     list_shipped_carts,
     list_staged_carts,
     save_staged_file,
@@ -144,6 +145,26 @@ def test_list_shipped_carts_unknown_status(mock_archived_files_base):
             "status": {"status": STATUS_UNKNOWN},
         }
     ]
+
+
+def test_archived_file_path(mock_archived_files_base):
+    cart_dir = mock_archived_files_base / "cart-1"
+    cart_dir.mkdir(parents=True)
+    (cart_dir / "barcodes.txt").write_bytes(b"12345\n")
+
+    file_path = archived_file_path("cart-1", "barcodes.txt")
+
+    assert file_path == (mock_archived_files_base / "cart-1" / "barcodes.txt").resolve()
+
+
+def test_archived_file_path_rejects_traversal_via_cart_name(mock_archived_files_base):
+    with pytest.raises(ValueError):
+        archived_file_path("../../etc", "passwd")
+
+
+def test_archived_file_path_rejects_traversal_via_filename(mock_archived_files_base):
+    with pytest.raises(ValueError):
+        archived_file_path("cart-1", "../../../etc/passwd")
 
 
 def test_trigger_stage_cart_items_dag(mocker):

--- a/tests/google_scanning/test_staging.py
+++ b/tests/google_scanning/test_staging.py
@@ -7,6 +7,7 @@ from libsys_airflow.plugins.google_scanning.staging import (
     STATUS_STAGED,
     STATUS_UNKNOWN,
     archived_file_path,
+    download_filename,
     list_shipped_carts,
     list_staged_carts,
     save_staged_file,
@@ -124,6 +125,7 @@ def test_list_shipped_carts(mock_archived_files_base):
         {
             "cart_name": "cart-1",
             "filename": "barcodes.txt",
+            "download_filename": "barcodes.csv",
             "shipped_at": "20260807",
             "status": status,
         }
@@ -141,10 +143,19 @@ def test_list_shipped_carts_unknown_status(mock_archived_files_base):
         {
             "cart_name": "cart-1",
             "filename": "barcodes.txt",
+            "download_filename": "barcodes.csv",
             "shipped_at": None,
             "status": {"status": STATUS_UNKNOWN},
         }
     ]
+
+
+def test_download_filename_renames_extension_to_csv():
+    assert download_filename("cart-Stanford001-barcodes.txt") == "cart-Stanford001-barcodes.csv"
+
+
+def test_download_filename_replaces_existing_csv_extension():
+    assert download_filename("barcodes.csv") == "barcodes.csv"
 
 
 def test_archived_file_path(mock_archived_files_base):


### PR DESCRIPTION
## Summary
- Adds a `GET /download/{cart_name}/{filename}` route so shipped/archived cart files can be downloaded directly from the "Shipped Items" table (filename is now a download link), guarded against path traversal (`..`)via `archived_file_path()`.
- Adds a manual "Refresh" button (left of the search box) that reloads the page to pick up filesystem changes — no auto-polling.

## Test plan
-  `poetry run pytest tests/google_scanning/ tests/apps/google_scanning/ -v` — all passing
-  `poetry run pytest -q` — full suite passing
-  `poetry run flake8` / `poetry run mypy` clean
-  Manually verified in the local docker-compose stack: downloaded a real archived file's contents, confirmed a path-traversal attempt and a nonexistent file both 404, confirmed refresh button reloads the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)