### PR TITLE
Re-add libmagic accidently removed in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM apache/airflow:3.3.0-python3.12
 USER root
 RUN usermod -u 214 airflow
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libmagic1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PYTHONPATH="${PYTHONPATH}:/opt/airflow/"
 ENV SLUGIFY_USES_TEXT_UNIDECODE="yes"
 


### PR DESCRIPTION
Removed on this commit but still needed: https://github.com/sul-dlss/libsys-airflow/commit/e5c739806612f10ce6f8da217dc2772671e1bdd0